### PR TITLE
Change UI behavior based on `EmailAsUsername`

### DIFF
--- a/src/Indice.Features.Identity.UI/Pages/Login.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Login.cshtml
@@ -3,6 +3,7 @@
 @model BaseLoginModel
 
 @inject IIdentityViewLocalizer Localizer
+@inject ExtendedUserManager<User> userManager
 
 @{
     var title = ViewData["Title"] = Localizer["Login"].Value;
@@ -33,8 +34,8 @@
             <input type="hidden" asp-for="Input.ReturnUrl" />
             <input type="hidden" asp-for="Input.DeviceId" />
             <div class="form-group">
-                <label asp-for="Input.UserName" class="">@Localizer["Username"]</label>
-                <input class="form-control" type="text" placeholder="@Localizer["Username"]" asp-for="Input.UserName" />
+                <label asp-for="Input.UserName" class="">@Localizer[userManager.EmailAsUserName ? "Email" : "Username"]</label>
+                <input class="form-control" type="text" placeholder="@Localizer[userManager.EmailAsUserName ? "Email" : "Username"]" asp-for="Input.UserName" />
                 <span asp-validation-for="Input.UserName" class="text-danger"></span>
             </div>
             <div class="form-group">

--- a/src/Indice.Features.Identity.UI/Pages/Register.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Register.cshtml
@@ -3,6 +3,7 @@
 @model BaseRegisterModel
 
 @inject IIdentityViewLocalizer Localizer
+@inject ExtendedUserManager<User> userManager
 
 @{
     var title = ViewData["Title"] = Localizer["Sign up"].Value;
@@ -45,6 +46,8 @@
             </div>
         </div>
         <div class="row">
+            @if (!userManager.EmailAsUserName)
+            {
             <div class="col-md-6">
                 <div class="form-group">
                     <label asp-for="Input.Email">@Localizer["Email"]</label>
@@ -52,7 +55,8 @@
                     <span asp-validation-for="Input.Email" class="text-danger"></span>
                 </div>
             </div>
-            <div class="col-md-6">
+            }
+            <div class="@(userManager.EmailAsUserName ? "col-md-12" : "col-md-6")">
                 <div class="form-group">
                     <label asp-for="Input.PhoneNumber">@Localizer["Phone number"]</label>
                     <input class="form-control" type="text" asp-for="Input.PhoneNumber" placeholder="@Localizer["Phone number"]" />
@@ -60,6 +64,34 @@
                 </div>
             </div>
         </div>
+        @if (userManager.EmailAsUserName)
+        {
+        <div class="row">
+            <div class="col-md-12">
+                <div class="form-group">
+                    <hr>
+                    <div>
+                        <p>
+                            @Localizer["Choose an email and a password of your choice. You can periodically change your password or whenever you wish to."]
+                            <br><br>
+                            @Localizer["These credentials are personal. Please remember them and do not reveal in any way (i.e orally, written, email) in third parties."]
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-md-12">
+                <div class="form-group">
+                    <label asp-for="Input.Email">@Localizer["Email"]</label>
+                    <input class="form-control" type="text" asp-for="Input.Email" placeholder="@Localizer["Email"]" />
+                    <span asp-validation-for="Input.Email" class="text-danger"></span>
+                </div>
+            </div>
+        </div>
+        }
+        else
+        {
         <div class="row">
             <div class="col-md-12">
                 <div class="form-group">
@@ -83,6 +115,7 @@
                 </div>
             </div>
         </div>
+        }
         <div class="row">
             <div class="col-md-12">
                 <div class="form-group">

--- a/src/Indice.Features.Identity.UI/Pages/Register.cshtml.cs
+++ b/src/Indice.Features.Identity.UI/Pages/Register.cshtml.cs
@@ -159,7 +159,7 @@ public abstract class BaseRegisterModel : BasePageModel
     /// <param name="input">The input model.</param>
     protected virtual User CreateUserFromInput(RegisterInputModel input) {
         var user = new User {
-            UserName = input.UserName,
+            UserName = UserManager.EmailAsUserName ? input.Email : input.UserName,
             Email = input.Email,
             PhoneNumber = input.PhoneNumber
         };

--- a/src/Indice.Features.Identity.UI/Resources/Pages/Register.el.resx
+++ b/src/Indice.Features.Identity.UI/Resources/Pages/Register.el.resx
@@ -123,6 +123,9 @@
   <data name="Choose a username and a password of your choice. You can periodically change your password or whenever you wish to." xml:space="preserve">
     <value>Επιλέξτε ένα όνομα χρήστη και έναν κωδικό πρόσβασης της προτίμησής σας. Έχετε τη δυνατότητα να αλλάξετε τον κωδικό σας σε περιοδικά διαστήματα ή όποτε το επιθυμείτε.</value>
   </data>
+  <data name="Choose an email and a password of your choice. You can periodically change your password or whenever you wish to." xml:space="preserve">
+    <value>Επιλέξτε ένα email και έναν κωδικό πρόσβασης της προτίμησής σας. Έχετε τη δυνατότητα να αλλάξετε τον κωδικό σας σε περιοδικά διαστήματα ή όποτε το επιθυμείτε.</value>
+  </data>
   <data name="First name" xml:space="preserve">
     <value>Όνομα</value>
   </data>

--- a/src/Indice.Features.Identity.UI/Validators/RegisterInputModelValidator.cs
+++ b/src/Indice.Features.Identity.UI/Validators/RegisterInputModelValidator.cs
@@ -1,4 +1,5 @@
 ﻿using FluentValidation;
+using Indice.Features.Identity.Core;
 using Indice.Features.Identity.Core.Data;
 using Indice.Features.Identity.Core.Data.Models;
 using Indice.Features.Identity.UI.Models;
@@ -21,12 +22,14 @@ public class RegisterInputModelValidator : AbstractValidator<RegisterInputModel>
     /// <summary>Creates a new instance of <see cref="LoginInputModelValidator"/> class.</summary>
     /// <param name="localizer">Represents a service that provides localized strings.</param>
     /// <param name="dbContext">An extended <see cref="DbContext"/> for the Identity framework.</param>
+    /// <param name="userManager">An extendned <see cref="UserManager{TUser}"/> for the identity framework.</param>
     /// <param name="identityOptions">Represents all the options you can use to configure the identity system.</param>
     /// <param name="configuration">Represents the configuration element.</param>
     /// <exception cref="ArgumentNullException"></exception>
     public RegisterInputModelValidator(
         IStringLocalizer<RegisterInputModelValidator> localizer,
         ExtendedIdentityDbContext<User, Role> dbContext,
+        ExtendedUserManager<User> userManager,
         IOptionsSnapshot<IdentityOptions> identityOptions,
         IConfiguration configuration
     ) {
@@ -35,9 +38,11 @@ public class RegisterInputModelValidator : AbstractValidator<RegisterInputModel>
         _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
         RuleFor(x => x.FirstName).NotEmpty().WithName(_localizer["First name"]);
         RuleFor(x => x.LastName).NotEmpty().WithName(_localizer["Last name"]);
-        RuleFor(x => x.UserName).NotEmpty().WithName(_localizer["Username"]);
-        RuleFor(x => x.UserName).UserName(identityOptions.Value.User).WithName(_localizer["Username"]).WithMessage(_localizer["Field '{PropertyName}' can accept digits, uppercase or lowercase latin characters and the symbols -._@+"]);
-        RuleFor(x => x.UserName).Must(UserNameNotBeAssignedToAnotherUser).WithMessage(_localizer["This username already exists. Please use a different one."]);
+        if (!userManager.EmailAsUserName) {
+            RuleFor(x => x.UserName).NotEmpty().WithName(_localizer["Username"]);
+            RuleFor(x => x.UserName).UserName(identityOptions.Value.User).WithName(_localizer["Username"]).WithMessage(_localizer["Field '{PropertyName}' can accept digits, uppercase or lowercase latin characters and the symbols -._@+"]);
+            RuleFor(x => x.UserName).Must(UserNameNotBeAssignedToAnotherUser).WithMessage(_localizer["This username already exists. Please use a different one."]);
+        };
         RuleFor(x => x.Password).NotEmpty().WithName(_localizer["Password"]);
         RuleFor(x => x.PhoneNumber).UserPhoneNumber(configuration).WithMessage(_localizer["The field '{PropertyName}' has invalid format."]);
         RuleFor(x => x.Email).NotEmpty().EmailAddress();


### PR DESCRIPTION
# Problem

The register & login pages ignore the `EmailAsUsername` option.

# Fix
- Update the `RegisterInputModel` validator to validate the username only when the option is disabled.
- Update the register page model to fill the username with the email if the option is enabled.
- Update the Register page by showing only email and password as a registration method when the option is enabled.
- Update the Login page to reflect the login method depending on the option.