### PR TITLE
Enrich UserNameChangedEvent with previous user state

### DIFF
--- a/src/Indice.Features.Identity.Core/Events/UserNameChangedEvent.cs
+++ b/src/Indice.Features.Identity.Core/Events/UserNameChangedEvent.cs
@@ -9,22 +9,22 @@ public class UserNameChangedEvent<TUser> : IPlatformEvent where TUser : User
 {
     /// <summary>Creates a new instance of <see cref="UserNameChangedEvent{TUser}"/>.</summary>
     /// <param name="user">The user entity.</param>
-    /// <param name="previousUserName">The previous username of the user.</param>
-    public UserNameChangedEvent(TUser user, string previousUserName) {
+    /// <param name="previousUserState">The previous state of the user.</param>
+    public UserNameChangedEvent(TUser user, TUser previousUserState) {
         User = user;
-        PreviousUserName = previousUserName;
+        PreviousUserState = previousUserState;
     }
 
     /// <summary>The user entity.</summary>
     public TUser User { get; }
 
-    /// <summary>The previous username of the user.</summary>
-    public string PreviousUserName { get; }
+    /// <summary>The previous state of the user.</summary>
+    public TUser PreviousUserState { get; }
 }
 
 /// <summary>An event that is raised when a user's username is changed on through <see cref="ExtendedUserManager{TUser}"/>.</summary>
 public class UserNameChangedEvent : UserNameChangedEvent<User>
 {
     /// <summary>Creates a new instance of <see cref="UserNameChangedEvent"/>.</summary>
-    public UserNameChangedEvent(User user, string previousUserName) : base(user, previousUserName) { }
+    public UserNameChangedEvent(User user, User previousUserState) : base(user, previousUserState) { }
 }

--- a/src/Indice.Features.Identity.Core/Events/UserNameChangedEvent.cs
+++ b/src/Indice.Features.Identity.Core/Events/UserNameChangedEvent.cs
@@ -9,15 +9,22 @@ public class UserNameChangedEvent<TUser> : IPlatformEvent where TUser : User
 {
     /// <summary>Creates a new instance of <see cref="UserNameChangedEvent{TUser}"/>.</summary>
     /// <param name="user">The user entity.</param>
-    public UserNameChangedEvent(TUser user) => User = user;
+    /// <param name="previousUserName">The previous username of the user.</param>
+    public UserNameChangedEvent(TUser user, string previousUserName) {
+        User = user;
+        PreviousUserName = previousUserName;
+    }
 
     /// <summary>The user entity.</summary>
     public TUser User { get; }
+
+    /// <summary>The previous username of the user.</summary>
+    public string PreviousUserName { get; }
 }
 
 /// <summary>An event that is raised when a user's username is changed on through <see cref="ExtendedUserManager{TUser}"/>.</summary>
 public class UserNameChangedEvent : UserNameChangedEvent<User>
 {
     /// <summary>Creates a new instance of <see cref="UserNameChangedEvent"/>.</summary>
-    public UserNameChangedEvent(User user) : base(user) { }
+    public UserNameChangedEvent(User user, string previousUserName) : base(user, previousUserName) { }
 }

--- a/src/Indice.Features.Identity.Core/ExtendedUserManager.cs
+++ b/src/Indice.Features.Identity.Core/ExtendedUserManager.cs
@@ -149,9 +149,10 @@ public class ExtendedUserManager<TUser> : UserManager<TUser> where TUser : User
 
     /// <inheritdoc />
     public async override Task<IdentityResult> SetUserNameAsync(TUser user, string userName) {
+        var previousUserName = user.UserName;
         var result = await base.SetUserNameAsync(user, EmailAsUserName ? user.Email : userName);
         if (result.Succeeded) {
-            await _eventService.Publish(new UserNameChangedEvent(user));
+            await _eventService.Publish(new UserNameChangedEvent(user, previousUserName));
         }
         return result;
     }

--- a/src/Indice.Features.Identity.Core/ExtendedUserManager.cs
+++ b/src/Indice.Features.Identity.Core/ExtendedUserManager.cs
@@ -149,10 +149,10 @@ public class ExtendedUserManager<TUser> : UserManager<TUser> where TUser : User
 
     /// <inheritdoc />
     public async override Task<IdentityResult> SetUserNameAsync(TUser user, string userName) {
-        var previousUserName = user.UserName;
+        var previousUserState = user;
         var result = await base.SetUserNameAsync(user, EmailAsUserName ? user.Email : userName);
         if (result.Succeeded) {
-            await _eventService.Publish(new UserNameChangedEvent(user, previousUserName));
+            await _eventService.Publish(new UserNameChangedEvent(user, previousUserState));
         }
         return result;
     }


### PR DESCRIPTION
Add support for accessing the previous user state in the `UserNameChangedEvent `.