### PR TITLE
Add an IPhoneNumberValidator to identity UI and API

### DIFF
--- a/src/Indice.Features.Identity.Core/Extensions/IdentityBuilderExtensions.cs
+++ b/src/Indice.Features.Identity.Core/Extensions/IdentityBuilderExtensions.cs
@@ -229,7 +229,7 @@ public static class IdentityBuilderExtensions
     /// <param name="builder">Helper functions for configuring identity services.</param>
     /// <returns>The <see cref="IdentityBuilder"/>.</returns>
     public static IdentityBuilder AddDefaultPhoneNumberValidator(this IdentityBuilder builder) {
-        builder.AddPhoneNumberValidator<DefaultPhoneNumberValidator>();
+        builder.Services.TryAddScoped<IPhoneNumberValidator, DefaultPhoneNumberValidator>();
         return builder;
     }
 

--- a/src/Indice.Features.Identity.Core/Extensions/IdentityBuilderExtensions.cs
+++ b/src/Indice.Features.Identity.Core/Extensions/IdentityBuilderExtensions.cs
@@ -6,6 +6,7 @@ using Indice.Features.Identity.Core.Data.Stores;
 using Indice.Features.Identity.Core.Events;
 using Indice.Features.Identity.Core.Models;
 using Indice.Features.Identity.Core.PasswordValidation;
+using Indice.Features.Identity.Core.PhoneNumberValidation;
 using Indice.Features.Identity.Core.TokenProviders;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Http;
@@ -219,6 +220,29 @@ public static class IdentityBuilderExtensions
         builder.AddPasswordValidator<UnicodeCharactersPasswordValidator>();
         builder.AddPasswordValidator<PreviousPasswordAwareValidator<ExtendedIdentityDbContext<User, Role>, User, Role>>();
         builder.AddPasswordValidator<UserNameAsPasswordValidator>();
+        return builder;
+    }
+
+    /// <summary>
+    /// Registers <see cref="DefaultPhoneNumberValidator"/> as a <see cref="IPhoneNumberValidator"/>.
+    /// </summary>
+    /// <param name="builder">Helper functions for configuring identity services.</param>
+    /// <returns>The <see cref="IdentityBuilder"/>.</returns>
+    public static IdentityBuilder AddDefaultPhoneNumberValidator(this IdentityBuilder builder) {
+        builder.AddPhoneNumberValidator<DefaultPhoneNumberValidator>();
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds an overridden implementation of <see cref="IPhoneNumberValidator"/>.
+    /// </summary>
+    /// <typeparam name="TPhoneValidator">The type of your <see cref="IPhoneNumberValidator"/>.</typeparam>
+    /// <param name="builder">Helper functions for configuring identity services.</param>
+    /// <param name="serviceLifetime">The lifetime of your service.</param>
+    /// <returns>The <see cref="IdentityBuilder"/>.</returns>
+    public static IdentityBuilder AddPhoneNumberValidator<TPhoneValidator>(this IdentityBuilder builder, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped) where TPhoneValidator : class, IPhoneNumberValidator {
+        var descriptor = new ServiceDescriptor(typeof(IPhoneNumberValidator), typeof(TPhoneValidator), serviceLifetime);
+        builder.Services.Add(descriptor);
         return builder;
     }
 

--- a/src/Indice.Features.Identity.Core/PhoneNumberValidation/DefaultPhoneNumberValidator.cs
+++ b/src/Indice.Features.Identity.Core/PhoneNumberValidation/DefaultPhoneNumberValidator.cs
@@ -33,14 +33,10 @@ public class DefaultPhoneNumberValidator : IPhoneNumberValidator
 
     /// <inheritdoc/>
     public bool Validate(string phoneNumber) {
-        bool result;
         var phoneNumberRegex = configuration.GetIdentityOption("User", "PhoneNumberRegex");
-        if (string.IsNullOrEmpty(phoneNumberRegex)) {
-            // Greek phone number default.
-            result = phoneNumber is { Length: 10 } && phoneNumber.StartsWith("69");
-        } else {
-            result = Regex.IsMatch(phoneNumber, phoneNumberRegex);
-        }
-        return result;
+
+        return string.IsNullOrEmpty(phoneNumberRegex)
+            ? phoneNumber is { Length: 10 } && phoneNumber.StartsWith("69") // Greek phone number default.
+            : Regex.IsMatch(phoneNumber, phoneNumberRegex);
     }
 }

