### PR TITLE
fix on default date value

### DIFF
--- a/src/Indice.AspNetCore.Identity/Data/Mappings/UserDeviceMap.cs
+++ b/src/Indice.AspNetCore.Identity/Data/Mappings/UserDeviceMap.cs
@@ -22,8 +22,6 @@ namespace Indice.AspNetCore.Identity.Data.Mappings
             builder.HasKey(x => x.Id);
             //Device name length
             builder.Property(x => x.DeviceName).HasMaxLength(256);
-            //Default value for DateCreated
-            builder.Property(x => x.DateCreated).HasDefaultValueSql("getdate()");
             // Configure relationships.
             builder.HasOne<TUser>().WithMany().HasForeignKey(x => x.UserId).OnDelete(DeleteBehavior.Cascade);
         }

--- a/src/Indice.AspNetCore.Identity/Data/Mappings/UserDeviceMap.cs
+++ b/src/Indice.AspNetCore.Identity/Data/Mappings/UserDeviceMap.cs
@@ -23,7 +23,7 @@ namespace Indice.AspNetCore.Identity.Data.Mappings
             //Device name length
             builder.Property(x => x.DeviceName).HasMaxLength(256);
             //Default value for DateCreated
-            builder.Property(x => x.DateCreated).HasDefaultValue(DateTimeOffset.Now);
+            builder.Property(x => x.DateCreated).HasDefaultValueSql("getdate()");
             // Configure relationships.
             builder.HasOne<TUser>().WithMany().HasForeignKey(x => x.UserId).OnDelete(DeleteBehavior.Cascade);
         }

--- a/src/Indice.AspNetCore.Identity/Features/PushNotifications/DevicesController.cs
+++ b/src/Indice.AspNetCore.Identity/Features/PushNotifications/DevicesController.cs
@@ -117,7 +117,8 @@ namespace Indice.AspNetCore.Identity.Features
                     DeviceName = request.DeviceName,
                     DevicePlatform = request.DevicePlatform,
                     IsPushNotificationsEnabled = true,
-                    UserId = user.Id
+                    UserId = user.Id,
+                    DateCreated = DateTimeOffset.Now
                 };
                 _dbContext.UserDevices.Add(deviceToAdd);
                 deviceId = deviceToAdd.Id;


### PR DESCRIPTION
The previous implementation was using the same date always, which was the date the migration was created