### PR TITLE
Add BusinessRegistryOptions.Enabled configuration

### DIFF
--- a/src/Indice.Features.GovGr/CHANGELOG.md
+++ b/src/Indice.Features.GovGr/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- ## [Unreleased] -->
 
+## [Unreleased] 
+### Added
+- `BusinessRegistryOptions.Enabled` option for backwards compatibility with previous installations. Consumers that require Business Registry feature will have to configure this option.
+
+## [7.4.0] - 2023-09-19
+### Added
+- Add Business Registry integration
+
 ## [6.6.0] - 2023-01-30
 - Jumped to 6.6.0 to match other Indice Packages
 

--- a/src/Indice.Features.GovGr/Configuration/ConfigurationExtensions.cs
+++ b/src/Indice.Features.GovGr/Configuration/ConfigurationExtensions.cs
@@ -30,10 +30,12 @@ public static class GovGrKycConfigurationExtensions
         services.AddLocalization();
         services.AddHttpClient();
         services.AddTransient<GovGrClient>();
-        services.AddTransient<RgWsPublic, RgWsPublicClient>(serviceProvider => {
-            var client = new RgWsPublicClient(options.BusinessRegistry);
-            return client;
-        });
+        if (options.BusinessRegistry.Enabled) {
+            services.AddTransient<RgWsPublic, RgWsPublicClient>(sp => {
+                var client = new RgWsPublicClient(options.BusinessRegistry);
+                return client;
+            });
+        }
         services.AddTransient<GovGrKycScopeDescriber>();
         return services;
     }

--- a/src/Indice.Features.GovGr/Configuration/GovGrOptions.cs
+++ b/src/Indice.Features.GovGr/Configuration/GovGrOptions.cs
@@ -66,7 +66,7 @@ public class GovGrOptions
     /// <summary>Business Registry settings</summary>
     public class BusinessRegistryOptions
     {
-        /// <summary>Indicates whether the feature BusinessRegistry feature is enabled. Default value is false.</summary>
+        /// <summary>Indicates whether the BusinessRegistry feature is enabled. Default value is false.</summary>
         public bool Enabled { get; set; } 
         /// <summary>BaseAddress</summary>
         public string BaseAddress { get; set; } = "https://www1.gsis.gr:443/webtax2/wsgsis/RgWsPublic/RgWsPublicPort";

--- a/src/Indice.Features.GovGr/Configuration/GovGrOptions.cs
+++ b/src/Indice.Features.GovGr/Configuration/GovGrOptions.cs
@@ -66,6 +66,8 @@ public class GovGrOptions
     /// <summary>Business Registry settings</summary>
     public class BusinessRegistryOptions
     {
+        /// <summary>Indicates whether the feature BusinessRegistry feature is enabled. Default value is false.</summary>
+        public bool Enabled { get; set; } 
         /// <summary>BaseAddress</summary>
         public string BaseAddress { get; set; } = "https://www1.gsis.gr:443/webtax2/wsgsis/RgWsPublic/RgWsPublicPort";
         /// <summary>Username</summary>


### PR DESCRIPTION
### Added
- `BusinessRegistryOptions.Enabled` option for backwards compatibility with previous installations. Consumers that require Business Registry feature will have to configure this option.