### PR TITLE
Add PushNotification Classification in TotpService

### DIFF
--- a/src/Indice.AspNetCore.Identity/Features/Totp/TotpController.cs
+++ b/src/Indice.AspNetCore.Identity/Features/Totp/TotpController.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
 using System.Net.Mime;
 using System.Threading.Tasks;
 using Indice.AspNetCore.Identity.Api.Security;
@@ -76,7 +75,13 @@ namespace Indice.AspNetCore.Identity.Features
                     }
                     break;
                 case TotpDeliveryChannel.PushNotification:
-                    result = await TotpService.Send(options => options.UsePrincipal(User).WithMessage(request.Message).UsingPushNotification().WithPurpose(request.Purpose).WithData(request.Data));
+                    result = await TotpService.Send(options => options
+                        .UsePrincipal(User)
+                        .WithMessage(request.Message)
+                        .UsingPushNotification()
+                        .WithPurpose(request.Purpose)
+                        .WithData(request.Data)
+                        .WithClassification(request.Classification));
                     if (!result.Success) {
                         ModelState.AddModelError(nameof(request.Channel), result.Error ?? "An error occurred.");
                         return BadRequest(new ValidationProblemDetails(ModelState));
@@ -138,6 +143,11 @@ namespace Indice.AspNetCore.Identity.Features
         /// The payload data in json string to be sent in the Push Notification.It's important for the data to contain the {0} placeholder in the position where the OTP should be placed.
         /// </summary>
         public string Data { get; set; }
+        /// <summary>
+        /// The type of the Push Notification.
+        /// <remarks>This applies only for <see cref="TotpDeliveryChannel.PushNotification"/>.</remarks>
+        /// </summary>
+        public string Classification { get; set; }
     }
 
     /// <summary>

--- a/src/Indice.AspNetCore.Identity/Services/DeveloperTotpService.cs
+++ b/src/Indice.AspNetCore.Identity/Services/DeveloperTotpService.cs
@@ -57,7 +57,7 @@ namespace Indice.AspNetCore.Identity
         }
 
         /// <inheritdoc />
-        public async Task<TotpResult> Send(ClaimsPrincipal principal, string message, TotpDeliveryChannel channel = TotpDeliveryChannel.Sms, string purpose = null, string securityToken = null, string phoneNumberOrEmail = null, string data = null) {
+        public async Task<TotpResult> Send(ClaimsPrincipal principal, string message, TotpDeliveryChannel channel = TotpDeliveryChannel.Sms, string purpose = null, string securityToken = null, string phoneNumberOrEmail = null, string data = null, string classification = null) {
             var userId = principal.GetSubjectId();
             if (!string.IsNullOrEmpty(userId)) {
                 var hasDeveloperTotp = await _dbContext.UserClaims.Where(x => x.UserId == userId && x.ClaimType == BasicClaimTypes.DeveloperTotp).AnyAsync();
@@ -65,7 +65,7 @@ namespace Indice.AspNetCore.Identity
                     return TotpResult.SuccessResult;
                 }
             }
-            return await _totpService.Send(principal, message, channel, purpose, securityToken, phoneNumberOrEmail, data);
+            return await _totpService.Send(principal, message, channel, purpose, securityToken, phoneNumberOrEmail, data, classification);
         }
 
         /// <inheritdoc />

--- a/src/Indice.AspNetCore.Identity/Services/TotpService.cs
+++ b/src/Indice.AspNetCore.Identity/Services/TotpService.cs
@@ -58,7 +58,7 @@ namespace Indice.AspNetCore.Identity
         }
 
         /// <inheritdoc />
