### PR TITLE
Add case metadata to my-case list

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,7 +6,7 @@
       <VersionPrefixCore>$(VersionPrefixBase).7</VersionPrefixCore>
       <VersionPrefixIdentity>$(VersionPrefixBase).8</VersionPrefixIdentity>
       <VersionPrefixIdentityUI>$(VersionPrefixBase).14</VersionPrefixIdentityUI>
-      <VersionPrefixCases>$(VersionPrefixBase).6</VersionPrefixCases>
+      <VersionPrefixCases>$(VersionPrefixBase).7</VersionPrefixCases>
       <VersionPrefixMessages>$(VersionPrefixBase).6</VersionPrefixMessages>
       <VersionPrefixMultitenancy>$(VersionPrefixBase).6</VersionPrefixMultitenancy>
       <VersionPrefix>$(VersionPrefixBase).6</VersionPrefix>

--- a/src/Indice.Features.Cases.AspNetCore/CHANGELOG.md
+++ b/src/Indice.Features.Cases.AspNetCore/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased] - 2023-05-09
+### Added
+- `GetMyCases` now returns case metadata.
+
+## [7.1.6] - 2023-05-09
 ### Changed
 - `IncludeDrafts` option to return draft cases.
 

--- a/src/Indice.Features.Cases.AspNetCore/Models/Responses/MyCasePartial.cs
+++ b/src/Indice.Features.Cases.AspNetCore/Models/Responses/MyCasePartial.cs
@@ -24,6 +24,9 @@ public class MyCasePartial
     /// <summary>The checkpoint name of the case.</summary>
     public string Checkpoint { get; set; }
 
+    /// <summary>The case metadata.</summary>
+    public Dictionary<string, string> Metadata { get; set; }   
+
     /// <summary>The message that has been submitted from the backoffice.</summary>
     public string Message { get; set; }
     /// <summary>Translations.</summary>

--- a/src/Indice.Features.Cases.AspNetCore/Services/MyCaseService.cs
+++ b/src/Indice.Features.Cases.AspNetCore/Services/MyCaseService.cs
@@ -177,18 +177,18 @@ internal class MyCaseService : BaseCaseService, IMyCaseService
             dbCaseQueryable = dbCaseQueryable.Where(c => options.Filter.CaseTypeCodes.Contains(c.CaseType.Code));
         }
 
-
         var myCasePartialQueryable = from c in dbCaseQueryable
                                      let reason = c.Approvals.OrderByDescending(a => a.CreatedBy.When).FirstOrDefault()
                                      let reasonMessage = reason != null && reason.Committed && reason.Action == Approval.Reject
-                                     ? _caseSharedResourceService.GetLocalizedHtmlString(reason.Reason)
-                                     : string.Empty
+                                         ? _caseSharedResourceService.GetLocalizedHtmlString(reason.Reason)
+                                         : string.Empty
                                      select new MyCasePartial {
                                          Id = c.Id,
                                          Created = c.CreatedBy.When,
                                          CaseTypeCode = c.CaseType.Code,
                                          Status = c.PublicCheckpoint.CheckpointType.Status,
                                          Checkpoint = c.PublicCheckpoint.CheckpointType.Code,
+                                         Metadata = c.Metadata,
                                          Message = reasonMessage,
                                          Translations = TranslationDictionary<MyCasePartialTranslation>.FromJson(c.CaseType.Translations)
                                      };


### PR DESCRIPTION
# Description 
A my-cases consumer SPA (with access only to `MyCases` endpoints), requires the metadata property to be included in my-cases list response.

# Concerns
If we are behind a case proxy, it's fine, we can hide the metadata from the SPA. However, in this case, are there any concerns related to security or sensitive data that should not be shown in the `case.metadata` property? We are allowing the developer to create a case with any metadata they choose. 