### PR TITLE
Fix Messages NotificationManager.SendMessageToRecipients doesn't parse content correctly

### DIFF
--- a/src/Indice.Features.Messages.Core/Manager/NotificationsManager.cs
+++ b/src/Indice.Features.Messages.Core/Manager/NotificationsManager.cs
@@ -134,7 +134,7 @@ public class NotificationsManager
     public async Task<CreateCampaignResult> SendMessageToRecipients(string title, MessageChannelKind channels, Guid templateId, Period period = null,
         Hyperlink actionLink = null, string type = null, dynamic data = null, params string[] recipientIds) {
         var template = await TemplateService.GetById(templateId);
-        return await SendMessageToRecipients(title, template.Content.ToDictionary(x => Enum.Parse<MessageChannelKind>(x.Key), x => x.Value), period, actionLink, type, data, recipientIds);
+        return await SendMessageToRecipients(title, template.Content.ToDictionary(x => Enum.Parse<MessageChannelKind>(x.Key, ignoreCase: true), x => x.Value), period, actionLink, type, data, recipientIds);
     }
 
     /// <summary>Creates a new message for the specified recipients.</summary>


### PR DESCRIPTION
## Problem
The `NotifiactionsManager` `SendMessageToRecipients` method that accepts a `templateId` doesn't parse the content type to the Enum correctly.

It does `template.Content.ToDictionary(x => Enum.Parse<MessageChannelKind>(x.Key), x => x.Value)`

## Solution
It should do `template.Content.ToDictionary(x => Enum.Parse<MessageChannelKind>(x.Key, ignoreCase: true), x => x.Value)`

as done in other places (`CampaingsService`, `TemplateService`, `ToCreateCampaignCommand`) inside the Messages project.