### PR TITLE
Add UserDeviceFilter to GetDevices

### DIFF
--- a/src/Indice.AspNetCore.Identity/Features/IdentityServerApi/Models/Filters/UserDeviceFilter.cs
+++ b/src/Indice.AspNetCore.Identity/Features/IdentityServerApi/Models/Filters/UserDeviceFilter.cs
@@ -1,0 +1,13 @@
+﻿namespace Indice.AspNetCore.Identity.Api.Models
+{
+    /// <summary>
+    /// Contains filter when querying for user device list.
+    /// </summary>
+    public class UserDeviceFilter
+    {
+        /// <summary>
+        /// Returns all the devices (value = null), the enabled devices (value = true) or the disabled devices (value = false).
+        /// </summary>
+        public bool? IsPushNotificationEnabled { get; set; }
+    }
+}

--- a/src/Indice.AspNetCore.Identity/Features/PushNotifications/DevicesController.cs
+++ b/src/Indice.AspNetCore.Identity/Features/PushNotifications/DevicesController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Net.Mime;
 using System.Threading.Tasks;
 using Indice.AspNetCore.Identity.Api.Filters;
@@ -9,6 +10,7 @@ using Indice.AspNetCore.Identity.Api.Security;
 using Indice.AspNetCore.Identity.Data;
 using Indice.AspNetCore.Identity.Data.Models;
 using Indice.Services;
+using Indice.Types;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -67,12 +69,12 @@ namespace Indice.AspNetCore.Identity.Features
         [HttpGet]
         [ProducesResponseType(statusCode: StatusCodes.Status200OK, type: typeof(IEnumerable<DeviceInfo>))]
         [ProducesResponseType(statusCode: StatusCodes.Status404NotFound, type: typeof(ProblemDetails))]
