### PR TITLE
Cases UI - Hide Pdf button from case type config property

### DIFF
--- a/src/Indice.Features.Cases.App/src/app/features/cases/case-detail-page/case-detail-page.component.html
+++ b/src/Indice.Features.Cases.App/src/app/features/cases/case-detail-page/case-detail-page.component.html
@@ -68,7 +68,7 @@
                                            (formIsValid)="isValid($event)"
                                            (unSavedChanges)="formDataHasChanged($event)"></app-case-form>
                             <app-case-print-pdf [caseId]="model.id"
-                                                [enabled]="!model.draft"
+                                                [enabled]="!(model.draft || caseTypeConfig?.boOptions?.hidePdf)"
                                                 [buttonDisabled]="!formValid || formUnSavedChanges"
                                                 (pdfButtonClicked)="onPdfButtonClicked($event)">
                             </app-case-print-pdf>

--- a/src/Indice.Features.Cases.App/src/app/features/cases/case-detail-page/case-detail-page.component.ts
+++ b/src/Indice.Features.Cases.App/src/app/features/cases/case-detail-page/case-detail-page.component.ts
@@ -29,9 +29,12 @@ export class CaseDetailPageComponent implements OnInit, OnDestroy {
   public showCustomDataValidation = false;
   public now: Date = new Date();
   public typeId?: string;
+  public caseTypeConfig: any;
+
   /** shows the warning modal conditionally */
   public showWarningModal: boolean = false;
   public warningModalState = { title: 'Έγκριση αίτησης', description: 'Δεν έχετε τυπώσει το PDF της αίτησης, θέλετε να προχωρήσετε στην έγκρισή της;' };
+
   constructor(
     private api: CasesApiService,
     private route: ActivatedRoute,
@@ -77,7 +80,10 @@ export class CaseDetailPageComponent implements OnInit, OnDestroy {
             this.getCustomerData$(caseDetails), // draft mode, we need to prefill the form with customer data (if any)
             of(caseDetails))
         }),
-        tap((response: CaseDetails) => this._model.next(response)),
+        tap((response: CaseDetails) => {
+          this.caseTypeConfig = response.caseType?.config ? JSON.parse(response.caseType?.config) : {};
+          this._model.next(response);
+        }),
         takeUntil(this.componentDestroy$)
       ).subscribe();
 


### PR DESCRIPTION
When a case type is configured with the following property  

`{ "boOptions": { "hidePdf": true } }`

the pdf button will be hidden in all checkpoints and modes (draft or published)