### PR TITLE
send notification token in payload data

### DIFF
--- a/src/Indice.AspNetCore.Identity/Services/TotpService.cs
+++ b/src/Indice.AspNetCore.Identity/Services/TotpService.cs
@@ -121,7 +121,7 @@ namespace Indice.AspNetCore.Identity
                     if(PushNotificationService == null) {
                         throw new ArgumentNullException(nameof(PushNotificationService));
                     }
-                    await PushNotificationService.SendAsync(Localizer[message, token], user.Id);
+                    await PushNotificationService.SendAsync(Localizer[message, token], token, user.Id);
                     break;
                 default:
                     break;


### PR DESCRIPTION
Send token in notification's template data so that it can be easily retrieved from clients