### PR TITLE
GroupName & ApiName bugfixes

### DIFF
--- a/src/Indice.Features.Cases.AspNetCore/CHANGELOG.md
+++ b/src/Indice.Features.Cases.AspNetCore/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Changed
+- The `CaseApiOptions` are now separated for each endpoint group. Use `MyCasesApiOptions` or `AdminCasesApiOptions` accordingly.
+### Bugfix
+- `GroupName` and `ApiPrefix` can be configured properly for each endpoint group (admin or my-cases). Resolves #225.
+### Migrations
+- at `AddCasesApiEndpoints` Replace `CasesApiOptions` with `MyCasesApiOptions`.
+- at `AddAdminCasesApiEndpoints` Replace `CasesApiOptions` with `AdminCasesApiOptions`.
+
+## [7.1.6] - 2023-05-09
+### Changed
 - `IncludeDrafts` option to return draft cases.
 
 ## [7.1.1] - 2023-04-19

--- a/src/Indice.Features.Cases.AspNetCore/CasesApiConstants.cs
+++ b/src/Indice.Features.Cases.AspNetCore/CasesApiConstants.cs
@@ -74,13 +74,19 @@ public static class CasesApiConstants
 /// <summary>Constant values for Cases Api Groups.</summary>
 internal static class ApiGroups
 {
-    /// <summary>The group name placeholder that will be replaced.</summary>
+    /// <summary>The group name placeholder that will be replaced for admin endpoints.</summary>
     internal const string CasesApiGroupNamePlaceholder = "[casesApiGroupName]";
+
+    /// <summary>The group name placeholder that will be replaced for my-cases endpoints.</summary>
+    internal const string MyCasesApiGroupNamePlaceholder = "[myCasesApiGroupName]";
 }
 
 /// <summary>Constant values for Cases Api Prefixes.</summary>
 internal class ApiPrefixes
 {
-    /// <summary>The api prefix placeholder that will be replaced.</summary>
+    /// <summary>The admin api prefix placeholder that will be replaced.</summary>
     internal const string CasesApiTemplatePrefixPlaceholder = "[casesApiPrefix]";
+
+    /// <summary>The my-cases api prefix placeholder that will be replaced.</summary>
+    internal const string MyCasesApiTemplatePrefixPlaceholder = "[myCasesApiPrefix]";
 }

--- a/src/Indice.Features.Cases.AspNetCore/CasesApiFeatureExtensions.cs
+++ b/src/Indice.Features.Cases.AspNetCore/CasesApiFeatureExtensions.cs
@@ -32,7 +32,7 @@ public static class CasesApiFeatureExtensions
     /// <summary>Add case management Api endpoints for Customer (api/my prefix).</summary>
     /// <param name="mvcBuilder">The <see cref="IMvcBuilder"/>.</param>
     /// <param name="configureAction">The <see cref="IConfiguration"/>.</param>
