### PR TITLE
Change default behaviour of Elsa CleanUpOptions

### DIFF
--- a/src/Indice.Features.Cases.AspNetCore/CHANGELOG.md
+++ b/src/Indice.Features.Cases.AspNetCore/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Default behaviour for Elsa CleanUp options set to `true`. Check version `7.7.0` for more.
+
+#### Action required
+If you want the default retention policy to be ignored, make sure you have the following configuration
+```json
+{
+    "Elsa":{
+        "CleanUpOptions": {
+            "Enabled": false            
+        }
+    }
+}
+```
+
 ## [7.14.1] - 2023-12-22
 ### Bugfix
 - GetMyCases now properly paginates when there is CaseData filter.

--- a/src/Indice.Features.Cases.AspNetCore/CasesApiFeatureExtensions.cs
+++ b/src/Indice.Features.Cases.AspNetCore/CasesApiFeatureExtensions.cs
@@ -228,7 +228,7 @@ public static class CasesApiFeatureExtensions
         });
 
         var cleanUpOptions = configuration.GetSection("Elsa").GetSection("CleanUpOptions");
-        if (cleanUpOptions.GetSection("Enabled").Get<bool?>() ?? false) {
+        if (cleanUpOptions.GetSection("Enabled").Get<bool?>() ?? true) {
             services.AddRetentionServices(options => {
                 options.BatchSize = cleanUpOptions.GetSection("BatchSize").Get<int?>() ?? 100;
                 options.TimeToLive = Duration.FromDays(cleanUpOptions.GetSection("TimeToLiveInDays").Get<int?>() ?? 30);


### PR DESCRIPTION
The default behaviour will clean up completed wf instances when their age is 30 days or more.