### PR TITLE
UserNameChangedEvent not raised when EmailAsUsername

### DIFF
--- a/src/Indice.Features.Identity.Core/ExtendedUserManager.cs
+++ b/src/Indice.Features.Identity.Core/ExtendedUserManager.cs
@@ -157,10 +157,17 @@ public class ExtendedUserManager<TUser> : UserManager<TUser> where TUser : User
 
     /// <inheritdoc />
     public override async Task<IdentityResult> SetEmailAsync(TUser user, string email) {
-        if (EmailAsUserName) {
-            await base.SetUserNameAsync(user, email);
+        var emailResult = await base.SetEmailAsync(user, email);
+        if (!emailResult.Succeeded) {
+            return emailResult;
         }
-        return await base.SetEmailAsync(user, email);
+        if (EmailAsUserName) {
+            var userNameResult = await SetUserNameAsync(user, email);
+            if (!userNameResult.Succeeded) {
+                return userNameResult;
+            }
+        }
+        return emailResult;
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
## Problem
Όταν χρησιμοποιείται το flag `EmailAsUsername = true;` δεν γίνετε raise το event `UserNameChangedEvent` κατά την αλλαγή του email.

## Fix
Εκτέλεση της `overridden` μεθόδου αντί για την `base` αφού γίνει αλλαγή του email.