-        public async Task<TotpResult> Send(ClaimsPrincipal principal, string message, TotpDeliveryChannel channel = TotpDeliveryChannel.Sms, string purpose = null, string securityToken = null, string phoneNumberOrEmail = null, string data = null) {
+        public async Task<TotpResult> Send(ClaimsPrincipal principal, string message, TotpDeliveryChannel channel = TotpDeliveryChannel.Sms, string purpose = null, string securityToken = null, string phoneNumberOrEmail = null, string data = null, string classification = null) {
             var totpResult = ValidateParameters(principal, securityToken, phoneNumberOrEmail);
             if (!totpResult.Success) {
                 return totpResult;
@@ -108,6 +108,7 @@ namespace Indice.AspNetCore.Identity
                             .WithToken(token)
                             .WithMessage(string.Format(message, token))
                             .WithData(data)
+                            .WithClassification(classification)
                     );
                     break;
                 default:

--- a/src/Indice.Common/Configuration/PushNotificationMessage.cs
+++ b/src/Indice.Common/Configuration/PushNotificationMessage.cs
@@ -34,6 +34,11 @@ namespace Indice.Services
         public string[] Tags { get; }
 
         /// <summary>
+        /// The type of the Push Notification.
+        /// </summary>
+        public string Classification { get; }
+
+        /// <summary>
         /// Constructs a <see cref="PushNotificationMessage"/>.
         /// </summary>
         /// <param name="data">The payload data that will be sent to the mobile client (not visible to the Push Notification Title or Message).  If the data is null then only the token will be sent as data.</param>
@@ -41,12 +46,14 @@ namespace Indice.Services
         /// <param name="token">The Otp token that must be passed to the client.</param>
         /// <param name="userId">The UserId to send the Push Notification.</param>
         /// <param name="tags">The tags of the Push Notification.</param>
-        public PushNotificationMessage(string data, string message, string token, string userId, string[] tags) {
+        /// <param name="classification">The type of the Push Notification.</param>
+        public PushNotificationMessage(string data, string message, string token, string userId, string[] tags, string classification) {
             Message = message ?? throw new ArgumentNullException(nameof(message));
             Token = token ?? throw new ArgumentNullException(nameof(token));
             UserId = userId ?? throw new ArgumentNullException(nameof(userId));
             Data = string.Format(data ?? "{0}", Token);
             Tags = tags ?? Array.Empty<string>();
+            Classification = classification;
         }
     }
 }

--- a/src/Indice.Common/Configuration/PushNotificationMessageBuilder.cs
+++ b/src/Indice.Common/Configuration/PushNotificationMessageBuilder.cs
@@ -32,6 +32,11 @@ namespace Indice.Services
         /// The tags of the Push Notification.
         /// </summary>
         public string[] Tags { get; set; } = Array.Empty<string>();
+
+        /// <summary>
+        /// The type of the Push Notification.
+        /// </summary>
+        public string Classification { get; set; }
     }
 
     /// <summary>
@@ -107,11 +112,22 @@ namespace Indice.Services
         }
 
         /// <summary>
+        /// Defines the type of the Push Notification.
+        /// </summary>
+        /// <param name="builder">the builder</param>
+        /// <param name="classification">The type of the push notification.</param>
+        /// <returns></returns>
+        public static PushNotificationMessageBuilder WithClassification(this PushNotificationMessageBuilder builder, string classification) {
+            builder.Classification = classification;
+            return builder;
+        }
+
+        /// <summary>
         /// Returns the <see cref="PushNotificationMessage"/> instance made by the builder.
         /// </summary>
         /// <param name="builder">The builder</param>
         /// <returns></returns>
         public static PushNotificationMessage Build(this PushNotificationMessageBuilder builder) =>
-            new(builder.Data, builder.Message, builder.Token, builder.UserId, builder.Tags);
+            new(builder.Data, builder.Message, builder.Token, builder.UserId, builder.Tags, builder.Classification);
     }
 }

--- a/src/Indice.Common/Services/IPushNotificationService.cs
+++ b/src/Indice.Common/Services/IPushNotificationService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Indice.Types;
@@ -30,7 +31,8 @@ namespace Indice.Services
         /// <param name="message">Message of notification.</param>
         /// <param name="tags">Tags are used to route notifications to the correct set of device handles.</param>
         /// <param name="data">Data passed to mobile client, not visible to notification toast.</param>
