### PR TITLE
Add InteractionMode parameter to DeviceRegistrationCodeMessage

### DIFF
--- a/src/Indice.AspNetCore.Identity/Features/TrustedDeviceAuthorization/Endpoints/InitRegistrationEndpoint.cs
+++ b/src/Indice.AspNetCore.Identity/Features/TrustedDeviceAuthorization/Endpoints/InitRegistrationEndpoint.cs
@@ -101,7 +101,7 @@ namespace Indice.AspNetCore.Identity.TrustedDeviceAuthorization.Endpoints
             if (!otpAuthenticated) {
                 // Send OTP code.
                 void messageBuilder(TotpMessageBuilder message) {
-                    var builder = message.UsePrincipal(requestValidationResult.Principal).WithMessage(IdentityMessageDescriber.DeviceRegistrationCodeMessage(existingDevice?.DeviceName));
+                    var builder = message.UsePrincipal(requestValidationResult.Principal).WithMessage(IdentityMessageDescriber.DeviceRegistrationCodeMessage(existingDevice?.DeviceName, requestValidationResult.InteractionMode));
                     if (requestValidationResult.DeliveryChannel == TotpDeliveryChannel.Sms) {
                         builder.UsingSms();
                     } else {

--- a/src/Indice.AspNetCore.Identity/Services/IdentityMessageDescriber.cs
+++ b/src/Indice.AspNetCore.Identity/Services/IdentityMessageDescriber.cs
@@ -1,4 +1,6 @@
-﻿namespace Indice.AspNetCore.Identity
+﻿using Indice.AspNetCore.Identity.Data.Models;
+
+namespace Indice.AspNetCore.Identity
 {
     /// <summary>
     /// Provides an extensibility point for altering localizing used inside the package.
@@ -69,7 +71,7 @@
         /// </summary>
         public virtual string PasswordIdenticalToUserNameRequirement => string.Format(IdentityResources.Culture, IdentityResources.PasswordIdenticalToUserNameRequirement);
         /// <summary>
-        /// It is a good practise not to re-use your past password.
+        /// It is a good practice not to re-use your past password.
         /// </summary>
         public virtual string PasswordRecentlyUsedRequirement => string.Format(IdentityResources.Culture, IdentityResources.PasswordRecentlyUsedRequirement);
         /// <summary>
@@ -95,6 +97,7 @@
         /// <summary>
         /// Registration OTP code for device {0} is {1}.
         /// </summary>
-        public virtual string DeviceRegistrationCodeMessage(string deviceName) => string.Format(IdentityResources.Culture, IdentityResources.DeviceRegistrationOtpCode, deviceName, "{0}");
+        public virtual string DeviceRegistrationCodeMessage(string deviceName, InteractionMode interactionMode) 
+            => string.Format(IdentityResources.Culture, IdentityResources.DeviceRegistrationOtpCode, deviceName, "{0}");
     }
 }


### PR DESCRIPTION
# What ?
I've added a new parameter to Resource `DeviceRegistrationCodeMessage`

# Why ?
Clients needs to distinguish between interaction mode in messages. 
 - Current Message `OTP CODE: {0} FOR YOUR DEVICE REGISTRATION {1} VIA MOBILE BANKING. IT WILL BE VALID FOR 2 MINUTES.`
 - Requested Message `OTP CODE: {0} FOR YOUR DEVICE {1} USING {2} VIA MOBILE BANKING. IT WILL BE VALID FOR 2 MINUTES.` where `{2}` is `Fingerprint` or `Pin`
