### PR TITLE
Fix: case-form becomes editable after assign

### DIFF
--- a/src/Indice.Features.Cases.App/src/app/features/cases/case-detail-page/case-detail-page.component.ts
+++ b/src/Indice.Features.Cases.App/src/app/features/cases/case-detail-page/case-detail-page.component.ts
@@ -58,6 +58,7 @@ export class CaseDetailPageComponent implements OnInit, OnDestroy {
 
   public updateData(event: { draft: boolean }): void {
     this.getCaseActionsAndThenRequestModel();
+    this.getTimeline();
     this.showWarningModal = this.caseTypeConfig?.boOptions?.showWarningModal === false ? false : true;
   }
 

--- a/src/Indice.Features.Cases.App/src/app/features/cases/case-detail-page/case-form/case-form.component.ts
+++ b/src/Indice.Features.Cases.App/src/app/features/cases/case-detail-page/case-form/case-form.component.ts
@@ -100,8 +100,8 @@ export class CaseFormComponent implements OnChanges, OnInit, OnDestroy {
     }
     // extract layout from case type
     let layout = JSON.parse(this.case.caseType?.layout!);
-    // transform layout only when formEditable input is changed
-    if (changes.hasOwnProperty('formEditable')) {
+    // since layout is reset we need to transform it
+    if (!this.formEditable) {
       this.transformLayout(layout, !this.formEditable, this.case.draft);
       // here we need to check if case has become editable: we need to "enable" checkboxes
       // note: this won't affect checkboxes that have "disableCheckbox" class in their layout!


### PR DESCRIPTION
### Problem
A user assigns a case to himself and the case which doesnt have an `AwaitEdit` after the assignment unlocks the form in an editable state (if the page reloads this goes away).

### Bug
The `layout` of the form was reset in `ngOnChanges` and the check to make the form read-only could not be executed since the change was not triggered by the `formEditable` property.

### Fix
In the `ngOnChanges` check the `formEditable` property directly.