-        Task SendAsync(string message, IList<string> tags, string data = null);
+        /// <param name="classification">The notification's type.</param>
+        Task SendAsync(string message, IList<string> tags, string data = null, string classification = null);
     }
 
     /// <summary>
@@ -61,7 +63,7 @@ namespace Indice.Services
             await service.SendAsync(message, new string[] { userId }.Concat(tags ?? Array.Empty<string>()).ToList());
 
         /// <summary>
-        /// Send notifications to devices registered to userId.
+        /// Send notifications to devices registered to userId with payload data.
         /// </summary>
         /// <param name="service">Instance of <see cref="IPushNotificationService"/>.</param>
         /// <param name="message">Message of notification.</param>
@@ -70,6 +72,18 @@ namespace Indice.Services
         /// <param name="tags">Optional tag parameters.</param>
         public static async Task SendAsync(this IPushNotificationService service, string message, string data, string userId, params string[] tags) =>
             await service.SendAsync(message, new string[] { userId }.Concat(tags ?? Array.Empty<string>()).ToList(), data);
+
+        /// <summary>
+        /// Send notifications to devices registered to userId with payload data and classification.
+        /// </summary>
+        /// <param name="service">Instance of <see cref="IPushNotificationService"/>.</param>
+        /// <param name="message">Message of notification.</param>
+        /// <param name="data">Data passed to mobile client, not visible to notification toast.</param>
+        /// <param name="userId">UserId to be passed as tag.</param>
+        /// <param name="classification">The type of the Push Notification.</param>
+        /// <param name="tags">Optional tag parameters.</param>
+        public static async Task SendAsync(this IPushNotificationService service, string message, string data, string userId , string classification, params string[] tags) =>
+            await service.SendAsync(message, new string[] { userId }.Concat(tags ?? Array.Empty<string>()).ToList(), data, classification);
 
         /// <summary>
         /// Send notification to devices registered to userId with optional data as payload
@@ -83,7 +97,7 @@ namespace Indice.Services
             }
             var pushNotificationMessageBuilder = configurePushNotificationMessage(new PushNotificationMessageBuilder());
             var pushNotificationMessage = pushNotificationMessageBuilder.Build();
-            await service.SendAsync(pushNotificationMessage.Message, pushNotificationMessage.Data, pushNotificationMessage.UserId, pushNotificationMessage.Tags.ToArray());
+            await service.SendAsync(pushNotificationMessage.Message, pushNotificationMessage.Data, pushNotificationMessage.UserId, pushNotificationMessage.Classification, pushNotificationMessage.Tags.ToArray());
         }
     }
 
@@ -98,7 +112,7 @@ namespace Indice.Services
         }
 
         ///<inheritdoc/>
-        public Task SendAsync(string message, IList<string> tags, string data = null) {
+        public Task SendAsync(string message, IList<string> tags, string data = null, string classification = null) {
             throw new NotImplementedException();
         }
 
@@ -122,10 +136,12 @@ namespace Indice.Services
             throw new NotImplementedException();
         }
         /// <inheritdoc />
