### PR TITLE
Minor change to the CaseType Description length.

### DIFF
--- a/src/Indice.Features.Cases.AspNetCore/Data/Config/DbCaseTypeConfiguration.cs
+++ b/src/Indice.Features.Cases.AspNetCore/Data/Config/DbCaseTypeConfiguration.cs
@@ -27,7 +27,7 @@ namespace Indice.Features.Cases.Data.Config
                 .IsRequired();
             builder
                 .Property(p => p.Description)
-                .HasMaxLength(TextSizePresets.M128)
+                .HasMaxLength(TextSizePresets.M256)
                 .IsRequired(false);
             builder
                 .Property(p => p.Translations);


### PR DESCRIPTION
New maximum needed to cater to the new descriptions at Chania Bank.