--- a/src/Indice.Features.Identity.Core/PhoneNumberValidation/DefaultPhoneNumberValidator.cs
+++ b/src/Indice.Features.Identity.Core/PhoneNumberValidation/DefaultPhoneNumberValidator.cs
@@ -1,0 +1,46 @@
+﻿using System.Text.RegularExpressions;
+using Indice.Globalization;
+using Microsoft.Extensions.Configuration;
+
+namespace Indice.Features.Identity.Core.PhoneNumberValidation;
+
+/// <summary>
+/// Provides a default implementation of <see cref="IPhoneNumberValidator"/>.
+/// The validator will use the 'IdentityOptions.User.PhoneNUmberRegex' to validate the phone number.
+/// If the regex is not provided then by default this will validate only Greek phone numbers without the country code.
+/// </summary>
+public class DefaultPhoneNumberValidator : IPhoneNumberValidator
+{
+    private readonly IConfiguration configuration;
+    private static readonly Lazy<CountryInfo[]> countries;
+
+    static DefaultPhoneNumberValidator() {
+        countries = new Lazy<CountryInfo[]>(static () => new[] { CountryInfo.GetCountryByNameOrCode("GR") });
+    }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="DefaultPhoneNumberValidator"/>.
+    /// </summary>
+    /// <param name="configuration">The application configuration.</param>
+    public DefaultPhoneNumberValidator(IConfiguration configuration) {
+        this.configuration = configuration;
+    }
+
+    /// <inheritdoc/>
+    public CountryInfo[] GetCountries() {
+        return countries.Value;
+    }
+
+    /// <inheritdoc/>
+    public bool Validate(string phoneNumber) {
+        bool result;
+        var phoneNumberRegex = configuration.GetIdentityOption("User", "PhoneNumberRegex");
+        if (string.IsNullOrEmpty(phoneNumberRegex)) {
+            // Greek phone number default.
+            result = phoneNumber is { Length: 10 } && phoneNumber.StartsWith("69");
+        } else {
+            result = Regex.IsMatch(phoneNumber, phoneNumberRegex);
+        }
+        return result;
+    }
+}

--- a/src/Indice.Features.Identity.Core/PhoneNumberValidation/IPhoneNumberValidator.cs
+++ b/src/Indice.Features.Identity.Core/PhoneNumberValidation/IPhoneNumberValidator.cs
@@ -1,0 +1,19 @@
+﻿using Indice.Globalization;
+
+namespace Indice.Features.Identity.Core.PhoneNumberValidation;
+
+/// <summary>
+/// Provides an abstraction for validating phone numbers.
+/// </summary>
+public interface IPhoneNumberValidator
+{
+    /// <summary>
+    /// Returns the two-letter ISO codes of supported countries.
+    /// </summary>
+    CountryInfo[] GetCountries();
+
+    /// <summary>
+    /// Validates a phone number.
+    /// </summary>
+    bool Validate(string phoneNumber);
+}

--- a/src/Indice.Features.Identity.Server/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Indice.Features.Identity.Server/Extensions/ServiceCollectionExtensions.cs
@@ -95,6 +95,7 @@ public static class IdentityServerEndpointServiceCollectionExtensions
                        .AddExtendedUserManager()
                        .AddExtendedSignInManager<User>()
                        .AddDefaultPasswordValidators()
+                       .AddDefaultPhoneNumberValidator()
                        .AddClaimsPrincipalFactory<ExtendedUserClaimsPrincipalFactory<User, Role>>()
                        .AddDefaultTokenProviders()
                        .AddExtendedPhoneNumberTokenProvider(configuration)