-        public Task SendAsync(string message, IList<string> tags, string data = null) {
-            Console.WriteLine($"PushNotification Message: {message}");
-            Console.WriteLine($"PushNotification Tags: {string.Join(",", tags)}");
-            Console.WriteLine($"PushNotification Data: {data}");
+        public Task SendAsync(string message, IList<string> tags, string data = null, string classification = null) {
+            Trace.WriteLine($"PushNotification Message: {message}");
+            Trace.WriteLine($"PushNotification Tags: {string.Join(",", tags)}");
+            Trace.WriteLine($"PushNotification Data: {data}");
+            Trace.WriteLine($"PushNotification Classification: {classification}");
+            
 #if NET452
             return Task.FromResult(0);
 #else

--- a/src/Indice.Common/Services/IPushNotificationService.cs
+++ b/src/Indice.Common/Services/IPushNotificationService.cs
@@ -53,27 +53,6 @@ namespace Indice.Services
             await service.Register(deviceId, pnsHandle, devicePlatform, new string[] { userId }.Concat(tags ?? Array.Empty<string>()).ToList());
 
         /// <summary>
-        /// Send notifications to devices registered to userId.
-        /// </summary>
-        /// <param name="service">Instance of <see cref="IPushNotificationService"/>.</param>
-        /// <param name="message">Message of notification.</param>
-        /// <param name="userId">UserId to be passed as tag.</param>
-        /// <param name="tags">Optional tag parameters.</param>
-        public static async Task SendAsync(this IPushNotificationService service, string message, string userId, params string[] tags) =>
-            await service.SendAsync(message, new string[] { userId }.Concat(tags ?? Array.Empty<string>()).ToList());
-
-        /// <summary>
-        /// Send notifications to devices registered to userId with payload data.
-        /// </summary>
-        /// <param name="service">Instance of <see cref="IPushNotificationService"/>.</param>
-        /// <param name="message">Message of notification.</param>
-        /// <param name="data">Data passed to mobile client, not visible to notification toast.</param>
-        /// <param name="userId">UserId to be passed as tag.</param>
-        /// <param name="tags">Optional tag parameters.</param>
-        public static async Task SendAsync(this IPushNotificationService service, string message, string data, string userId, params string[] tags) =>
-            await service.SendAsync(message, new string[] { userId }.Concat(tags ?? Array.Empty<string>()).ToList(), data);
-
-        /// <summary>
         /// Send notifications to devices registered to userId with payload data and classification.
         /// </summary>
         /// <param name="service">Instance of <see cref="IPushNotificationService"/>.</param>

--- a/src/Indice.Services/PushNotificationServiceAzure.cs
+++ b/src/Indice.Services/PushNotificationServiceAzure.cs
@@ -18,11 +18,11 @@ namespace Indice.Services
         /// <summary>
         /// iOS template.
         /// </summary>
-        private const string IosTemplate = @"{""aps"":{""alert"":""$(message)""}, ""payload"":{""data"":""$(data)""}}";
+        private const string IosTemplate = @"{""aps"":{""alert"":""$(message)"", ""category"":""$(classification)""}, ""payload"":{""data"":""$(data)""}}";
         /// <summary>
         /// Android template.
         /// </summary>
-        private const string AndroidTemplate = @"{""data"":{""message"":""$(message)"", ""data"":""$(data)""}}";
+        private const string AndroidTemplate = @"{""data"":{""message"":""$(message)"", ""data"":""$(data)"", ""category"":""$(classification)""}}"; 
         /// <summary>
         /// The connection string parameter name. The setting key that will be searched inside the configuration.
         /// </summary>
@@ -102,7 +102,7 @@ namespace Indice.Services
         }
 
         /// <inheritdoc/>
-        public async Task SendAsync(string message, IList<string> tags, string data = null) {
+        public async Task SendAsync(string message, IList<string> tags, string data = null, string classification = null) {
             if (string.IsNullOrEmpty(message)) {
                 throw new ArgumentNullException(nameof(message));
             }
@@ -114,6 +114,9 @@ namespace Indice.Services
             };
             if (!string.IsNullOrEmpty(data)) {
                 notification.Add("data", data);
+            }
+            if (!string.IsNullOrEmpty(classification)) {
+                notification.Add("classification", classification);
             }
             await NotificationHub.SendTemplateNotificationAsync(notification, tags);
         }

--- a/test/Indice.AspNetCore.Identity.Tests/Services/MockTotpService.cs
+++ b/test/Indice.AspNetCore.Identity.Tests/Services/MockTotpService.cs
@@ -13,6 +13,9 @@ namespace Indice.AspNetCore.Identity
         public Task<TotpResult> Send(ClaimsPrincipal principal, string message, TotpDeliveryChannel channel = TotpDeliveryChannel.Sms, string purpose = null, string securityToken = null, string phoneNumberOrEmail = null, string data = null) => 
             Task.FromResult(TotpResult.SuccessResult);
 
+        public Task<TotpResult> Send(ClaimsPrincipal principal, string message, TotpDeliveryChannel channel = TotpDeliveryChannel.Sms, string purpose = null, string securityToken = null, string phoneNumberOrEmail = null, string data = null, string classification = null) =>
+            Task.FromResult(TotpResult.SuccessResult);
+
         public Task<TotpResult> Verify(ClaimsPrincipal principal, string code, TotpProviderType? provider = null, string purpose = null, string securityToken = null, string phoneNumberOrEmail = null) => 
             Task.FromResult(TotpResult.SuccessResult);
     }

