### PR TITLE
Add CaseMessageCreatedEvent

### DIFF
--- a/src/Indice.Features.Cases.AspNetCore/Events/CaseMessageCreatedEvent.cs
+++ b/src/Indice.Features.Cases.AspNetCore/Events/CaseMessageCreatedEvent.cs
@@ -15,15 +15,15 @@ namespace Indice.Features.Cases.Events
         public Guid CaseId { get; set; }
         
         /// <summary>
-        /// The <see cref="Message"/> that has been sent to the case service.
+        /// The <see cref="Message"/> that will be sent to the case service.
         /// </summary>
         public Message Message { get; set; }
 
         /// <summary>
-        /// Construct a new <see cref="CaseMessageSentEvent"/>.
+        /// Construct a new <see cref="CaseMessageCreatedEvent"/>.
         /// </summary>
         /// <param name="caseId">The Id of the case.</param>
-        /// <param name="message">The <see cref="Message"/> that has been sent to the case service.</param>
+        /// <param name="message">The <see cref="Message"/> that will be sent to the case service.</param>
         public CaseMessageCreatedEvent(Guid caseId, Message message) {
             CaseId = caseId;
             Message = message;

--- a/src/Indice.Features.Cases.AspNetCore/Events/CaseMessageCreatedEvent.cs
+++ b/src/Indice.Features.Cases.AspNetCore/Events/CaseMessageCreatedEvent.cs
@@ -5,9 +5,9 @@ using Indice.Features.Cases.Models;
 namespace Indice.Features.Cases.Events
 {
     /// <summary>
-    /// The event that will be raised <b>after</b> the case service handles a <see cref="Message"/>.
+    /// The event that will be raised <b>before</b> the case service handles a <see cref="Message"/>.
     /// </summary>
-    public class CaseMessageSentEvent : ICaseEvent
+    public class CaseMessageCreatedEvent : ICaseEvent
     {
         /// <summary>
         /// The Id of the case.
@@ -24,7 +24,7 @@ namespace Indice.Features.Cases.Events
         /// </summary>
         /// <param name="caseId">The Id of the case.</param>
         /// <param name="message">The <see cref="Message"/> that has been sent to the case service.</param>
-        public CaseMessageSentEvent(Guid caseId, Message message) {
+        public CaseMessageCreatedEvent(Guid caseId, Message message) {
             CaseId = caseId;
             Message = message;
         }

--- a/src/Indice.Features.Cases.AspNetCore/Models/Message.cs
+++ b/src/Indice.Features.Cases.AspNetCore/Models/Message.cs
@@ -27,12 +27,12 @@ namespace Indice.Features.Cases.Models
         /// <summary>
         /// The comment to add to the checkpoint.
         /// </summary>
-        public string Comment { get; set; }
+        public string? Comment { get; set; }
         
         /// <summary>
         /// The file that is attached with the checkpoint.
         /// </summary>
-        public IFormFile File { get; set; }
+        public IFormFile? File { get; set; }
 
         /// <summary>
         /// The data related with the message.

--- a/src/Indice.Features.Cases.AspNetCore/Services/CaseMessageService/BaseCaseMessageService.cs
+++ b/src/Indice.Features.Cases.AspNetCore/Services/CaseMessageService/BaseCaseMessageService.cs
@@ -30,6 +30,7 @@ namespace Indice.Features.Cases.Services.CaseMessageService
         protected async Task<Guid?> SendInternal(DbCase @case, Message message, ClaimsPrincipal user) {
             Guid? attachmentId = null;
             var caseId = @case.Id;
+            if (message == null) throw new ArgumentNullException(nameof(message));
             if (message.File == null && message.CheckpointTypeName == null && message.Comment == null && message.Data == null) {
                 return attachmentId;
             }


### PR DESCRIPTION
Add a new `CaseMessageCreatedEvent` for handling events before saving the message to the database.

example scenario:
When a user uploads an attachment, do someting before saving the file to the storage.