### PR TITLE
Add ITotpDataBuilder to TotpMessageBuilder when building a TotpMessage from the OtpController

### DIFF
--- a/src/Indice.AspNetCore.Identity/Features/Totp/TotpController.cs
+++ b/src/Indice.AspNetCore.Identity/Features/Totp/TotpController.cs
@@ -64,21 +64,21 @@ namespace Indice.AspNetCore.Identity.Features
                 case TotpDeliveryChannel.Sms:
                     result = await TotpService.Send(options => options.UsePrincipal(User).WithMessage(request.Message).UsingSms().WithPurpose(request.Purpose));
                     if (!result.Success) {
-                        ModelState.AddModelError(nameof(request.Channel), result.Error ?? "An error occured.");
+                        ModelState.AddModelError(nameof(request.Channel), result.Error ?? "An error occurred.");
                         return BadRequest(new ValidationProblemDetails(ModelState));
                     }
                     break;
                 case TotpDeliveryChannel.Viber:
                     result = await TotpService.Send(options => options.UsePrincipal(User).WithMessage(request.Message).UsingViber().WithPurpose(request.Purpose));
                     if (!result.Success) {
-                        ModelState.AddModelError(nameof(request.Channel), result.Error ?? "An error occured.");
+                        ModelState.AddModelError(nameof(request.Channel), result.Error ?? "An error occurred.");
                         return BadRequest(new ValidationProblemDetails(ModelState));
                     }
                     break;
                 case TotpDeliveryChannel.PushNotification:
-                    result = await TotpService.Send(options => options.UsePrincipal(User).WithMessage(request.Message).UsingPushNotification().WithPurpose(request.Purpose));
+                    result = await TotpService.Send(options => options.UsePrincipal(User).WithMessage(request.Message).UsingPushNotification().WithPurpose(request.Purpose).WithData(request.Data));
                     if (!result.Success) {
-                        ModelState.AddModelError(nameof(request.Channel), result.Error ?? "An error occured.");
+                        ModelState.AddModelError(nameof(request.Channel), result.Error ?? "An error occurred.");
                         return BadRequest(new ValidationProblemDetails(ModelState));
                     }
                     break;
@@ -125,13 +125,19 @@ namespace Indice.AspNetCore.Identity.Features
         [Required]
         public TotpDeliveryChannel Channel { get; set; }
         /// <summary>
-        /// Optionaly pass the reason to generate the TOTP.
+        /// Optionally pass the reason to generate the TOTP.
         /// </summary>
         public string Purpose { get; set; }
         /// <summary>
-        /// The message to be sent in the SMS. It's important for the message to contain the {0} placeholder in the position where the OTP should be placed.
+        /// The message to be sent in the SMS/Viber or PushNotification. It's important for the message to contain the {0} placeholder in the position where the OTP should be placed.
+        /// In the case of <see cref="TotpDeliveryChannel.PushNotification"/> the {0} placeholder can be avoided so the message will be User Friendly in the Push Notification. The
+        /// {0} placeholder should be placed inside the <see cref="Data"/>.
         /// </summary>
         public string Message { get; set; }
+        /// <summary>
+        /// The payload data in json string to be sent in the Push Notification.It's important for the data to contain the {0} placeholder in the position where the OTP should be placed.
+        /// </summary>
+        public string Data { get; set; }
     }
 
     /// <summary>

--- a/src/Indice.Common/Services/ITotpService.cs
+++ b/src/Indice.Common/Services/ITotpService.cs
@@ -73,7 +73,7 @@ namespace Indice.Services
             var messageBuilder = new TotpMessageBuilder();
             configureMessage(messageBuilder);
             var totpMessage = messageBuilder.Build();
-            return service.Send(totpMessage.ClaimsPrincipal, totpMessage.Message, totpMessage.DeliveryChannel, totpMessage.Purpose, totpMessage.SecurityToken, totpMessage.PhoneNumberOrEmail);
+            return service.Send(totpMessage.ClaimsPrincipal, totpMessage.Message, totpMessage.DeliveryChannel, totpMessage.Purpose, totpMessage.SecurityToken, totpMessage.PhoneNumberOrEmail, totpMessage.Data);
         }
 
         /// <summary>
@@ -108,8 +108,13 @@ namespace Indice.Services
         public ClaimsPrincipal ClaimsPrincipal { get; internal set; }
         /// <summary>
         /// The message to be sent in the SMS. It's important for the message to contain the {0} placeholder in the position where the OTP should be placed.
+        /// If the <see cref="DeliveryChannel"/> is PushNotification, the {0} placeholder can be ignored and use a human friendly message.
         /// </summary>
         public string Message { get; internal set; }
+        /// <summary>
+        /// The payload data as json string to be sent in PushNotification. It's important for the data to contain the {0} placeholder in the position where the OTP should be placed.
+        /// </summary>
+        public string Data { get; internal set; }
         /// <summary>
         /// Security token.
         /// </summary>
@@ -158,11 +163,44 @@ namespace Indice.Services
         public TotpMessage Build() => new() {
             ClaimsPrincipal = ClaimsPrincipal,
             Message = Message,
+            Data = Data,
             SecurityToken = SecurityToken,
             PhoneNumberOrEmail = PhoneNumberOrEmail,
             DeliveryChannel = DeliveryChannel,
             Purpose = Purpose
         };
