### PR TITLE
Add data parameter in ITotpService.Send to be able to send complex data to the mobile client when delivery channel is PushNotification

### DIFF
--- a/src/Indice.AspNetCore.Identity/Services/DeveloperTotpService.cs
+++ b/src/Indice.AspNetCore.Identity/Services/DeveloperTotpService.cs
@@ -57,7 +57,7 @@ namespace Indice.AspNetCore.Identity
         }
 
         /// <inheritdoc />
-        public async Task<TotpResult> Send(ClaimsPrincipal principal, string message, TotpDeliveryChannel channel = TotpDeliveryChannel.Sms, string purpose = null, string securityToken = null, string phoneNumberOrEmail = null) {
+        public async Task<TotpResult> Send(ClaimsPrincipal principal, string message, TotpDeliveryChannel channel = TotpDeliveryChannel.Sms, string purpose = null, string securityToken = null, string phoneNumberOrEmail = null, string data = null) {
             var userId = principal.GetSubjectId();
             if (!string.IsNullOrEmpty(userId)) {
                 var hasDeveloperTotp = await _dbContext.UserClaims.Where(x => x.UserId == userId && x.ClaimType == BasicClaimTypes.DeveloperTotp).AnyAsync();
@@ -65,7 +65,7 @@ namespace Indice.AspNetCore.Identity
                     return TotpResult.SuccessResult;
                 }
             }
-            return await _totpService.Send(principal, message, channel, purpose, securityToken, phoneNumberOrEmail);
+            return await _totpService.Send(principal, message, channel, purpose, securityToken, phoneNumberOrEmail, data);
         }
 
         /// <inheritdoc />

--- a/src/Indice.AspNetCore.Identity/Services/TotpService.cs
+++ b/src/Indice.AspNetCore.Identity/Services/TotpService.cs
@@ -103,7 +103,12 @@ namespace Indice.AspNetCore.Identity
                     if (_pushNotificationService == null) {
                         throw new ArgumentNullException(nameof(_pushNotificationService), $"Cannot send push notification since there is no implementation of {nameof(IPushNotificationService)}.");
                     }
-                    await _pushNotificationService.SendAsync(string.Format(message, token), string.Format(data ?? "{0}", token), user.Id);
+                    await _pushNotificationService.SendAsync(builder => builder
+                            .To(user?.Id)
+                            .WithToken(token)
+                            .WithMessage(string.Format(message, token))
+                            .WithData(data)
+                    );
                     break;
                 default:
                     break;

--- a/src/Indice.AspNetCore.Identity/Services/TotpService.cs
+++ b/src/Indice.AspNetCore.Identity/Services/TotpService.cs
@@ -58,7 +58,7 @@ namespace Indice.AspNetCore.Identity
         }
 
         /// <inheritdoc />
