### PR TITLE
fix on default date value release/3.1.0

### DIFF
--- a/src/Indice.AspNetCore.Identity/Data/Mappings/UserDeviceMap.cs
+++ b/src/Indice.AspNetCore.Identity/Data/Mappings/UserDeviceMap.cs
@@ -23,7 +23,7 @@ namespace Indice.AspNetCore.Identity.Data.Mappings
             //Device name length
             builder.Property(x => x.DeviceName).HasMaxLength(256);
             //Default value for DateCreated
-            builder.Property(x => x.DateCreated).HasDefaultValue(DateTimeOffset.Now);
+            builder.Property(x => x.DateCreated).HasDefaultValueSql("getdate()");
             // Configure relationships.
             builder.HasOne<TUser>().WithMany().HasForeignKey(x => x.UserId).OnDelete(DeleteBehavior.Cascade);
         }


### PR DESCRIPTION
The previous implementation was using the same date always, which was the date the migration was created

