### PR TITLE
Configurable min and max dates through the layout

### DIFF
--- a/src/Indice.Features.Cases.App/package.json
+++ b/src/Indice.Features.Cases.App/package.json
@@ -29,6 +29,7 @@
     "@tailwindcss/line-clamp": "^0.2.0",
     "@tailwindcss/typography": "^0.4.0",
     "@types/lodash": "^4.14.180",
+    "moment": "~2.29.1",
     "f": "^1.4.0",
     "file-saver": "^2.0.5",
     "lodash": "^4.17.21",

--- a/src/Indice.Features.Cases.App/src/app/shared/ajsf/json-schema-frameworks/tailwind-framework/date-widget/date-widget.component.ts
+++ b/src/Indice.Features.Cases.App/src/app/shared/ajsf/json-schema-frameworks/tailwind-framework/date-widget/date-widget.component.ts
@@ -1,5 +1,7 @@
+import { MenuOption } from '@indice/ng-components';
 import { JsonSchemaFormService } from '@ajsf-extended/core';
 import { Component, Input, OnInit } from '@angular/core';
+import * as  moment from 'moment';
 
 @Component({
   selector: 'app-date-widget',
@@ -17,8 +19,15 @@ export class DateWidgetComponent implements OnInit {
   @Input() layoutNode: any;
   @Input() layoutIndex: any[] = [];
   @Input() dataIndex: any[] = [];
-  min: string = ''
-  max: string = ''
+  min: string = '';
+  max: string = '';
+
+  readonly minDateDays = 0;
+  readonly minDateMonths = 0;
+  readonly minDateYears = -3;
+  readonly maxDateDays = 0;
+  readonly maxDateMonths = 0;
+  readonly maxDateYears = 1;
 
   constructor(
     private jsf: JsonSchemaFormService
@@ -26,11 +35,15 @@ export class DateWidgetComponent implements OnInit {
 
   ngOnInit() {
     this.options = this.layoutNode.options || {};
-    if (this.options.min !== undefined) {
+    if (this.options.min) {
       this.min = this.options.min;
+    } else {
+      this.min = this.setMinDate(this.options);
     }
-    if (this.options.max !== undefined) {
-      this.max = this.options.max;
+    if (this.options.max) {
+      this.max = this.options.max
+    } else {
+      this.max = this.setMaxDate(this.options)
     }
     this.jsf.initializeControl(this);
   }
@@ -39,4 +52,27 @@ export class DateWidgetComponent implements OnInit {
     this.jsf.updateValue(this, event.target.value);
   }
 
+  private setMinDate(options: any): string {
+    var currentDate = moment(new Date());
+    currentDate.add(options.minDateYears ?? this.minDateYears, 'years').year();
+    currentDate.add(options.minDateMonths ?? this.minDateMonths, 'months').month();
+    currentDate.add(options.minDateDays ?? this.minDateDays, 'days').date();
+
+    var year = currentDate.year();
+    var month = (currentDate.month() + 1).toLocaleString('en-GR', { minimumIntegerDigits: 2, useGrouping: false });
+    var day = currentDate.date().toLocaleString('en-GR', { minimumIntegerDigits: 2, useGrouping: false });
+    return `${year}-${month}-${day}`;
+  }
+
+  private setMaxDate(options: any): string {
+    var currentDate = moment(new Date());
+    currentDate.add(options.maxDateYears ?? this.maxDateYears, 'years').year();
+    currentDate.add(options.maxDateMonths ?? this.maxDateMonths, 'months').month();
+    currentDate.add(options.maxDateDays ?? this.maxDateDays, 'days').date();
+
+    var year = currentDate.year();
+    var month = (currentDate.month() + 1).toLocaleString('en-GR', { minimumIntegerDigits: 2, useGrouping: false });
+    var day = currentDate.date().toLocaleString('en-GR', { minimumIntegerDigits: 2, useGrouping: false });
+    return `${year}-${month}-${day}`;
+  }
 }


### PR DESCRIPTION
New layout options to determine the minimum and maximum date for a date widget:
minDateDays
minDateMonths
minDateYears
maxDateDays
maxDateMonths
maxDateYears

A specific date can also be set through the min or max configuration (template: "year-month-day")
Some default values have been given in case there is no specific or configurable date so that a date from 1821 can not be picked for example. Default maximum of 1 year in the future and 3 years in the past.