### PR TITLE
Add dashboard canvas configuration (show/hide) for cases-ui

### DIFF
--- a/src/Indice.Features.Cases.App/src/app/core/models/settings.model.ts
+++ b/src/Indice.Features.Cases.App/src/app/core/models/settings.model.ts
@@ -5,6 +5,7 @@ export interface IAppSettings {
     isTemplate: boolean,
     production: boolean;
     version: string;
+    canvases: string;
 }
 
 export interface IAuthSettings {

--- a/src/Indice.Features.Cases.App/src/app/core/models/settings.ts
+++ b/src/Indice.Features.Cases.App/src/app/core/models/settings.ts
@@ -3,7 +3,7 @@ import { IAppSettings, IAuthSettings } from './settings.model';
 
 function createAppSettings(): IAppSettings {
     const isTemplate = environment.isTemplate;
-    let authority: string = '', clientId: string = '', host: string = '', baseHref: string = '', culture: string = '', version: string = '', scopes = '', apiUrl = '';
+    let authority: string = '', clientId: string = '', host: string = '', baseHref: string = '', culture: string = '', version: string = '', scopes = '', apiUrl = '', canvases = '';
     if (isTemplate) {
         const appRoot = document.getElementsByTagName('app-root')[0];
         authority = appRoot.getAttribute('authority') || '';
@@ -14,6 +14,7 @@ function createAppSettings(): IAppSettings {
         version = appRoot.getAttribute('version') || '';
         scopes = appRoot.getAttribute('scopes') || '';
         apiUrl = appRoot.getAttribute('apiUrl') || '';
+        canvases = appRoot.getAttribute('canvases') || '';
         if (!authority || !clientId || !host) {
             throw new Error('Please provide authority, clientId and baseAddress as properties of app-root element.');
         }
@@ -25,6 +26,7 @@ function createAppSettings(): IAppSettings {
         appRoot.attributes.removeNamedItem('version');
         appRoot.attributes.removeNamedItem('scopes');
         appRoot.attributes.removeNamedItem('apiUrl');
+        appRoot.attributes.removeNamedItem('canvases');
     }
     return {
         api_url: !isTemplate ? environment.api_url : apiUrl,
@@ -50,7 +52,8 @@ function createAppSettings(): IAppSettings {
         culture: !isTemplate ? environment.culture : culture,
         isTemplate: environment.isTemplate,
         production: environment.production,
-        version: version || '1.0.0'
+        version: version || '1.0.0',
+        canvases: !isTemplate ? environment.canvases : canvases
     };
 }
 

--- a/src/Indice.Features.Cases.App/src/app/features/dashboard/dashboard.component.html
+++ b/src/Indice.Features.Cases.App/src/app/features/dashboard/dashboard.component.html
@@ -1,25 +1,27 @@
 <lib-view-layout title="Καλώς ήλθατε, {{ user?.profile?.name }}!"
                  [meta-items]="metaItems">
     <div class="cards-deck-1 mb-4">
-        <div class="cards-deck-3">
-            <app-canvas-tile [title]="'Συνολικες Αιτησεις ανα Τυπο Αιτησης'"
+        <div class="grid grid-cols-3 gap-x-5 gap-y-0">
+            <app-canvas-tile *ngIf="showCanvas(reportTag.GroupedByCasetype)"
+                             [title]="'Συνολικες Αιτησεις ανα Τυπο Αιτησης'"
                              [canvasId]="reportTag.GroupedByCasetype"></app-canvas-tile>
-            <app-canvas-tile [title]="'Αιτησεις απο Καταστημα ανα Τυπο Αιτησης'"
+            <app-canvas-tile *ngIf="showCanvas(reportTag.AgentGroupedByCasetype)" 
+                             [title]="'Αιτησεις απο Καταστημα ανα Τυπο Αιτησης'"
                              [canvasId]="reportTag.AgentGroupedByCasetype"></app-canvas-tile>
-            <app-canvas-tile [title]="'Αιτησεις μεσω eBanking ανα Τυπο Αιτησης'"
+            <app-canvas-tile *ngIf="showCanvas(reportTag.CustomerGroupedByCasetype)" 
+                             [title]="'Αιτησεις μεσω eBanking ανα Τυπο Αιτησης'"
                              [canvasId]="reportTag.CustomerGroupedByCasetype"></app-canvas-tile>
-        </div>
-        <div class="cards-deck-3">
-            <app-canvas-tile [title]="'Συνολικες Αιτησεις ανα Status'"
+            <app-canvas-tile *ngIf="showCanvas(reportTag.GroupedByStatus)" 
+                             [title]="'Συνολικες Αιτησεις ανα Status'"
                              [canvasId]="reportTag.GroupedByStatus"></app-canvas-tile>
-            <app-canvas-tile [title]="'Αιτησεις απο Καταστημα ανα Status'"
+            <app-canvas-tile *ngIf="showCanvas(reportTag.AgentGroupedByStatus)" 
+                             [title]="'Αιτησεις απο Καταστημα ανα Status'"
                              [canvasId]="reportTag.AgentGroupedByStatus"></app-canvas-tile>
-            <app-canvas-tile [title]="'Αιτησεις μεσω eBanking ανα Status'"
+            <app-canvas-tile *ngIf="showCanvas(reportTag.CustomerGroupedByStatus)" 
+                             [title]="'Αιτησεις μεσω eBanking ανα Status'"
                              [canvasId]="reportTag.CustomerGroupedByStatus"></app-canvas-tile>
-        </div>
-        <div *ngIf="isAdmin"
-             class="cards-deck-3">
-            <app-canvas-tile [title]="'Συνολικες Αιτησεις ανα Καταστημα'"
+            <app-canvas-tile *ngIf="showCanvas(reportTag.GroupedByGroupId)"
+                             [title]="'Συνολικες Αιτησεις ανα Καταστημα'"
                              [canvasId]="reportTag.GroupedByGroupId"></app-canvas-tile>
         </div>
     </div>

--- a/src/Indice.Features.Cases.App/src/app/features/dashboard/dashboard.component.ts
+++ b/src/Indice.Features.Cases.App/src/app/features/dashboard/dashboard.component.ts
@@ -3,6 +3,7 @@ import { AuthService } from '@indice/ng-auth';
 import { HeaderMetaItem } from '@indice/ng-components';
 import { User } from 'oidc-client';
 import { Subscription } from 'rxjs';
+import { settings } from 'src/app/core/models/settings';
 import { ReportTag } from 'src/app/core/services/cases-api.service';
 
 @Component({
@@ -15,6 +16,7 @@ export class DashboardComponent implements OnInit {
     public isAdmin: boolean | undefined;
     public userSub$: Subscription | null = null;
     public reportTag = ReportTag;
+    public canvases: string[] = [];
 
     constructor(@Inject(AuthService) private authService: AuthService) { }
 
@@ -31,6 +33,12 @@ export class DashboardComponent implements OnInit {
             this.isAdmin = this.authService.isAdmin();
         });
         this.metaItems = [];
+        this.canvases = settings.canvases.split(',');
     }
 
+    showCanvas(id: string) {
+        return settings.canvases === ''
+            ? true
+            : this.canvases.find(canvas => canvas === id);
+    }
 }

--- a/src/Indice.Features.Cases.App/src/environments/environment.prod.ts
+++ b/src/Indice.Features.Cases.App/src/environments/environment.prod.ts
@@ -18,5 +18,6 @@ export const environment = {
   },
   culture: 'el-GR',
   isTemplate: false,
-  production: true
+  production: true,
+  canvases: ''
 };

--- a/src/Indice.Features.Cases.App/src/environments/environment.template.ts
+++ b/src/Indice.Features.Cases.App/src/environments/environment.template.ts
@@ -17,5 +17,6 @@ export const environment = {
     },
     culture: '',
     isTemplate: true,
-    production: true
+    production: true,
+    canvases: ''
 };

--- a/src/Indice.Features.Cases.App/src/environments/environment.ts
+++ b/src/Indice.Features.Cases.App/src/environments/environment.ts
@@ -24,7 +24,8 @@ export const environment = {
   },
   culture: 'el-GR',
   isTemplate: false,
-  production: false
+  production: false,
+  canvases: ''
 };
 
 /*

--- a/src/Indice.Features.Cases.UI/CHANGELOG.md
+++ b/src/Indice.Features.Cases.UI/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Added the ability to control which canvases should be enabled for the dashboard
+> Example enabling only two canvases
+```cs
+app.UseCasesUI(options => {
+    options.Canvases = new List<string>() {
+        "GroupedByCasetype",
+        "GroupedByStatus"
+    };
+});
+```
+
 ## [7.1.8] - 2023-05-26
 ## Bugfix
 - CaseForm now allows empty layout and shows json schema correctly

--- a/src/Indice.Features.Cases.UI/CasesUIOptions.cs
+++ b/src/Indice.Features.Cases.UI/CasesUIOptions.cs
@@ -11,11 +11,16 @@ public class CasesUIOptions : SpaUIOptions
     /// <summary> The html application language.</summary>
     public string Lang { get; set; }
 
+    /// <summary>A list containing the tags of the canvases that should be displayed in the dashboard.</summary>
+    /// <remarks>If left null or empty all canvases are displayed.</remarks>
+    public List<string> Canvases { get; set; }
+
     /// <summary>Creates a new instance <see cref="CasesUIOptions"/>.</summary>
     public CasesUIOptions() {
         ConfigureIndexParameters = args => {
             args[$"%({nameof(ApiUrl)})"] = ApiUrl;
             args[$"%({nameof(Lang)})"] = Lang;
+            args[$"%({nameof(Canvases)})"] = Canvases?.Count is 0 ? null : string.Join(',', Canvases);
         };
     }
 }

--- a/src/Indice.Features.Cases.UI/cases-app/index.html
+++ b/src/Indice.Features.Cases.UI/cases-app/index.html
@@ -14,14 +14,15 @@
     %(HeadContent)
 </head>
 <body class="fixed-left fixed-left-void">
-    <app-root host="%(Host)" 
-              authority="%(Authority)" 
-              clientId="%(ClientId)" 
-              baseHref="%(Path)" 
-              culture="%(Culture)" 
-              version="%(ProductVersion)" 
+    <app-root host="%(Host)"
+              authority="%(Authority)"
+              clientId="%(ClientId)"
+              baseHref="%(Path)"
+              culture="%(Culture)"
+              version="%(ProductVersion)"
               scopes="%(Scopes)"
-              apiUrl="%(ApiUrl)">
+              apiUrl="%(ApiUrl)"
+              canvases="%(Canvases)">
     </app-root>
     <script src="%(Path)/runtime.js" defer></script>
     <script src="%(Path)/polyfills.js" defer></script>


### PR DESCRIPTION
By providing a comma separated list to the cases-ui you control which canvas to display. The values derive from the canvas id which is the `ReportTag` in the base package.

> Example
```cs
app.UseCasesUI(options => {
    // display only the two canvases that we want.
    options.Canvases = new() {
        ReportTag.GroupedByCasetype.ToString(),
        ReportTag.GroupedByStatus.ToString()
    };
});
```

By default all canvases are displayed.