### PR TITLE
Greek translation fix in register email template.

### DIFF
--- a/src/Indice.Features.Identity.UI/Resources/Pages/Shared/EmailRegister.el.resx
+++ b/src/Indice.Features.Identity.UI/Resources/Pages/Shared/EmailRegister.el.resx
@@ -133,7 +133,7 @@
     <value>Ευχαριστούμε</value>
   </data>
   <data name="to get verified" xml:space="preserve">
-    <value>το επιβεβαιώσετε</value>
+    <value>για να το επιβεβαιώσετε</value>
   </data>
   <data name="We need you to verify your email. Please click" xml:space="preserve">
     <value>Πρέπει να επιβεβαιώσουμε το λογαριασμό email σας. Παρακαλώ πατήστε</value>


### PR DESCRIPTION
Αλλαγή λεκτικού στο EmailRegister template γιατί το κείμενο ερχόταν ως εξής:

![image](https://github.com/indice-co/Indice.AspNet/assets/25502619/9c9f7112-0a34-442a-9d28-160229aaee44)

