### PR TITLE
Translations feature for Client & ApiScopes

### DIFF
--- a/src/Indice.AspNetCore.Identity/Features/IdentityServerApi/Models/Requests/ClientRequests.cs
+++ b/src/Indice.AspNetCore.Identity/Features/IdentityServerApi/Models/Requests/ClientRequests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using IdentityServer4.Models;
+using Indice.Types;
 
 namespace Indice.AspNetCore.Identity.Api.Models
 {
@@ -185,12 +186,16 @@ namespace Indice.AspNetCore.Identity.Api.Models
         /// Specifies whether a consent screen is required.
         /// </summary>
         public bool RequireConsent { get; set; }
+        /// <summary>
+        /// Translations.
+        /// </summary>
+        public TranslationDictionary<ClientTranslation> Translations { get; set; } = new();
     }
 
     /// <summary>
     /// Defines the model required to update client URLs.
     /// </summary>
-    public class UpdateClientUrls 
+    public class UpdateClientUrls
     {
         /// <summary>
         /// Cors origins allowed.

--- a/src/Indice.AspNetCore.Identity/Features/IdentityServerApi/Models/Requests/ResourceRequests.cs
+++ b/src/Indice.AspNetCore.Identity/Features/IdentityServerApi/Models/Requests/ResourceRequests.cs
@@ -17,7 +17,7 @@ namespace Indice.AspNetCore.Identity.Api.Models
         /// </summary>
         public string AllowedAccessTokenSigningAlgorithms { get; set; }
         /// <summary>
-        /// List of accociated user claims that should be included when this resource is requested.
+        /// List of associated user claims that should be included when this resource is requested.
         /// </summary>
         public List<string> UserClaims { get; set; }
         /// <summary>
@@ -96,6 +96,10 @@ namespace Indice.AspNetCore.Identity.Api.Models
         /// Determines whether this scope should be displayed in the discovery document or not.
         /// </summary>
         public bool ShowInDiscoveryDocument { get; set; }
+        /// <summary>
+        /// Translations.
+        /// </summary>
+        public TranslationDictionary<ApiScopeTranslation> Translations { get; set; } = new TranslationDictionary<ApiScopeTranslation>();
     }
 
     /// <summary>

--- a/src/Indice.AspNetCore.Identity/Features/IdentityServerApi/Models/Responses/ApiResourceInfo.cs
+++ b/src/Indice.AspNetCore.Identity/Features/IdentityServerApi/Models/Responses/ApiResourceInfo.cs
@@ -32,7 +32,7 @@ namespace Indice.AspNetCore.Identity.Api.Models
         /// </summary>
         public bool NonEditable { get; set; }
         /// <summary>
-        /// List of accociated claims that should be included when this resource is requested.
+        /// List of associated claims that should be included when this resource is requested.
         /// </summary>
         public IEnumerable<string> AllowedClaims { get; set; }
         /// <summary>

--- a/src/Indice.AspNetCore.Identity/Features/IdentityServerApi/Models/Responses/ApiScopeInfo.cs
+++ b/src/Indice.AspNetCore.Identity/Features/IdentityServerApi/Models/Responses/ApiScopeInfo.cs
@@ -37,7 +37,7 @@ namespace Indice.AspNetCore.Identity.Api.Models
         /// </summary>
         public TranslationDictionary<ApiScopeTranslation> Translations { get; set; }
         /// <summary>
-        /// List of accociated user claims that should be included when a resource is requested.
+        /// List of associated user claims that should be included when a resource is requested.
         /// </summary>
         public IEnumerable<string> UserClaims { get; set; }
     }

--- a/src/Indice.AspNetCore.Identity/Features/IdentityServerApi/Models/Responses/ClientInfo.cs
+++ b/src/Indice.AspNetCore.Identity/Features/IdentityServerApi/Models/Responses/ClientInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using IdentityServer4.Models;
+using Indice.Types;
 
 namespace Indice.AspNetCore.Identity.Api.Models
 {
@@ -190,5 +191,24 @@ namespace Indice.AspNetCore.Identity.Api.Models
         /// The identity resources that the client has access to.
         /// </summary>
         public IEnumerable<string> IdentityResources { get; set; }
+        /// <summary>
+        /// Translations.
+        /// </summary>
+        public TranslationDictionary<ClientTranslation> Translations { get; set; }
+    }
+
+    /// <summary>
+    /// Translation object for type <see cref="SingleClientInfo"/>.
+    /// </summary>
+    public class ClientTranslation
+    {
+        /// <summary>
+        /// The display name of the client.
+        /// </summary>
+        public string DisplayName { get; set; }
+        /// <summary>
+        /// The description of the client.
+        /// </summary>
+        public string Description { get; set; }
     }
 }

--- a/src/Indice.AspNetCore.Identity/Features/IdentityServerApi/Models/Responses/IdentityResourceInfo.cs
+++ b/src/Indice.AspNetCore.Identity/Features/IdentityServerApi/Models/Responses/IdentityResourceInfo.cs
@@ -44,7 +44,7 @@ namespace Indice.AspNetCore.Identity.Api.Models
         /// </summary>
         public bool NonEditable { get; set; }
         /// <summary>
-        /// List of accociated claims that should be included when this resource is requested.
+        /// List of associated claims that should be included when this resource is requested.
         /// </summary>
         public IEnumerable<string> AllowedClaims { get; set; }
     }


### PR DESCRIPTION
## What?
I've added (completed, to be precise) translations to `Client` and `ApiScopes` Entities via their corresponding `Properties` navigation property.

A new `TranslationDictionary<T>` class has been added to keep the translations logic into one place.
 
## Why ?
We need to set names/descriptions for clients and scopes in more than one language.

## Testing?
I've tested all CRUD operations with swagger for Client and ApiScopes.

## Anything Else?
There is no code written for `delete` actions because there is a cascade delete on the database for the FK's.