--- a/src/Indice.Features.Identity.Server/Manager/MyAccountApi.cs
+++ b/src/Indice.Features.Identity.Server/Manager/MyAccountApi.cs
@@ -135,6 +135,12 @@ public static class MyAccountApi
              .AllowAnonymous()
              .RequireRateLimiting(IdentityEndpoints.RateLimiter.Policies.PasswordOptions);
 
+        group.MapGet("account/phone-number-countries", MyAccountHandlers.GetPhoneNumberCountries)
+             .WithName(nameof(MyAccountHandlers.GetPhoneNumberCountries))
+             .WithSummary("Gets the available countries and their options that are applied when the user creates an account.")
+             .AllowAnonymous()
+             .RequireRateLimiting(IdentityEndpoints.RateLimiter.Policies.PasswordOptions);
+
         group.MapPost("account/username-exists", MyAccountHandlers.CheckUserNameExists)
              .WithName(nameof(MyAccountHandlers.CheckUserNameExists))
              .WithSummary("Checks if a username already exists in the database.")

--- a/src/Indice.Features.Identity.Server/Manager/MyAccountHandlers.cs
+++ b/src/Indice.Features.Identity.Server/Manager/MyAccountHandlers.cs
@@ -7,8 +7,10 @@ using Indice.Features.Identity.Core;
 using Indice.Features.Identity.Core.Data;
 using Indice.Features.Identity.Core.Data.Models;
 using Indice.Features.Identity.Core.PasswordValidation;
+using Indice.Features.Identity.Core.PhoneNumberValidation;
 using Indice.Features.Identity.Server.Manager.Models;
 using Indice.Features.Identity.Server.Options;
+using Indice.Globalization;
 using Indice.Security;
 using Indice.Services;
 using Indice.Types;
@@ -464,6 +466,11 @@ internal static class MyAccountHandlers
         return TypedResults.Ok(identityOptions.Value.Password);
     }
 
+    internal static Results<Ok<CountryInfo[]>, NotFound> GetPhoneNumberCountries(IPhoneNumberValidator phoneNumberValidator) {
+        var countries = phoneNumberValidator.GetCountries();
+        return TypedResults.Ok(countries);
+    }
+
     internal static async Task<Ok<CredentialsValidationInfo>> ValidatePassword(
         ExtendedUserManager<User> userManager,
         ValidatePasswordRequest request
@@ -491,8 +498,8 @@ internal static class MyAccountHandlers
                 }
             }
         }
