### PR TITLE
Case api bugfix on members authorization

### DIFF
--- a/src/Indice.Features.Cases.AspNetCore/CHANGELOG.md
+++ b/src/Indice.Features.Cases.AspNetCore/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Bugfix
+- While sending a Case Message from `SendMessageActivity` the authorization provider is being successfully called.
+- Rename `RoleCaseTypeService` to `MemberAuthorizationService`.
+
 ## [7.1.7] - 2023-05-23
 ### Added
 - `GetMyCases` now returns case metadata.

--- a/src/Indice.Features.Cases.AspNetCore/CasesApiFeatureExtensions.cs
+++ b/src/Indice.Features.Cases.AspNetCore/CasesApiFeatureExtensions.cs
@@ -141,7 +141,7 @@ public static class CasesApiFeatureExtensions
         services.AddTransient<IAdminCaseService, AdminCaseService>();
         services.AddTransient<IAdminReportService, AdminReportService>();
         services.AddTransient<IQueryService, QueryService>();
-        services.AddTransient<ICaseAuthorizationService, RoleCaseTypeService>();
+        services.AddTransient<ICaseAuthorizationService, MemberAuthorizationService>();
         services.AddTransient<ICaseActionsService, CaseActionsService>();
         services.AddTransient<IAdminCaseMessageService, AdminCaseMessageService>();
         services.AddTransient<ISchemaValidator, SchemaValidator>();

--- a/src/Indice.Features.Cases.AspNetCore/Services/AggregateCaseAuthorizationProvider.cs
+++ b/src/Indice.Features.Cases.AspNetCore/Services/AggregateCaseAuthorizationProvider.cs
@@ -7,21 +7,21 @@ namespace Indice.Features.Cases.Services;
 
 internal class AggregateCaseAuthorizationProvider : ICaseAuthorizationProvider
 {
-    private readonly IEnumerable<ICaseAuthorizationService> _listOfServices;
+    private readonly IEnumerable<ICaseAuthorizationService> _caseAuthorizationServices;
 
     public AggregateCaseAuthorizationProvider(IEnumerable<ICaseAuthorizationService> listOfServices) {
-        _listOfServices = listOfServices ?? throw new ArgumentNullException(nameof(listOfServices));
+        _caseAuthorizationServices = listOfServices ?? throw new ArgumentNullException(nameof(listOfServices));
     }
 
     public async Task<GetCasesListFilter> Filter(ClaimsPrincipal user, GetCasesListFilter filter) {
-        foreach (var authorizationService in _listOfServices) {
+        foreach (var authorizationService in _caseAuthorizationServices) {
             filter = await authorizationService.ApplyFilterFor(user, filter);
         }
         return filter;
     }
 
     public async Task<bool> IsValid(ClaimsPrincipal user, Case @case) {
-        foreach (var authorizationService in _listOfServices) {
+        foreach (var authorizationService in _caseAuthorizationServices) {
             if (!await authorizationService.IsValid(user, @case)) {
                 return false;
             }


### PR DESCRIPTION
### Bugfix
- While sending a Case Message from `SendMessageActivity` the authorization provider is being successfully called.
- Rename `RoleCaseTypeService` to `MemberAuthorizationService`.