### PR TITLE
Add Dynamic otp message for device registration in InitRegistrationEndpoint

### DIFF
--- a/src/Indice.AspNetCore.Identity/Features/TrustedDeviceAuthorization/Endpoints/InitRegistrationEndpoint.cs
+++ b/src/Indice.AspNetCore.Identity/Features/TrustedDeviceAuthorization/Endpoints/InitRegistrationEndpoint.cs
@@ -34,7 +34,8 @@ namespace Indice.AspNetCore.Identity.TrustedDeviceAuthorization.Endpoints
             IProfileService profileService,
             IResourceStore resourceStore,
             ITotpService totpService,
-            IUserDeviceStore userDeviceStore
+            IUserDeviceStore userDeviceStore,
+            IdentityMessageDescriber identityMessageDescriber
         ) {
             Logger = logger ?? throw new ArgumentNullException(nameof(logger));
             ProfileService = profileService ?? throw new ArgumentNullException(nameof(profileService));
@@ -44,6 +45,7 @@ namespace Indice.AspNetCore.Identity.TrustedDeviceAuthorization.Endpoints
             Token = tokenUsageValidator ?? throw new ArgumentNullException(nameof(tokenUsageValidator));
             TotpService = totpService ?? throw new ArgumentNullException(nameof(totpService));
             UserDeviceStore = userDeviceStore ?? throw new ArgumentNullException(nameof(userDeviceStore));
+            IdentityMessageDescriber = identityMessageDescriber ?? throw new ArgumentNullException(nameof(identityMessageDescriber));
         }
 
         public BearerTokenUsageValidator Token { get; }
@@ -54,6 +56,7 @@ namespace Indice.AspNetCore.Identity.TrustedDeviceAuthorization.Endpoints
         public IResourceStore ResourceStore { get; }
         public ITotpService TotpService { get; }
         public IUserDeviceStore UserDeviceStore { get; }
+        public IdentityMessageDescriber IdentityMessageDescriber { get; }
 
         public async Task<IEndpointResult> ProcessAsync(HttpContext httpContext) {
             Logger.LogInformation($"[{nameof(InitRegistrationEndpoint)}] Started processing trusted device registration initiation endpoint.");
@@ -106,7 +109,7 @@ namespace Indice.AspNetCore.Identity.TrustedDeviceAuthorization.Endpoints
                 // Send OTP code.
                 var totpResult = await TotpService.Send(message =>
                     message.UsePrincipal(requestValidationResult.Principal)
-                           .WithMessage("Device registration OTP code is {0}.")
+                           .WithMessage(IdentityMessageDescriber.DeviceRegistrationCodeMessage(existingDevice?.DeviceName))
                            .UsingSms()
                            .WithPurpose(Constants.TrustedDeviceOtpPurpose(requestValidationResult.UserId, requestValidationResult.DeviceId))
                 );

--- a/src/Indice.AspNetCore.Identity/IdentityResources.Designer.cs
+++ b/src/Indice.AspNetCore.Identity/IdentityResources.Designer.cs
@@ -61,6 +61,15 @@ namespace Indice.AspNetCore.Identity {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Registration OTP code for device {0} is {1}..
+        /// </summary>
+        internal static string DeviceRegistrationOtpCode {
+            get {
+                return ResourceManager.GetString("DeviceRegistrationOtpCode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to User&apos;s email is already confirmed..
         /// </summary>
         internal static string EmailAlreadyConfirmed {

--- a/src/Indice.AspNetCore.Identity/IdentityResources.resx
+++ b/src/Indice.AspNetCore.Identity/IdentityResources.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="DeviceRegistrationOtpCode" xml:space="preserve">
+    <value>Registration OTP code for device {0} is {1}.</value>
+  </data>
   <data name="EmailAlreadyConfirmed" xml:space="preserve">
     <value>User's email is already confirmed.</value>
   </data>

--- a/src/Indice.AspNetCore.Identity/Services/IdentityMessageDescriber.cs
+++ b/src/Indice.AspNetCore.Identity/Services/IdentityMessageDescriber.cs
@@ -92,5 +92,9 @@
         /// Message sent on message when <see cref="OtpAuthenticateExtensionGrantValidator"/> is used.
         /// </summary>
         public virtual string OtpSecuredValidatorOtpBody(string code) => string.Format(IdentityResources.Culture, IdentityResources.OtpSecuredValidatorOtpBody, code);
+        /// <summary>
+        /// Registration OTP code for device {0} is {1}.
+        /// </summary>
+        public virtual string DeviceRegistrationCodeMessage(string deviceName) => string.Format(IdentityResources.Culture, IdentityResources.DeviceRegistrationOtpCode, deviceName, "{0}");
     }
 }


### PR DESCRIPTION
# What ?
I've add a new resource in `IdentityMessageDescriber` for the device registration otp code.

# Why ?
Clients needs custom text for this message. Something like `Κωδικός Otp {otp} για την εγγραφή της συσκευής σας {{device name}} μέσω mobile banking. Ο κωδικός ισχύει 2 λεπτά.`

# Tests ?
No testing

# Anything Else ?
Nope.