### PR TITLE
Fix messages admin endpoint swagger

### DIFF
--- a/src/Indice.Features.Messages.Core/Services/Validators/CreateCampaignRequestValidator.cs
+++ b/src/Indice.Features.Messages.Core/Services/Validators/CreateCampaignRequestValidator.cs
@@ -16,7 +16,8 @@ public class CreateCampaignRequestValidator : CampaignRequestValidator<CreateCam
         RuleFor(campaign => campaign)
             .Must(campaign => campaign.RecipientIds?.Count > 0 || campaign.RecipientListId.HasValue || campaign.Recipients?.Count > 0)
             .When(campaign => !campaign.IsGlobal)
-            .WithMessage("Please provide recipientIds, recipientListId or recipients property.");
+            .WithMessage("Please provide recipientIds, recipientListId or recipients property.")
+            .OverridePropertyName("RecipientIds");
 
     }
 }


### PR DESCRIPTION
Fixes the swagger generation error for the messages admin endpoint `CreateCampaign` by assigning a key to the rule that was for the entire model and not for a specific property in the `CampaignRequestValidator<CreateCampaignRequest>`.