-        return TypedResults.Ok(new CredentialsValidationInfo { 
-            PasswordRules = availableRules.Values.ToList() 
+        return TypedResults.Ok(new CredentialsValidationInfo {
+            PasswordRules = availableRules.Values.ToList()
         });
     }
 

--- a/src/Indice.Features.Identity.Server/Manager/Validation/UpdateUserPhoneNumberRequestValidator.cs
+++ b/src/Indice.Features.Identity.Server/Manager/Validation/UpdateUserPhoneNumberRequestValidator.cs
@@ -1,4 +1,5 @@
 ﻿using FluentValidation;
+using Indice.Features.Identity.Core.PhoneNumberValidation;
 using Indice.Features.Identity.Server.Manager.Models;
 using Microsoft.Extensions.Configuration;
 
@@ -10,8 +11,14 @@ public class UpdateUserPhoneNumberRequestValidator : AbstractValidator<UpdateUse
     private readonly IConfiguration _configuration;
 
     /// <summary></summary>
-    public UpdateUserPhoneNumberRequestValidator(IConfiguration configuration) {
+    public UpdateUserPhoneNumberRequestValidator(IConfiguration configuration, IPhoneNumberValidator phoneNumberValidator) {
         _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
-        RuleFor(x => x.PhoneNumber).UserPhoneNumber(_configuration).NotEmpty();
+
+        var regexMessage = configuration.GetIdentityOption("User", "PhoneNumberRegexMessage");
+
+        RuleFor(x => x.PhoneNumber)
+            .NotEmpty()
+            .Must(phoneNumberValidator.Validate)
+            .WithMessage(string.IsNullOrWhiteSpace(regexMessage) ? "The field '{PropertyName}' has invalid format." : regexMessage);
     }
 }

--- a/src/Indice.Features.Identity.UI/Models/AddPhoneInputModel.cs
+++ b/src/Indice.Features.Identity.UI/Models/AddPhoneInputModel.cs
@@ -3,6 +3,8 @@
 /// <summary>The input model that backs the add phone page.</summary>
 public class AddPhoneInputModel
 {
+    /// <summary></summary>
+    public string? PhoneCallingCode { get; set; }
     /// <summary>The phone number.</summary>
     public string? PhoneNumber { get; set; }
     /// <summary>The return URL.</summary>

--- a/src/Indice.Features.Identity.UI/Models/EnableMfaSmsInputModel.cs
+++ b/src/Indice.Features.Identity.UI/Models/EnableMfaSmsInputModel.cs
@@ -4,6 +4,8 @@
 public class EnableMfaSmsInputModel
 {
     /// <summary></summary>
+    public string? PhoneCallingCode { get; set; }
+    /// <summary></summary>
     public string? PhoneNumber { get; set; }
     /// <summary></summary>
     public string? ReturnUrl { get; set; }

--- a/src/Indice.Features.Identity.UI/Models/ProfileInputModel.cs
+++ b/src/Indice.Features.Identity.UI/Models/ProfileInputModel.cs
@@ -12,6 +12,8 @@ public class ProfileInputModel
     /// <summary></summary>
     public string? Email { get; set; }
     /// <summary></summary>
+    public string? PhoneCallingCode { get; set; }
+    /// <summary></summary>
     public string? PhoneNumber { get; set; }
     /// <summary></summary>
     public string? Tin { get; set; }

--- a/src/Indice.Features.Identity.UI/Models/RegisterInputModel.cs
+++ b/src/Indice.Features.Identity.UI/Models/RegisterInputModel.cs
@@ -15,6 +15,8 @@ public class RegisterInputModel
     public string? PasswordConfirmation { get; set; }
     /// <summary>The users email.</summary>
     public string? Email { get; set; }
+    /// <summary></summary>
+    public string? PhoneCallingCode { get; set; }
     /// <summary>The users phone number. Usually used to store the mobile phone in order later on enable 2 factor authentication scenarios through SMS.</summary>
     public string? PhoneNumber { get; set; }
     /// <summary>The return URL is used to keep track of the original intent of the user when he landed on login and switched over to register.</summary>

--- a/src/Indice.Features.Identity.UI/Models/VerifyPhoneInputModel.cs
+++ b/src/Indice.Features.Identity.UI/Models/VerifyPhoneInputModel.cs
@@ -5,6 +5,8 @@ public class VerifyPhoneInputModel
 {
     /// <summary>The verification code.</summary>
     public string? Code { get; set; }
+    /// <summary></summary>
+    public string? PhoneCallingCode { get; set; }
     /// <summary>The phone number.</summary>
     public string? PhoneNumber { get; set; }
     /// <summary>The return URL.</summary>

--- a/src/Indice.Features.Identity.UI/Pages/AddPhone.cs
+++ b/src/Indice.Features.Identity.UI/Pages/AddPhone.cs
@@ -63,7 +63,7 @@ public abstract class BaseAddPhoneModel : BasePageModel
             return Page();
         }
         var user = await UserManager.GetUserAsync(User) ?? throw new InvalidOperationException("User cannot be null.");
-        var result = await UserManager.SetPhoneNumberAsync(user, Input.PhoneNumber);
+        var result = await UserManager.SetPhoneNumberAsync(user, $"{Input.PhoneCallingCode}{Input.PhoneNumber}");
         if (!result.Succeeded) {
             AddModelErrors(result);
             return Page();

--- a/src/Indice.Features.Identity.UI/Pages/MfaOnboardingAddPhone.cs
+++ b/src/Indice.Features.Identity.UI/Pages/MfaOnboardingAddPhone.cs
@@ -68,7 +68,7 @@ public abstract class BaseMfaOnboardingAddPhoneModel : BasePageModel
         var user = await UserManager.GetUserAsync(User) ?? throw new InvalidOperationException("User cannot be null.");
         IdentityResult result;
         if (!user.PhoneNumberConfirmed) {
-            result = await UserManager.SetPhoneNumberAsync(user, Input.PhoneNumber);
+            result = await UserManager.SetPhoneNumberAsync(user, $"{Input.PhoneCallingCode}{Input.PhoneNumber}");
             if (!result.Succeeded) {
                 AddModelErrors(result);
                 return Page();

--- a/src/Indice.Features.Identity.UI/Pages/Profile.cs
+++ b/src/Indice.Features.Identity.UI/Pages/Profile.cs
@@ -100,7 +100,10 @@ public abstract class BaseProfileModel : BasePageModel
                 await SendChangeEmailConfirmationEmail(user, Input.Email);
             }
         }
-        user.PhoneNumber = Input.PhoneNumber;
+        var phoneNumber = $"{Input.PhoneCallingCode}{Input.PhoneNumber}";
+        if (!user.PhoneNumber.Equals(phoneNumber, StringComparison.Ordinal)) {
+            await UserManager.SetPhoneNumberAsync(user, phoneNumber);
+        }
         if (user.UserName != Input.UserName) {
             result = await UserManager.SetUserNameAsync(user, Input.UserName);
             AddModelErrors(result);

--- a/src/Indice.Features.Identity.UI/Pages/Register.cs
+++ b/src/Indice.Features.Identity.UI/Pages/Register.cs
@@ -162,7 +162,7 @@ public abstract class BaseRegisterModel : BasePageModel
         var user = new User {
             UserName = UserManager.EmailAsUserName ? input.Email : input.UserName,
             Email = input.Email,
-            PhoneNumber = input.PhoneNumber
+            PhoneNumber = $"{input.PhoneCallingCode}{input.PhoneNumber}"
         };
         if (!string.IsNullOrWhiteSpace(input.FirstName)) {
             user.Claims.Add(new() {

--- a/src/Indice.Features.Identity.UI/Pages/VerifyPhone.cs
+++ b/src/Indice.Features.Identity.UI/Pages/VerifyPhone.cs
@@ -68,7 +68,7 @@ public abstract class BaseVerifyPhoneModel : BasePageModel
             await SendVerificationSmsAsync(user, Input.PhoneNumber!);
             return Page();
         }
-        var result = await UserManager.ChangePhoneNumberAsync(user, Input.PhoneNumber, Input.Code);
+        var result = await UserManager.ChangePhoneNumberAsync(user, $"{Input.PhoneCallingCode}{Input.PhoneNumber}", Input.Code);
         if (result.Succeeded) {
             if (UserManager.StateProvider.CurrentState == UserState.LoggedIn) {
                 await SignInManager.AutoSignIn(user, ExtendedIdentityConstants.ExtendedValidationUserIdScheme);

--- a/src/Indice.Features.Identity.UI/Validators/AddPhoneInputModelValidator.cs
+++ b/src/Indice.Features.Identity.UI/Validators/AddPhoneInputModelValidator.cs
@@ -1,4 +1,5 @@
 ﻿using FluentValidation;
+using Indice.Features.Identity.Core.PhoneNumberValidation;
 using Indice.Features.Identity.UI.Models;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Localization;
@@ -15,9 +16,13 @@ public class AddPhoneInputModelValidator : AbstractValidator<AddPhoneInputModel>
     /// <param name="localizer">Represents a service that provides localized strings.</param>
     /// <param name="configuration">Represents the configuration element.</param>
     /// <exception cref="ArgumentNullException"></exception>
-    public AddPhoneInputModelValidator(IStringLocalizer<AddPhoneInputModelValidator> localizer, IConfiguration configuration) {
+    public AddPhoneInputModelValidator(IStringLocalizer<AddPhoneInputModelValidator> localizer, IConfiguration configuration, IPhoneNumberValidator phoneNumberValidator) {
         _localizer = localizer ?? throw new ArgumentNullException(nameof(localizer));
         _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
-        RuleFor(x => x.PhoneNumber).NotEmpty().WithName(_localizer["Phone Number"]).UserPhoneNumber(_configuration).WithMessage(_localizer["The field '{PropertyName}' has invalid format."]);
+        RuleFor(x => x.PhoneNumber)
+            .NotEmpty()
+            .WithName(_localizer["Phone Number"])
+            .Must((model, phone) => phoneNumberValidator.Validate($"{model.PhoneCallingCode}{phone}"))
+            .UserPhoneNumber(_configuration).WithMessage(_localizer["The field '{PropertyName}' has invalid format."]);
     }
 }

--- a/src/Indice.Features.Identity.UI/Validators/AddPhoneInputModelValidator.cs
+++ b/src/Indice.Features.Identity.UI/Validators/AddPhoneInputModelValidator.cs
@@ -1,7 +1,6 @@
 ﻿using FluentValidation;
 using Indice.Features.Identity.Core.PhoneNumberValidation;
 using Indice.Features.Identity.UI.Models;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Localization;
 
 namespace Indice.Features.Identity.UI.Validators;
@@ -10,19 +9,19 @@ namespace Indice.Features.Identity.UI.Validators;
 public class AddPhoneInputModelValidator : AbstractValidator<AddPhoneInputModel>
 {
     private readonly IStringLocalizer<AddPhoneInputModelValidator> _localizer;
-    private readonly IConfiguration _configuration;
 
     /// <summary>Creates a new instance of <see cref="AddPhoneInputModelValidator"/> class.</summary>
     /// <param name="localizer">Represents a service that provides localized strings.</param>
-    /// <param name="configuration">Represents the configuration element.</param>
+    /// <param name="phoneNumberValidator">Represents a validator that validates phone numbers.</param>
     /// <exception cref="ArgumentNullException"></exception>
-    public AddPhoneInputModelValidator(IStringLocalizer<AddPhoneInputModelValidator> localizer, IConfiguration configuration, IPhoneNumberValidator phoneNumberValidator) {
+    public AddPhoneInputModelValidator(IStringLocalizer<AddPhoneInputModelValidator> localizer, IPhoneNumberValidator phoneNumberValidator) {
         _localizer = localizer ?? throw new ArgumentNullException(nameof(localizer));
-        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        ArgumentNullException.ThrowIfNull(nameof(phoneNumberValidator));
+
         RuleFor(x => x.PhoneNumber)
             .NotEmpty()
             .WithName(_localizer["Phone Number"])
             .Must((model, phone) => phoneNumberValidator.Validate($"{model.PhoneCallingCode}{phone}"))
-            .UserPhoneNumber(_configuration).WithMessage(_localizer["The field '{PropertyName}' has invalid format."]);
+            .WithMessage(_localizer["The field '{PropertyName}' has invalid format."]);
     }
 }

--- a/src/Indice.Features.Identity.UI/Validators/EnableMfaSmsInputModelValidator.cs
+++ b/src/Indice.Features.Identity.UI/Validators/EnableMfaSmsInputModelValidator.cs
@@ -1,7 +1,6 @@
 ﻿using FluentValidation;
 using Indice.Features.Identity.Core.PhoneNumberValidation;
 using Indice.Features.Identity.UI.Models;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Localization;
 
 namespace Indice.Features.Identity.UI.Validators;
@@ -10,15 +9,15 @@ namespace Indice.Features.Identity.UI.Validators;
 public class EnableMfaSmsInputModelValidator : AbstractValidator<EnableMfaSmsInputModel>
 {
     private readonly IStringLocalizer<EnableMfaSmsInputModelValidator> _localizer;
-    private readonly IConfiguration _configuration;
 
     /// <summary>Creates a new instance of <see cref="EnableMfaSmsInputModelValidator"/> class.</summary>
     /// <param name="localizer">Represents a service that provides localized strings.</param>
-    /// <param name="configuration">Represents the configuration element.</param>
+    /// <param name="phoneNumberValidator">Represents a validator that validates phone numbers.</param>
     /// <exception cref="ArgumentNullException"></exception>
-    public EnableMfaSmsInputModelValidator(IStringLocalizer<EnableMfaSmsInputModelValidator> localizer, IConfiguration configuration, IPhoneNumberValidator phoneNumberValidator) {
+    public EnableMfaSmsInputModelValidator(IStringLocalizer<EnableMfaSmsInputModelValidator> localizer, IPhoneNumberValidator phoneNumberValidator) {
         _localizer = localizer ?? throw new ArgumentNullException(nameof(localizer));
-        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        ArgumentNullException.ThrowIfNull(nameof(phoneNumberValidator));
+
         RuleFor(x => x.PhoneNumber)
             .NotEmpty()
             .WithName(_localizer["Phone Number"])

--- a/src/Indice.Features.Identity.UI/Validators/EnableMfaSmsInputModelValidator.cs
+++ b/src/Indice.Features.Identity.UI/Validators/EnableMfaSmsInputModelValidator.cs
@@ -1,4 +1,5 @@
 ﻿using FluentValidation;
+using Indice.Features.Identity.Core.PhoneNumberValidation;
 using Indice.Features.Identity.UI.Models;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Localization;
@@ -15,9 +16,13 @@ public class EnableMfaSmsInputModelValidator : AbstractValidator<EnableMfaSmsInp
     /// <param name="localizer">Represents a service that provides localized strings.</param>
     /// <param name="configuration">Represents the configuration element.</param>
     /// <exception cref="ArgumentNullException"></exception>
-    public EnableMfaSmsInputModelValidator(IStringLocalizer<EnableMfaSmsInputModelValidator> localizer, IConfiguration configuration) {
+    public EnableMfaSmsInputModelValidator(IStringLocalizer<EnableMfaSmsInputModelValidator> localizer, IConfiguration configuration, IPhoneNumberValidator phoneNumberValidator) {
         _localizer = localizer ?? throw new ArgumentNullException(nameof(localizer));
         _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
-        RuleFor(x => x.PhoneNumber).NotEmpty().WithName(_localizer["Phone Number"]).UserPhoneNumber(_configuration).WithMessage(_localizer["The field '{PropertyName}' has invalid format."]);
+        RuleFor(x => x.PhoneNumber)
+            .NotEmpty()
+            .WithName(_localizer["Phone Number"])
+            .Must((model, phone) => phoneNumberValidator.Validate($"{model.PhoneCallingCode}{phone}"))
+            .WithMessage(_localizer["The field '{PropertyName}' has invalid format."]);
     }
 }

--- a/src/Indice.Features.Identity.UI/Validators/ProfileInputModelValidator.cs
+++ b/src/Indice.Features.Identity.UI/Validators/ProfileInputModelValidator.cs
@@ -16,6 +16,7 @@ public class ProfileInputModelValidator : AbstractValidator<ProfileInputModel>
     /// <summary>Creates a new instance of <see cref="ProfileInputModelValidator"/> class.</summary>
     /// <param name="localizer">Represents a service that provides localized strings.</param>
     /// <param name="identityOptions">Represents all the options you can use to configure the identity system.</param>
+    /// <param name="phoneNumberValidator">Represents a validator that validates phone numbers.</param>
     /// <exception cref="ArgumentNullException"></exception>
     public ProfileInputModelValidator(
         IStringLocalizer<ProfileInputModelValidator> localizer,
@@ -23,6 +24,8 @@ public class ProfileInputModelValidator : AbstractValidator<ProfileInputModel>
         IPhoneNumberValidator phoneNumberValidator
     ) {
         _localizer = localizer ?? throw new ArgumentNullException(nameof(localizer));
+        ArgumentNullException.ThrowIfNull(nameof(phoneNumberValidator));
+
         RuleFor(x => x.UserName).NotEmpty().WithName(_localizer["Username"]);
         RuleFor(x => x.UserName).UserName(identityOptions.Value.User).WithName(_localizer["Username"]).WithMessage(_localizer["Field '{PropertyName}' can accept digits, uppercase or lowercase latin characters and the symbols -._@+"]);
         RuleFor(x => x.Email).NotEmpty().EmailAddress();

--- a/src/Indice.Features.Identity.UI/Validators/VerifyPhoneInputModelValidator.cs
+++ b/src/Indice.Features.Identity.UI/Validators/VerifyPhoneInputModelValidator.cs
@@ -1,4 +1,5 @@
 ﻿using FluentValidation;
+using Indice.Features.Identity.Core.PhoneNumberValidation;
 using Indice.Features.Identity.UI.Models;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Localization;
@@ -15,10 +16,14 @@ public class VerifyPhoneInputModelValidator : AbstractValidator<VerifyPhoneInput
     /// <param name="localizer">Represents a service that provides localized strings.</param>
     /// <param name="configuration">Represents a set of key/value application configuration properties.</param>
     /// <exception cref="ArgumentNullException"></exception>
-    public VerifyPhoneInputModelValidator(IStringLocalizer<VerifyPhoneInputModelValidator> localizer, IConfiguration configuration) {
+    public VerifyPhoneInputModelValidator(IStringLocalizer<VerifyPhoneInputModelValidator> localizer, IConfiguration configuration, IPhoneNumberValidator phoneNumberValidator) {
         _localizer = localizer ?? throw new ArgumentNullException(nameof(localizer));
         _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
-        RuleFor(x => x.PhoneNumber).NotEmpty().WithName(_localizer["Phone Number"]).UserPhoneNumber(_configuration).WithMessage(_localizer["The field '{PropertyName}' has invalid format."]);
+        RuleFor(x => x.PhoneNumber)
+            .NotEmpty()
+            .WithName(_localizer["Phone Number"])
+            .Must((model, phone) => phoneNumberValidator.Validate($"{model.PhoneCallingCode}{phone}"))
+            .WithMessage(_localizer["The field '{PropertyName}' has invalid format."]);
         RuleFor(x => x.Code).NotEmpty().When(x => !x.OtpResend).WithName(_localizer["Code"]);
     }
 }

--- a/src/Indice.Features.Identity.UI/Validators/VerifyPhoneInputModelValidator.cs
+++ b/src/Indice.Features.Identity.UI/Validators/VerifyPhoneInputModelValidator.cs
@@ -1,7 +1,6 @@
 ﻿using FluentValidation;
 using Indice.Features.Identity.Core.PhoneNumberValidation;
 using Indice.Features.Identity.UI.Models;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Localization;
 
 namespace Indice.Features.Identity.UI.Validators;
@@ -10,15 +9,15 @@ namespace Indice.Features.Identity.UI.Validators;
 public class VerifyPhoneInputModelValidator : AbstractValidator<VerifyPhoneInputModel>
 {
     private readonly IStringLocalizer<VerifyPhoneInputModelValidator> _localizer;
-    private readonly IConfiguration _configuration;
 
     /// <summary>Creates a new instance of <see cref="VerifyPhoneInputModelValidator"/> class.</summary>
     /// <param name="localizer">Represents a service that provides localized strings.</param>
-    /// <param name="configuration">Represents a set of key/value application configuration properties.</param>
+    /// <param name="phoneNumberValidator">Represents a validator that validates phone numbers.</param>
     /// <exception cref="ArgumentNullException"></exception>
-    public VerifyPhoneInputModelValidator(IStringLocalizer<VerifyPhoneInputModelValidator> localizer, IConfiguration configuration, IPhoneNumberValidator phoneNumberValidator) {
+    public VerifyPhoneInputModelValidator(IStringLocalizer<VerifyPhoneInputModelValidator> localizer, IPhoneNumberValidator phoneNumberValidator) {
         _localizer = localizer ?? throw new ArgumentNullException(nameof(localizer));
-        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        ArgumentNullException.ThrowIfNull(nameof(phoneNumberValidator));
+
         RuleFor(x => x.PhoneNumber)
             .NotEmpty()
             .WithName(_localizer["Phone Number"])


### PR DESCRIPTION
Make phone number validation abstract to allow for different implementations, like a global phone number validator.

This will require to update the validators of the `API` and `UI` to use this interface.

Later changes:
- Provide an API endpoint that returns the supported countries of the validator (like password options).
- Add to `Identity.UI` pages with phone numbers a `PhoneCallingCode` property (null) to represent optional country codes so that custom implementations can use a combination of UI elements to represent a phone number.

