### PR TITLE
Fix non-static method and DbContext Include for ApiScope Properties

### DIFF
--- a/src/Indice.AspNetCore.Identity/Features/IdentityServerApi/Controllers/ResourcesController.cs
+++ b/src/Indice.AspNetCore.Identity/Features/IdentityServerApi/Controllers/ResourcesController.cs
@@ -312,7 +312,6 @@ namespace Indice.AspNetCore.Identity.Api.Controllers
         [CacheResourceFilter]
         public async Task<IActionResult> GetApiResource([FromRoute] int resourceId) {
             var apiResource = await _configurationDbContext.ApiResources
-                .Include(x => x.Properties)
                 .AsNoTracking()
                 .Select(x => new ApiResourceInfo {
                     Id = x.Id,
@@ -323,7 +322,7 @@ namespace Indice.AspNetCore.Identity.Api.Controllers
                     NonEditable = x.NonEditable,
                     AllowedClaims = x.UserClaims.Select(x => x.Type),
                     Scopes = x.Scopes.Any() ? x.Scopes.Join(
-                        _configurationDbContext.ApiScopes,
+                        _configurationDbContext.ApiScopes.Include(y => y.Properties),
                         apiResourceScope => apiResourceScope.Scope,
                         apiScope => apiScope.Name,
                         (apiResourceScope, apiScope) => new {
@@ -771,7 +770,7 @@ namespace Indice.AspNetCore.Identity.Api.Controllers
         /// Deserialize the JSON translation of an <see cref="ApiScope"/>.
         /// </summary>
         /// <param name="apiScope">The API scope.</param>
-        private TranslationDictionary<ApiScopeTranslation> GetTranslationsFromApiScope(ApiScope apiScope) => 
+        private static TranslationDictionary<ApiScopeTranslation> GetTranslationsFromApiScope(ApiScope apiScope) => 
             TranslationDictionary<ApiScopeTranslation>.FromJson(apiScope.Properties.Any(x => x.Key == IdentityServerApi.ObjectTranslationKey)
                 ? apiScope.Properties.Single(x => x.Key == IdentityServerApi.ObjectTranslationKey).Value
                 : string.Empty


### PR DESCRIPTION
# Bugfix
At my previous PR (#33 ) I had two mistakes
- I had declared a non static private method that caused the following error 
```text
Client projection contains reference to constant expression of 'Indice.AspNetCore.Identity.Api.Controllers.ResourcesController' through instance method 'GetTranslationsFromApiScope'. This could potentially cause memory leak. Consider making the method static so that it does not capture constant in the instance. See https://go.microsoft.com/fwlink/?linkid=2103067 for more information.
```
- A wrong `.Include` for `ApiScopes.Properties`

This PR is a fix for those two errors.