### PR TITLE
fix: RegisterInputModel.ReturnUrl was not set

### DIFF
--- a/src/Indice.Features.Identity.UI/Pages/Register.cshtml.cs
+++ b/src/Indice.Features.Identity.UI/Pages/Register.cshtml.cs
@@ -79,6 +79,7 @@ public abstract class BaseRegisterModel : BasePageModel
                 returnUrl
             });
         }
+        Input.ReturnUrl = returnUrl;
         return Page();
     }
 


### PR DESCRIPTION
# Problem

After completing registration I am redirected to the identity login page instead of the page that started it (redirect URL was sent)

# Fix

Set the `ReturnURL` on the input model when the get method of the page is called.