### PR TITLE
Add missing data when OTP delivery channel is Email

### DIFF
--- a/src/Indice.Features.Identity.Server/Totp/TotpHandlers.cs
+++ b/src/Indice.Features.Identity.Server/Totp/TotpHandlers.cs
@@ -71,6 +71,7 @@ internal static class TotpHandlers
                     .UsingEmail(request.EmailTemplate)
                     .WithSubject(request.Subject)
                     .WithPurpose(request.Purpose)
+                    .WithData(request.Data)
                     .UsingTokenProvider(tokenProvider));
                 break;
             case TotpDeliveryChannel.Telephone:


### PR DESCRIPTION
Dynamic Data object is missing when the OTP delivery channel is Email