-        public async Task<TotpResult> Send(ClaimsPrincipal principal, string message, TotpDeliveryChannel channel = TotpDeliveryChannel.Sms, string purpose = null, string securityToken = null, string phoneNumberOrEmail = null) {
+        public async Task<TotpResult> Send(ClaimsPrincipal principal, string message, TotpDeliveryChannel channel = TotpDeliveryChannel.Sms, string purpose = null, string securityToken = null, string phoneNumberOrEmail = null, string data = null) {
             var totpResult = ValidateParameters(principal, securityToken, phoneNumberOrEmail);
             if (!totpResult.Success) {
                 return totpResult;
@@ -103,7 +103,7 @@ namespace Indice.AspNetCore.Identity
                     if (_pushNotificationService == null) {
                         throw new ArgumentNullException(nameof(_pushNotificationService), $"Cannot send push notification since there is no implementation of {nameof(IPushNotificationService)}.");
                     }
-                    await _pushNotificationService.SendAsync(string.Format(message, token), token, user.Id);
+                    await _pushNotificationService.SendAsync(string.Format(message, token), string.Format(data ?? "{0}", token), user.Id);
                     break;
                 default:
                     break;

--- a/src/Indice.Common/Configuration/PushNotificationMessage.cs
+++ b/src/Indice.Common/Configuration/PushNotificationMessage.cs
@@ -1,0 +1,52 @@
+﻿using System;
+
+namespace Indice.Services
+{
+    /// <summary>
+    /// Models the data that are sent in an push notification message.
+    /// </summary>
+    public class PushNotificationMessage
+    {
+        /// <summary>
+        /// The payload data that will be sent to the mobile client (not visible to the Push Notification Title or Message).
+        /// If the data is null then only the token will be sent as data.
+        /// </summary>
+        public string Data { get; }
+
+        /// <summary>
+        /// The message of the Push Notification.
+        /// </summary>
+        public string Message { get; }
+
+        /// <summary>
+        /// The Otp token that must be passed to the client.
+        /// </summary>
+        public string Token { get; }
+
+        /// <summary>
+        /// The UserId to send the Push Notification.
+        /// </summary>
+        public string UserId { get; }
+
+        /// <summary>
+        /// The tags of the Push Notification.
+        /// </summary>
+        public string[] Tags { get; }
+
+        /// <summary>
+        /// Constructs a <see cref="PushNotificationMessage"/>.
+        /// </summary>
+        /// <param name="data">The payload data that will be sent to the mobile client (not visible to the Push Notification Title or Message).  If the data is null then only the token will be sent as data.</param>
+        /// <param name="message">The message of the Push Notification.</param>
+        /// <param name="token">The Otp token that must be passed to the client.</param>
+        /// <param name="userId">The UserId to send the Push Notification.</param>
+        /// <param name="tags">The tags of the Push Notification.</param>
+        public PushNotificationMessage(string data, string message, string token, string userId, string[] tags) {
+            Message = message ?? throw new ArgumentNullException(nameof(message));
+            Token = token ?? throw new ArgumentNullException(nameof(token));
+            UserId = userId ?? throw new ArgumentNullException(nameof(userId));
+            Data = string.Format(data ?? "{0}", Token);
+            Tags = tags ?? Array.Empty<string>();
+        }
+    }
+}

--- a/src/Indice.Common/Configuration/PushNotificationMessageBuilder.cs
+++ b/src/Indice.Common/Configuration/PushNotificationMessageBuilder.cs
@@ -1,0 +1,117 @@
+﻿using System;
+
+namespace Indice.Services
+{
+    /// <summary>
+    /// The builder to construct an instance of <see cref="PushNotificationMessage"/>
+    /// </summary>
+    public class PushNotificationMessageBuilder
+    {
+        /// <summary>
+        /// The payload data that will be sent to the mobile client (not visible to the Push Notification Title or Message).
+        /// If the data is null then only the token will be sent as data.
+        /// </summary>
+        public string Data { get; set; }
+
+        /// <summary>
+        /// The message of the Push Notification.
+        /// </summary>
+        public string Message { get; set; }
+
+        /// <summary>
+        /// The Otp token that must be passed to the client.
+        /// </summary>
+        public string Token { get; set; }
+
+        /// <summary>
+        /// The UserId to send the Push Notification.
+        /// </summary>
+        public string UserId { get; set; }
+
+        /// <summary>
+        /// The tags of the Push Notification.
+        /// </summary>
+        public string[] Tags { get; set; } = Array.Empty<string>();
+    }
+
+    /// <summary>
+    /// <see cref="PushNotificationMessageBuilder"/> extensions
+    /// </summary>
+    public static class PushNotificationMessageBuilderExtensions
+    {
+        /// <summary>
+        /// Defines the message to the Push Notification. 
+        /// </summary>
+        /// <param name="builder">The builder</param>
+        /// <param name="message">The message to add to the push notification</param>
+        /// <returns></returns>
+        public static PushNotificationMessageBuilder WithMessage(this PushNotificationMessageBuilder builder, string message) {
+            if (string.IsNullOrEmpty(message)) {
+                throw new ArgumentException("You must define a message for the Push Notification.", nameof(message));
+            }
+            builder.Message = message;
+            return builder;
+        }
+
+        /// <summary>
+        /// Defines the data of the Push Notification. Data is optional.
+        /// </summary>
+        /// <param name="builder">The builder</param>
+        /// <param name="data">The data that will be sent to the push notification.</param>
+        /// <returns></returns>
+        public static PushNotificationMessageBuilder WithData(this PushNotificationMessageBuilder builder, string data) {
+            builder.Data = data;
+            return builder;
+        }
+
+        /// <summary>
+        /// Defines the otp token that will be sent to the Push Notification.
+        /// </summary>
+        /// <param name="builder">The builder</param>
+        /// <param name="token">The otp token.</param>
+        /// <returns></returns>
+        public static PushNotificationMessageBuilder WithToken(this PushNotificationMessageBuilder builder, string token) {
+            if (string.IsNullOrEmpty(token)) {
+                throw new ArgumentException("You must define the otp token of the Push Notification.", nameof(token));
+            }
+            builder.Token = token;
+            return builder;
+        }
+
+        /// <summary>
+        /// Defines the user that will receive the Push Notification.
+        /// </summary>
+        /// <param name="builder">The builder</param>
+        /// <param name="userId">The Id of the user.</param>
+        /// <returns></returns>
+        public static PushNotificationMessageBuilder To(this PushNotificationMessageBuilder builder, string userId) {
+            if (string.IsNullOrEmpty(userId)) {
+                throw new ArgumentException("You must define the userId of the Push Notification.", nameof(userId));
+            }
+            builder.UserId = userId;
+            return builder;
+        }
+
+        /// <summary>
+        /// Defines the tags that will be sent to the Push Notification.
+        /// </summary>
+        /// <param name="builder">The builder</param>
+        /// <param name="tags">The tags to send.</param>
+        /// <returns></returns>
+        public static PushNotificationMessageBuilder WithTags(this PushNotificationMessageBuilder builder, params string[] tags) {
+            if (tags?.Length == 0) {
+                throw new ArgumentException("You must set the tags to the Push Notification.", nameof(tags));
+            }
+            builder.Tags = tags;
+            return builder;
+        }
+
+        /// <summary>
+        /// Returns the <see cref="PushNotificationMessage"/> instance made by the builder.
+        /// </summary>
+        /// <param name="builder">The builder</param>
+        /// <returns></returns>
+        public static PushNotificationMessage Build(this PushNotificationMessageBuilder builder) =>
+            new(builder.Data, builder.Message, builder.Token, builder.UserId, builder.Tags);
+    }
+}

--- a/src/Indice.Common/Services/IPushNotificationService.cs
+++ b/src/Indice.Common/Services/IPushNotificationService.cs
@@ -70,6 +70,21 @@ namespace Indice.Services
         /// <param name="tags">Optional tag parameters.</param>
         public static async Task SendAsync(this IPushNotificationService service, string message, string data, string userId, params string[] tags) =>
             await service.SendAsync(message, new string[] { userId }.Concat(tags ?? Array.Empty<string>()).ToList(), data);
+
+        /// <summary>
+        /// Send notification to devices registered to userId with optional data as payload
+        /// </summary>
+        /// <param name="service">Instance of <see cref="IPushNotificationService"/>.</param>
+        /// <param name="configurePushNotificationMessage">The delegate that will be used to build the <see cref="PushNotificationMessage"/>.</param>
+        /// <returns></returns>
+        public static async Task SendAsync(this IPushNotificationService service, Func<PushNotificationMessageBuilder, PushNotificationMessageBuilder> configurePushNotificationMessage) {
+            if (configurePushNotificationMessage == null) {
+                throw new ArgumentNullException(nameof(configurePushNotificationMessage));
+            }
+            var pushNotificationMessageBuilder = configurePushNotificationMessage(new PushNotificationMessageBuilder());
+            var pushNotificationMessage = pushNotificationMessageBuilder.Build();
+            await service.SendAsync(pushNotificationMessage.Message, pushNotificationMessage.Data, pushNotificationMessage.UserId, pushNotificationMessage.Tags.ToArray());
+        }
     }
 
     /// <summary>
@@ -90,6 +105,32 @@ namespace Indice.Services
         ///<inheritdoc/>
         public Task UnRegister(string deviceId) {
             throw new NotImplementedException();
+        }
+    }
+
+    /// <summary>
+    /// Mock implementation of <see cref="IPushNotificationService"/>.
+    /// </summary>
+    public class MockPushNotificationService : IPushNotificationService
+    {
+        /// <inheritdoc />
+        public Task Register(string deviceId, string pnsHandle, DevicePlatform devicePlatform, IList<string> tags) {
+            throw new NotImplementedException();
+        }
+        /// <inheritdoc />
+        public Task UnRegister(string deviceId) {
+            throw new NotImplementedException();
+        }
+        /// <inheritdoc />
+        public Task SendAsync(string message, IList<string> tags, string data = null) {
+            Console.WriteLine($"PushNotification Message: {message}");
+            Console.WriteLine($"PushNotification Tags: {string.Join(",", tags)}");
+            Console.WriteLine($"PushNotification Data: {data}");
+#if NET452
+            return Task.FromResult(0);
+#else
+            return Task.CompletedTask;
+#endif
         }
     }
 }