+    }
+
+    /// <summary>
+    /// Builder for the <see cref="TotpDataBuilder"/>.
+    /// </summary>
+    public interface ITotpDataBuilder
+    {
+        /// <summary>
+        /// Sets the <see cref="TotpMessageBuilder.Data"/> property.
+        /// </summary>
+        /// <param name="data">The payload data as json string to be sent in PushNotification. It's important for the data to contain the {0} placeholder in the position where the OTP should be placed.</param>
+        /// <returns></returns>
+        void WithData(string data);
+    }
+
+    /// <inheritdoc />
+    public class TotpDataBuilder : ITotpDataBuilder
+    {
+        private readonly TotpMessageBuilder _totpMessageBuilder;
+
+        /// <summary>
+        /// Creates a new instance of <see cref="TotpDataBuilder"/>.
+        /// </summary>
+        /// <param name="totpMessageBuilder">The instance of <see cref="TotpMessageBuilder"/>.</param>
+        public TotpDataBuilder(TotpMessageBuilder totpMessageBuilder) {
+            _totpMessageBuilder = totpMessageBuilder ?? throw new ArgumentNullException(nameof(totpMessageBuilder));
+        }
+
+        /// <inheritdoc/>
+        public void WithData(string data) {
+            _totpMessageBuilder.Data = data;
+        }
     }
 
     /// <summary>
@@ -277,7 +315,8 @@ namespace Indice.Services
         /// Sets the <see cref="TotpMessageBuilder.Purpose"/> property.
         /// </summary>
         /// <param name="purpose">The purpose.</param>
-        void WithPurpose(string purpose);
+        ITotpDataBuilder WithPurpose(string purpose);
+        
     }
 
     /// <inheritdoc/>
@@ -294,11 +333,13 @@ namespace Indice.Services
         }
 
         /// <inheritdoc/>
-        public void WithPurpose(string purpose) {
+        public ITotpDataBuilder WithPurpose(string purpose) {
             if (string.IsNullOrEmpty(purpose)) {
                 throw new ArgumentNullException(nameof(purpose), $"Parameter {nameof(purpose)} cannot be null or empty.");
             }
             _totpMessageBuilder.Purpose = purpose;
+            var dataBuilder = new TotpDataBuilder(_totpMessageBuilder);
+            return dataBuilder;
         }
     }
 
@@ -383,8 +424,8 @@ namespace Indice.Services
         /// </summary>
         /// <param name="error">The error.</param>
         public static TotpResult ErrorResult(string error) {
-            return new TotpResult { 
-                Error = error 
+            return new TotpResult {
+                Error = error
             };
         }
 
@@ -521,8 +562,13 @@ namespace Indice.Services
         public ClaimsPrincipal ClaimsPrincipal { get; set; }
         /// <summary>
         /// The message to be sent in the SMS. It's important for the message to contain the {0} placeholder in the position where the OTP should be placed.
+        /// If the <see cref="DeliveryChannel"/> is PushNotification, the {0} placeholder can be ignored and use a human friendly message.
         /// </summary>
-        public string Message { get; set; }
+        public string Message { get; internal set; }
+        /// <summary>
+        /// The payload data as json string to be sent in PushNotification. It's important for the data to contain the {0} placeholder in the position where the OTP should be placed.
+        /// </summary>
+        public string Data { get; internal set; }
         /// <summary>
         /// Chosen delivery channel.
         /// </summary>

--- a/src/Indice.Common/Services/ITotpService.cs
+++ b/src/Indice.Common/Services/ITotpService.cs
@@ -564,11 +564,11 @@ namespace Indice.Services
         /// The message to be sent in the SMS. It's important for the message to contain the {0} placeholder in the position where the OTP should be placed.
         /// If the <see cref="DeliveryChannel"/> is PushNotification, the {0} placeholder can be ignored and use a human friendly message.
         /// </summary>
-        public string Message { get; internal set; }
+        public string Message { get; set; }
         /// <summary>
         /// The payload data as json string to be sent in PushNotification. It's important for the data to contain the {0} placeholder in the position where the OTP should be placed.
         /// </summary>
-        public string Data { get; internal set; }
+        public string Data { get; set; }
         /// <summary>
         /// Chosen delivery channel.
         /// </summary>


### PR DESCRIPTION
# What?
I've added a new builder to the `TotpMessageBuilder` in order to include the data the client is sending.

# Why?
We have made some changes with PR #46, but I missed the fact that our consumer is using a delegate service to do a HTTP call to `OtpController`, instead of using the `ITotpService` directly.

# Testing?
I've tested with swagger UI that the controller receives the parameter and the builder is building the message as it should. The example request I was testing is

```json
{
  "channel": "PushNotification",
  "purpose": "A purpose",
  "message": "This is the push message",
  "data": "{{\"transMetadata\":[{{\"label\":\"TransactionHeader\",\"value\":\"Transaction Test Header\"}},{{\"label\":\"TransactionMessage\",\"value\":\"Transaction Message \\u03C3\\u03C4\\u03B1 \\u0395\\u03BB\\u03BB\\u03B7\\u03BD\\u03B9\\u03BA\\u03AC\"}},{{\"label\":\"TransactionFooter\",\"value\":\"Transaction Test Footer\"}}],\"connectionId\":\"xTVbyMOP-zs2SXX0I6Ec6wdff0e6431\",\"otp\":\"{0}\"}}"
}
```

Notice that the data is a json escaped string with `{{` and `}}` except for the otp parameter that is `{0}`. This means the data must be `string.Format` ready!

# Anything Else?
Currently, we are sending data as json string, formatted to be used as a `string.Format` parameter. Is it too much to pass the concern of serialization and object building (Data from client + otp)  to the framework ? Could `Data` parameter could be of type `<T>` ?