### PR TITLE
Bugfix/register device remove is enabled check

### DIFF
--- a/src/Indice.AspNetCore.Identity/Features/PushNotifications/DevicesController.cs
+++ b/src/Indice.AspNetCore.Identity/Features/PushNotifications/DevicesController.cs
@@ -102,9 +102,6 @@ namespace Indice.AspNetCore.Identity.Features
                 return NotFound();
             }
             var device = await _dbContext.UserDevices.SingleOrDefaultAsync(x => x.UserId == user.Id && x.DeviceId == request.DeviceId);
-            if(device?.IsPushNotificationsEnabled == true) {
-                return NoContent();
-            }
             await _pushNotificationService.Register(request.DeviceId.ToString(), request.PnsHandle, request.DevicePlatform, user.Id,  request.Tags?.ToArray());
             var deviceId = default(Guid);
             if (device != null) {

--- a/src/Indice.AspNetCore.Identity/Features/PushNotifications/DevicesController.cs
+++ b/src/Indice.AspNetCore.Identity/Features/PushNotifications/DevicesController.cs
@@ -102,6 +102,9 @@ namespace Indice.AspNetCore.Identity.Features
                 return NotFound();
             }
             var device = await _dbContext.UserDevices.SingleOrDefaultAsync(x => x.UserId == user.Id && x.DeviceId == request.DeviceId);
+            if(device?.IsPushNotificationsEnabled == true) {
+                return NoContent();
+            }
             await _pushNotificationService.Register(request.DeviceId.ToString(), request.PnsHandle, request.DevicePlatform, user.Id,  request.Tags?.ToArray());
             var deviceId = default(Guid);
             if (device != null) {


### PR DESCRIPTION
There are cases where the pnsHandle, provided from mobile services provider(Apple,Google) can change.
For these cases we must update the device installation on notifications hub with the new pnsHandle.
The update process is being handled by  NotificationHub.CreateOrUpdateInstallationAsync which is called in the PushNotificationServiceAzure.Register method