### PR TITLE
Add RunAsSystemUser property to SendMessage Activity

### DIFF
--- a/src/Indice.Features.Cases.AspNetCore/Data/Models/DbAttachment.cs
+++ b/src/Indice.Features.Cases.AspNetCore/Data/Models/DbAttachment.cs
@@ -15,7 +15,7 @@ public class DbAttachment
     public DbAttachment(string fileName, Stream dataStream, bool saveData = false) : this() => PopulateFrom(fileName, CaseId, dataStream, saveData);
 
     public Guid Id { get; set; }
-    public DateTimeOffset LastModified { get; set; }
+    public DateTimeOffset LastModified { get; set; } = DateTimeOffset.Now;
     public Guid CaseId { get; set; }
     public Guid Guid { get; set; }
     public string Name { get; set; }


### PR DESCRIPTION
Add `RunAsSystemUser` to handle authorization exceptions when the workflow is trying to move from checkpoint type A to B, and the context user has not membership for checkpoint B.