### PR TITLE
PushNotification Azure - Topt controller fixes/additions

### DIFF
--- a/src/Indice.AspNetCore.Identity/Features/Totp/Models/TotpRequest.cs
+++ b/src/Indice.AspNetCore.Identity/Features/Totp/Models/TotpRequest.cs
@@ -18,5 +18,7 @@ namespace Indice.AspNetCore.Identity.Features.Totp.Models
         /// <summary>The type of the Push Notification.</summary>
         /// <remarks>This applies only for <see cref="TotpDeliveryChannel.PushNotification"/> channel.</remarks>
         public string Classification { get; set; }
+        /// <summary>The subject of the message for the <see cref="TotpDeliveryChannel.PushNotification"/> <see cref="Channel"/>.</summary>
+        public string Subject { get; set; }
     }
 }

--- a/src/Indice.AspNetCore.Identity/Features/Totp/TotpController.cs
+++ b/src/Indice.AspNetCore.Identity/Features/Totp/TotpController.cs
@@ -64,6 +64,7 @@ namespace Indice.AspNetCore.Identity.Features
                         .ToPrincipal(User)
                         .WithMessage(request.Message)
                         .UsingPushNotification()
+                        .WithSubject(request.Subject)
                         .WithPurpose(request.Purpose)
                         .WithData(request.Data)
                         .WithClassification(request.Classification)

--- a/src/Indice.Services/PushNotificationServiceAzure.cs
+++ b/src/Indice.Services/PushNotificationServiceAzure.cs
@@ -99,7 +99,7 @@ namespace Indice.Services
                     properties,
                     tags.Select(
                         tag => tag.Kind == PushNotificationTagKind.User || tag.Kind == PushNotificationTagKind.Unspecified
-                            ? tag.Value
+                            ? tag.ToString()
                             : "$InstallationId:{" + tag.Value + "}" // https://learn.microsoft.com/en-us/azure/notification-hubs/notification-hubs-push-notification-registration-management#installations
                     )
                 );


### PR DESCRIPTION
- we need title property at TotpRequest for the PushNotification title
- we need to send the correct tag to the registered device to push notification 
   

for backwards compatibility, consumers using `IPushNotificationService` need to implement something like this
 ```cs
  await _pushNotificationService.SendAsync(
                                title: "Push title",
                                body: "Push body",
                                data: null,
                                tags: new List<PushNotificationTag> {
                                    new ("userId-here", PushNotificationTagKind.Unspecified), // backwards compatibility
                                    new ("userId-here", PushNotificationTagKind.User)
                                }, 
                                classification: "SomeAlert";
```