-    public static IMvcBuilder AddCasesApiEndpoints(this IMvcBuilder mvcBuilder, Action<CasesApiOptions> configureAction = null) {
+    public static IMvcBuilder AddCasesApiEndpoints(this IMvcBuilder mvcBuilder, Action<MyCasesApiOptions> configureAction = null) {
         // Add
         mvcBuilder.ConfigureApplicationPartManager(x => x.FeatureProviders.Add(new CasesApiFeatureProviderMyCases()));
         var services = mvcBuilder.Services;
@@ -49,21 +49,22 @@ public static class CasesApiFeatureExtensions
             .AddNewtonsoftJson(x => x.SerializerSettings.Converters.Add(new SystemTextConverter()));
 
         // Configure options given by the consumer.
-        var casesApiOptions = new CasesApiOptions();
+        var casesApiOptions = new MyCasesApiOptions();
         configureAction?.Invoke(casesApiOptions);
-        services.Configure<CasesApiOptions>(options => {
+        services.Configure<MyCasesApiOptions>(options => {
             options.ApiPrefix = casesApiOptions.ApiPrefix;
             options.ConfigureDbContext = casesApiOptions.ConfigureDbContext;
             options.DatabaseSchema = casesApiOptions.DatabaseSchema;
             options.ExpectedScope = casesApiOptions.ExpectedScope;
             options.UserClaimType = casesApiOptions.UserClaimType;
             options.GroupIdClaimType = casesApiOptions.GroupIdClaimType;
+            options.GroupName = casesApiOptions.GroupName;
         }).AddSingleton(casesApiOptions);
 
         // Post configure MVC options.
         services.PostConfigure<MvcOptions>(options => {
-            options.Conventions.Add(new ApiPrefixControllerModelConvention(ApiPrefixes.CasesApiTemplatePrefixPlaceholder, casesApiOptions.ApiPrefix ?? "api"));
-            options.Conventions.Add(new ApiGroupNameControllerModelConvention(ApiGroups.CasesApiGroupNamePlaceholder, casesApiOptions.GroupName));
+            options.Conventions.Add(new ApiPrefixControllerModelConvention(ApiPrefixes.MyCasesApiTemplatePrefixPlaceholder, casesApiOptions.ApiPrefix ?? "api"));
+            options.Conventions.Add(new ApiGroupNameControllerModelConvention(ApiGroups.MyCasesApiGroupNamePlaceholder, casesApiOptions.GroupName));
         });
 
         // Register framework services.
@@ -102,7 +103,7 @@ public static class CasesApiFeatureExtensions
     /// <summary>Add case management Api endpoints for manage cases from back-office (api/manage prefix).</summary>
     /// <param name="mvcBuilder">The <see cref="IMvcBuilder"/>.</param>
     /// <param name="configureAction">The <see cref="IConfiguration"/>.</param>
-    public static IMvcBuilder AddAdminCasesApiEndpoints(this IMvcBuilder mvcBuilder, Action<CasesApiOptions> configureAction = null) {
+    public static IMvcBuilder AddAdminCasesApiEndpoints(this IMvcBuilder mvcBuilder, Action<AdminCasesApiOptions> configureAction = null) {
         // Add
         mvcBuilder.ConfigureApplicationPartManager(x => x.FeatureProviders.Add(new CasesApiFeatureProviderAdminCases()));
         var services = mvcBuilder.Services;
@@ -115,15 +116,16 @@ public static class CasesApiFeatureExtensions
         services.AddGeneralSettings(configuration);
 
         // Configure options given by the consumer.
-        var casesApiOptions = new CasesApiOptions();
+        var casesApiOptions = new AdminCasesApiOptions();
         configureAction?.Invoke(casesApiOptions);
-        services.Configure<CasesApiOptions>(options => {
+        services.Configure<AdminCasesApiOptions>(options => {
             options.ApiPrefix = casesApiOptions.ApiPrefix;
             options.ConfigureDbContext = casesApiOptions.ConfigureDbContext;
             options.DatabaseSchema = casesApiOptions.DatabaseSchema;
             options.ExpectedScope = casesApiOptions.ExpectedScope;
             options.UserClaimType = casesApiOptions.UserClaimType;
             options.GroupIdClaimType = casesApiOptions.GroupIdClaimType;
+            options.GroupName = casesApiOptions.GroupName;
         }).AddSingleton(casesApiOptions);
 
         // Post configure MVC options.

--- a/src/Indice.Features.Cases.AspNetCore/CasesApiOptions.cs
+++ b/src/Indice.Features.Cases.AspNetCore/CasesApiOptions.cs
@@ -4,7 +4,7 @@ using Microsoft.EntityFrameworkCore;
 namespace Indice.Features.Cases;
 
 /// <summary>The options for the initialization of the Case Api.</summary>
-public class CasesApiOptions
+public abstract class CasesApiOptions
 {
     /// <summary>
     /// Configuration <see cref="Action"/> for internal <see cref="DbContext"/>. 
@@ -29,4 +29,20 @@ public class CasesApiOptions
 
     /// <summary>The claim type groupid name</summary>
     public string GroupIdClaimType { get; set; } = CasesApiConstants.DefaultGroupIdClaimType;
+}
+
+/// <summary>
+/// The Admin case options, specific for the admin Api.
+/// </summary>
+public class AdminCasesApiOptions: CasesApiOptions
+{
+
+}
+
+/// <summary>
+/// The My-Cases options, specific for the my-cases Api.
+/// </summary>
+public class MyCasesApiOptions: CasesApiOptions
+{
+
 }

--- a/src/Indice.Features.Cases.AspNetCore/Controllers/AdminNotificationsController.cs
+++ b/src/Indice.Features.Cases.AspNetCore/Controllers/AdminNotificationsController.cs
@@ -20,11 +20,11 @@ namespace Indice.Features.Cases.Controllers;
 internal class AdminNotificationsController : ControllerBase
 {
     private readonly INotificationSubscriptionService _service;
-    private readonly CasesApiOptions _casesApiOptions;
+    private readonly AdminCasesApiOptions _casesApiOptions;
 
     public AdminNotificationsController(
         INotificationSubscriptionService service,
-        CasesApiOptions casesApiOptions) {
+        AdminCasesApiOptions casesApiOptions) {
         _service = service ?? throw new ArgumentNullException(nameof(service));
         _casesApiOptions = casesApiOptions ?? throw new ArgumentNullException(nameof(casesApiOptions));
     }

--- a/src/Indice.Features.Cases.AspNetCore/Controllers/MyCaseTypesController.cs
+++ b/src/Indice.Features.Cases.AspNetCore/Controllers/MyCaseTypesController.cs
@@ -11,13 +11,13 @@ namespace Indice.Features.Cases.Controllers;
 
 /// <summary>Case types from the customer's perspective.</summary>
 [ApiController]
-[ApiExplorerSettings(GroupName = ApiGroups.CasesApiGroupNamePlaceholder)]
+[ApiExplorerSettings(GroupName = ApiGroups.MyCasesApiGroupNamePlaceholder)]
 [Authorize(AuthenticationSchemes = CasesApiConstants.AuthenticationScheme, Policy = CasesApiConstants.Policies.BeCasesUser)]
 [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ValidationProblemDetails))]
 [ProducesResponseType(StatusCodes.Status401Unauthorized, Type = typeof(ProblemDetails))]
 [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ProblemDetails))]
 [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(ProblemDetails))]
-[Route($"{ApiPrefixes.CasesApiTemplatePrefixPlaceholder}/my/case-types")]
+[Route($"{ApiPrefixes.MyCasesApiTemplatePrefixPlaceholder}/my/case-types")]
 internal class MyCaseTypesController : ControllerBase
 {
     private readonly IMyCaseService _myCaseService;

--- a/src/Indice.Features.Cases.AspNetCore/Controllers/MyCasesController.cs
+++ b/src/Indice.Features.Cases.AspNetCore/Controllers/MyCasesController.cs
@@ -13,13 +13,13 @@ namespace Indice.Features.Cases.Controllers;
 
 /// <summary>Manage customer cases.</summary>
 [ApiController]
-[ApiExplorerSettings(GroupName = ApiGroups.CasesApiGroupNamePlaceholder)]
+[ApiExplorerSettings(GroupName = ApiGroups.MyCasesApiGroupNamePlaceholder)]
 [Authorize(AuthenticationSchemes = CasesApiConstants.AuthenticationScheme, Policy = CasesApiConstants.Policies.BeCasesUser)]
 [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ValidationProblemDetails))]
 [ProducesResponseType(StatusCodes.Status401Unauthorized, Type = typeof(ProblemDetails))]
 [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ProblemDetails))]
 [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(ProblemDetails))]
-[Route($"{ApiPrefixes.CasesApiTemplatePrefixPlaceholder}/my/cases")]
+[Route($"{ApiPrefixes.MyCasesApiTemplatePrefixPlaceholder}/my/cases")]
 internal class MyCasesController : ControllerBase
 {
     public const string Name = "Cases";


### PR DESCRIPTION
With this bugfix you can now configure 2 separate endpoints groups and api explorer groups correctly.

Read `CHANGELOG` for code migrations.

closes #225.

