### PR TITLE
Response with 200 OK instead of 302 Found in UsernameExists

### DIFF
--- a/samples/Indice.WorkerHost/appsettings.json
+++ b/samples/Indice.WorkerHost/appsettings.json
@@ -8,20 +8,20 @@
   "IdentityServer": {
     "BaseAddress": "https://indice-identity.azurewebsites.net",
     "ClientId": "indice-notifications-functions-worker",
-    "ClientSecret": "3a70ae5b-cdc2-4775-be7b-a9ceecdfe67b"
+    "ClientSecret": "XXXXX"
   },
   "PushNotifications": {
     "NotificationHubPath": "indice-notifications"
   },
   "Sms": {
-    "ApiKey": "9370FEBC-ED48-4F04-AED6-B6F4883E5640",
+    "ApiKey": "XXXXX",
     "Sender": "INDICE",
     "SenderName": "Indice",
     "TestMode": true
   },
   "SparkPost": {
     "Api": "https://api.eu.sparkpost.com/api/v1/",
-    "ApiKey": "df8dfecb1bab37a1c0a25b805f1a5f84d102ae3a",
+    "ApiKey": "XXXXX",
     "Sender": "no-reply@indice.gr",
     "SenderName": "Indice"
   }

--- a/src/Indice.AspNetCore.Identity/Features/IdentityServerApi/Controllers/MyAccountController.cs
+++ b/src/Indice.AspNetCore.Identity/Features/IdentityServerApi/Controllers/MyAccountController.cs
@@ -548,13 +548,13 @@ namespace Indice.AspNetCore.Identity.Api.Controllers
         public IActionResult GetPasswordOptions() => Ok(_identityOptions.Password);
 
         /// <summary>Checks if a username already exists in the database.</summary>
-        /// <response code="302">Found</response>
+        /// <response code="200">OK</response>
         /// <response code="400">Bad Request</response>
         /// <response code="404">Not Found</response>
         /// <response code="410">Gone</response>
         [AllowAnonymous]
         [HttpPost("account/username-exists")]
-        [ProducesResponseType(statusCode: StatusCodes.Status302Found, type: typeof(void))]
+        [ProducesResponseType(statusCode: StatusCodes.Status200OK, type: typeof(void))]
         [ProducesResponseType(statusCode: StatusCodes.Status400BadRequest, type: typeof(ValidationProblemDetails))]
         [ProducesResponseType(statusCode: StatusCodes.Status404NotFound, type: typeof(void))]
         [ProducesResponseType(statusCode: StatusCodes.Status410Gone, type: typeof(void))]
@@ -567,7 +567,7 @@ namespace Indice.AspNetCore.Identity.Api.Controllers
                 return BadRequest(new ValidationProblemDetails(ModelState));
             }
             var user = await _userManager.FindByNameAsync(request.UserName);
-            return user == null ? NotFound() : StatusCode(StatusCodes.Status302Found);
+            return user == null ? NotFound() : StatusCode(StatusCodes.Status200OK);
         }
 
         /// <summary>Validates a user's password against one or more configured <see cref="IPasswordValidator{TUser}"/>.</summary>


### PR DESCRIPTION
f5 WAF is expecting a redirect header in a 302 response, which in this case is missing.
Thus, firewall treats the specific response as bad and blocks it. In return, the client receives code 500.