### PR TITLE
add GetApplicationInsightsConnectionString extension method

### DIFF
--- a/src/Indice.Services/Extensions/IConfigurationExtensions.cs
+++ b/src/Indice.Services/Extensions/IConfigurationExtensions.cs
@@ -84,6 +84,11 @@ namespace Microsoft.Extensions.Configuration
         /// <returns>Checks for the <strong>ApplicationInsights:InstrumentationKey</strong> option in appsettings.json file.</returns>
         public static string GetInstrumentationKey(this IConfiguration configuration) => configuration.GetSection("ApplicationInsights").GetValue<string>("InstrumentationKey");
 
+        /// <summary>Gets the Application Insights Connection String.</summary>
+        /// <param name="configuration">Represents a set of key/value application configuration properties.</param>
+        /// <returns>Checks for the <strong>ApplicationInsights:ConnectionString</strong> option in appsettings.json file.</returns>
+        public static string GetApplicationInsightsConnectionString(this IConfiguration configuration) => configuration.GetSection("ApplicationInsights").GetValue<string>("ConnectionString");
+
         /// <summary>A string that represents the default host name binding for this web application <see cref="GeneralSettings.Host"/>.</summary>
         /// <param name="configuration">Represents a set of key/value application configuration properties.</param>
         /// <returns>Example can be https://www.example.com</returns>

--- a/src/Indice.Services/Extensions/IConfigurationExtensions.cs
+++ b/src/Indice.Services/Extensions/IConfigurationExtensions.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Extensions.Configuration
         /// <summary>Gets the Application Insights Connection String.</summary>
         /// <param name="configuration">Represents a set of key/value application configuration properties.</param>
         /// <returns>Checks for the <strong>ApplicationInsights:ConnectionString</strong> option in appsettings.json file.</returns>
-        public static string GetApplicationInsightsConnectionString(this IConfiguration configuration) => configuration.GetSection("ApplicationInsights").GetValue<string>("ConnectionString");
+        public static string GetApplicationInsightsConnectionString(this IConfiguration configuration) => configuration.GetSection("ApplicationInsights").GetValue<string>("ConnectionString") ?? configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"];
 
         /// <summary>A string that represents the default host name binding for this web application <see cref="GeneralSettings.Host"/>.</summary>
         /// <param name="configuration">Represents a set of key/value application configuration properties.</param>


### PR DESCRIPTION
According to [this](https://learn.microsoft.com/en-us/azure/azure-monitor/app/asp-net-core?tabs=netcoreold%2Cnetcore6):

_On March 31, 2025, support for instrumentation key ingestion will end. Instrumentation key ingestion will continue to work, but we'll no longer provide updates or support for the feature. Transition to connection strings to take advantage of new capabilities._

So, I just added a new GetApplicationInsightsConnectionString extension method.