--- a/src/Indice.Common/Services/ITotpService.cs
+++ b/src/Indice.Common/Services/ITotpService.cs
@@ -21,8 +21,9 @@ namespace Indice.Services
         /// <param name="purpose">Optionally pass the reason to generate the TOTP.</param>
         /// <param name="securityToken">The generated security token to use, if no <paramref name="principal"/> is provided.</param>
         /// <param name="phoneNumberOrEmail">The phone number to use, if no <paramref name="principal"/> is provided.</param>
+        /// <param name="data">The json string that will be passed as data to the <see cref="IPushNotificationService"/>. It's important for the data to contain the {0} placeholder in the position where the OTP should be placed.</param>
         /// <exception cref="TotpServiceException">Used to pass errors between service and the caller.</exception>
-        Task<TotpResult> Send(ClaimsPrincipal principal, string message, TotpDeliveryChannel channel = TotpDeliveryChannel.Sms, string purpose = null, string securityToken = null, string phoneNumberOrEmail = null);
+        Task<TotpResult> Send(ClaimsPrincipal principal, string message, TotpDeliveryChannel channel = TotpDeliveryChannel.Sms, string purpose = null, string securityToken = null, string phoneNumberOrEmail = null, string data = null);
         /// <summary>
         /// Verify the code received for the given claims principal.
         /// </summary>