--- a/test/Indice.AspNetCore.Identity.Tests/Services/MockTotpService.cs
+++ b/test/Indice.AspNetCore.Identity.Tests/Services/MockTotpService.cs
@@ -10,9 +10,6 @@ namespace Indice.AspNetCore.Identity
         public Task<Dictionary<string, TotpProviderMetadata>> GetProviders(ClaimsPrincipal principal) => 
             Task.FromResult(new Dictionary<string, TotpProviderMetadata>());
 
-        public Task<TotpResult> Send(ClaimsPrincipal principal, string message, TotpDeliveryChannel channel = TotpDeliveryChannel.Sms, string purpose = null, string securityToken = null, string phoneNumberOrEmail = null, string data = null) => 
-            Task.FromResult(TotpResult.SuccessResult);
-
         public Task<TotpResult> Send(ClaimsPrincipal principal, string message, TotpDeliveryChannel channel = TotpDeliveryChannel.Sms, string purpose = null, string securityToken = null, string phoneNumberOrEmail = null, string data = null, string classification = null) =>
             Task.FromResult(TotpResult.SuccessResult);
 

--- a/test/Indice.Services.Tests/Indice.Services.Tests.csproj
+++ b/test/Indice.Services.Tests/Indice.Services.Tests.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/test/Indice.Services.Tests/PushNotificationMessageTests.cs
+++ b/test/Indice.Services.Tests/PushNotificationMessageTests.cs
@@ -29,6 +29,19 @@ namespace Indice.Services.Tests
                 .WithData("{{\"connectionId\":\"1234-abcd\", \"otp\":{0}}}"));
 
             Assert.True(true);
+        }   
+        
+        [Fact]
+        public async Task PushNotificationBuilderTestWithClassification() {
+            IPushNotificationService service = new MockPushNotificationService();
+
+            await service.SendAsync(builder => builder
+                .To(Guid.NewGuid().ToString())
+                .WithMessage("Push Notification Message")
+                .WithToken("123456")
+                .WithClassification("PushApprovals"));
+
+            Assert.True(true);
         }
 
         [Fact]
@@ -40,6 +53,7 @@ namespace Indice.Services.Tests
                 .WithMessage("Push Notification Message")
                 .WithToken("123456")
                 .WithData("{{\"connectionId\":\"1234-abcd\", \"otp\":{0}}}")
+                .WithClassification("PushApprovals")
                 .WithTags("tag1", "tag2"));
 
             Assert.True(true);


### PR DESCRIPTION
# What ?
I've added a new parameter `classification` to the `TotpService` and `IPushNotification`. This is a breaking change. Also we had to update the iOS and Android templates.

# Why ?
We need to classify the push notification messages to the mobile clients (eg "PushApprovals", "Marketing", "Information") so the client will be able to handle all those cases differently, and of course, avoid "weird notifications" for new categories in old clients.

# Testing ?
I've created the nuget packages locally, updated them to the Consumer project and tested with real device.

Scenarios
- Send push notification to an old client (registered without classification) and the new template -> `Passed` 
- Send push notification to new client (registered with classification) and the new template -> `Passed`
 
# Anything Else ?
Windows Phone template has not been changed.