-        public async Task<IActionResult> GetDevices() {
+        public async Task<IActionResult> GetDevices([FromQuery] ListOptions<UserDeviceFilter> options = null) {
             var user = await _userManager.GetUserAsync(User);
             if (user == null) {
                 return NotFound();
             }
-            var devices = await _dbContext.UserDevices.Where(x => x.UserId == user.Id).Select(x => new DeviceInfo {
+            var devices = await _dbContext.UserDevices.Where(UserDevicePredicate(user.Id, options)).Select(x => new DeviceInfo {
                 DeviceId = x.DeviceId,
                 DeviceName = x.DeviceName,
                 DevicePlatform = x.DevicePlatform,
@@ -138,6 +140,12 @@ namespace Indice.AspNetCore.Identity.Features
             device.IsPushNotificationsEnabled = false;
             await _dbContext.SaveChangesAsync();
             return NoContent();
+        }
+
+        private Expression<Func<UserDevice, bool>> UserDevicePredicate(string userId, ListOptions<UserDeviceFilter> options) {
+            return options?.Filter.IsPushNotificationEnabled == null
+                ? x => x.UserId == userId
+                : x => x.UserId == userId && x.IsPushNotificationsEnabled == options.Filter.IsPushNotificationEnabled.Value;
         }
     }
 }

--- a/src/Indice.AspNetCore.Identity/Features/PushNotifications/DevicesController.cs
+++ b/src/Indice.AspNetCore.Identity/Features/PushNotifications/DevicesController.cs
@@ -67,7 +67,7 @@ namespace Indice.AspNetCore.Identity.Features
         /// <response code="200">OK</response>
         /// <response code="404">Not Found</response>
         [HttpGet]
-        [ProducesResponseType(statusCode: StatusCodes.Status200OK, type: typeof(IEnumerable<DeviceInfo>))]
+        [ProducesResponseType(statusCode: StatusCodes.Status200OK, type: typeof(ResultSet<DeviceInfo>))]
         [ProducesResponseType(statusCode: StatusCodes.Status404NotFound, type: typeof(ProblemDetails))]
         public async Task<IActionResult> GetDevices([FromQuery] ListOptions<UserDeviceFilter> options = null) {
             var user = await _userManager.GetUserAsync(User);
@@ -80,7 +80,7 @@ namespace Indice.AspNetCore.Identity.Features
                 DevicePlatform = x.DevicePlatform,
                 IsPushNotificationsEnabled = x.IsPushNotificationsEnabled
             })
-            .ToArrayAsync();
+            .ToResultSetAsync(options);
             return Ok(devices);
         }
 


### PR DESCRIPTION
# What?
I've added filtering options to `GetDevices` action in `DevicesController` but only for the `IsPushNotificationEnabled` property.

The filter supports 3 values
- `null` fetch all user devices (default value)
- `true` fetch all user devices with `IsPushNotificationEnabled = true`
- `false` fetch all user devices with `IsPushNotificationEnabled = false`

# Why?
We've noticed that the `GetDevices` action is fetching all the devices and we are filtering the deleted ones in the client.

# Testing?
I've added some data to my localDb and tested with Postman and SqlProfiler that the query and data are correct. Here are the results

## filter = null (default value)
### Postman
![all-devices](https://user-images.githubusercontent.com/8275452/128705227-c30c53eb-1c45-4e20-8490-5dee1c2b168f.PNG)
### SQL Profiler
```sql
exec sp_executesql N'SELECT [u].[DeviceId], [u].[DeviceName], [u].[DevicePlatform], [u].[IsPushNotificationsEnabled]
FROM [auth].[UserDevice] AS [u]
WHERE [u].[UserId] = @__userId_0',N'@__userId_0 nvarchar(450)',@__userId_0=N'9f6617a6-9a8d-4d5e-8132-bb95564ae04c'
```

## filter = true
### Postman
![true-devices](https://user-images.githubusercontent.com/8275452/128705299-463c266e-4823-429d-ac11-b815f3fafb1e.PNG)

### SQL Profiler
```sql
exec sp_executesql N'SELECT [u].[DeviceId], [u].[DeviceName], [u].[DevicePlatform], [u].[IsPushNotificationsEnabled]
FROM [auth].[UserDevice] AS [u]
WHERE ([u].[UserId] = @__userId_0) AND ([u].[IsPushNotificationsEnabled] = @__options_Filter_IsPushNotificationEnabled_Value_1)',N'@__userId_0 nvarchar(450),@__options_Filter_IsPushNotificationEnabled_Value_1 bit',@__userId_0=N'9f6617a6-9a8d-4d5e-8132-bb95564ae04c',@__options_Filter_IsPushNotificationEnabled_Value_1=1
```

## filter = false
### Postman
![false-devices](https://user-images.githubusercontent.com/8275452/128705266-20a5da1d-3df0-4b1a-bd87-009bfed47a8f.PNG)

### SQL Profiler
```sql
exec sp_executesql N'SELECT [u].[DeviceId], [u].[DeviceName], [u].[DevicePlatform], [u].[IsPushNotificationsEnabled]
FROM [auth].[UserDevice] AS [u]
WHERE ([u].[UserId] = @__userId_0) AND ([u].[IsPushNotificationsEnabled] = @__options_Filter_IsPushNotificationEnabled_Value_1)',N'@__userId_0 nvarchar(450),@__options_Filter_IsPushNotificationEnabled_Value_1 bit',@__userId_0=N'9f6617a6-9a8d-4d5e-8132-bb95564ae04c',@__options_Filter_IsPushNotificationEnabled_Value_1=0
```

# Anything Else?
I've used the `ListOptions<T>`, but I didn't implemented the paging/sorting functionality. 

This is for discussion:

The `IsPushNotificationEnabled` property is misleading and maybe we need to add a `Status` property with values like `None`, `Registered`, `Unregistered`, `Deleted` because there might be a case with an Active/Registered device but with IsPushNotificationEnabled = false.