--- a/test/Indice.AspNetCore.Identity.Tests/Services/MockTotpService.cs
+++ b/test/Indice.AspNetCore.Identity.Tests/Services/MockTotpService.cs
@@ -10,7 +10,7 @@ namespace Indice.AspNetCore.Identity
         public Task<Dictionary<string, TotpProviderMetadata>> GetProviders(ClaimsPrincipal principal) => 
             Task.FromResult(new Dictionary<string, TotpProviderMetadata>());
 
-        public Task<TotpResult> Send(ClaimsPrincipal principal, string message, TotpDeliveryChannel channel = TotpDeliveryChannel.Sms, string purpose = null, string securityToken = null, string phoneNumberOrEmail = null) => 
+        public Task<TotpResult> Send(ClaimsPrincipal principal, string message, TotpDeliveryChannel channel = TotpDeliveryChannel.Sms, string purpose = null, string securityToken = null, string phoneNumberOrEmail = null, string data = null) => 
             Task.FromResult(TotpResult.SuccessResult);
 
         public Task<TotpResult> Verify(ClaimsPrincipal principal, string code, TotpProviderType? provider = null, string purpose = null, string securityToken = null, string phoneNumberOrEmail = null) => 

--- a/test/Indice.Services.Tests/PushNotificationMessageTests.cs
+++ b/test/Indice.Services.Tests/PushNotificationMessageTests.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Indice.Services.Tests
+{
+    public class PushNotificationMessageTests
+    {
+        [Fact]
+        public async Task PushNotificationBuilderTestMinimum() {
+            IPushNotificationService service = new MockPushNotificationService();
+
+            await service.SendAsync(builder => builder
+                .To(Guid.NewGuid().ToString())
+                .WithMessage("Push Notification Message")
+                .WithToken("123456"));
+
+            Assert.True(true);
+        }
+
+        [Fact]
+        public async Task PushNotificationBuilderTestWithData() {
+            IPushNotificationService service = new MockPushNotificationService();
+
+            await service.SendAsync(builder => builder
+                .To(Guid.NewGuid().ToString())
+                .WithMessage("Push Notification Message")
+                .WithToken("123456")
+                .WithData("{{\"connectionId\":\"1234-abcd\", \"otp\":{0}}}"));
+
+            Assert.True(true);
+        }
+
+        [Fact]
+        public async Task PushNotificationBuilderTestAllOptions() {
+            IPushNotificationService service = new MockPushNotificationService();
+
+            await service.SendAsync(builder => builder
+                .To(Guid.NewGuid().ToString())
+                .WithMessage("Push Notification Message")
+                .WithToken("123456")
+                .WithData("{{\"connectionId\":\"1234-abcd\", \"otp\":{0}}}")
+                .WithTags("tag1", "tag2"));
+
+            Assert.True(true);
+        }
+    }
+}


### PR DESCRIPTION
# What ?
I've added a new optional parameter `string data = null` to the `ITotpService.Send` method so we can handle structed objects when the delivery channel is `PushNotification`.

As consumer we want to do something like the following

```cs
var pushNotificationMessage = "Business Message Here"; // eg "Please approve the transaction from your account *1234"
var serializedData = "{{ \"connectionId\": \"123\", \"otp\": \"{0}\", \"moreData\": [ ...  ] }}"
var totpResult = await totpService.Send(principal,  message: pushNotificationMessage, deliveryChannel, purpose: "purpose", data: serializedData);
```

And then the client will handle the deserialization of the structured data.

## Backwards Compatibility
For existing consumers or if the consumer does not need to send json message to the client, by ignoring the `data` parameter the code will continue to act as before, which is `data: 123456`

```cs
await _pushNotificationService.SendAsync(string.Format(message, token), string.Format(data ?? "{0}", token), user.Id);
```


# Why ?
Currently, the API is allowing to set only the `message` to the PushNotification Service and for our new "Push Approvals" feature, we need to send complex data to the client (serilized as JSON string) and those data must be hidden from mobile clients.


# Testing ?
No testing have been done. The existing tests are passing successfully.

# Anything Else ?
Nope.