### PR TITLE
Feature/case management/upload attachment file extension handling

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,7 +6,7 @@
       <VersionPrefixCore>$(VersionPrefixBase).0</VersionPrefixCore>
       <VersionPrefixIdentity>$(VersionPrefixBase).0</VersionPrefixIdentity>
       <VersionPrefixIdentityUI>$(VersionPrefixBase).0</VersionPrefixIdentityUI>
-      <VersionPrefixCases>$(VersionPrefixBase).2</VersionPrefixCases>
+      <VersionPrefixCases>$(VersionPrefixBase).3</VersionPrefixCases>
       <VersionPrefixMessages>$(VersionPrefixBase).0</VersionPrefixMessages>
       <VersionPrefixMultitenancy>$(VersionPrefixBase).0</VersionPrefixMultitenancy>
       <VersionPrefixRisk>$(VersionPrefixBase).0</VersionPrefixRisk>

--- a/src/Indice.Features.Cases.AspNetCore/CHANGELOG.md
+++ b/src/Indice.Features.Cases.AspNetCore/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.18.3] - 2024-01-19
+### Added
+`PermittedAttachmentFileExtensions` config property in `CasesApiOptions` (base, `AdminCasesApiOptions` or `MyCasesApiOptions`) which specifies the permitted file extensions to check when uploading an attachment to an existing case. Can be configured via `appsettings` level.
+
+#### Default values:
+```
+".pdf", ".jpeg", ".jpg", ".tif", ".tiff"
+```
+
+### Changed
+- Replaced hardcoded file extension checks in `UploadAdminCaseAttachment` of `AdminCasesController` to use the new `PermittedAttachmentFileExtensions`.
+- **Breaking change:** Added file extension checks in `UploadCaseAttachment` of `MyCasesController` to use the new `PermittedAttachmentFileExtensions`.
+- If no `PermittedAttachmentFileExtensions` are provided in project level, the default values will be used.
+- In case of failure, `400 Bad Request` will be returned.
+
+#### Action required
+If you want to set dedicated file extension rules on your project, make sure you have the following example configuration in the options of your preference (`CasesApiOptions`, `AdminCasesApiOptions` or/and `MyCasesApiOptions`)
+### AdminCasesApiOptions Example
+```json
+{
+    "AdminCasesApiOptions": {
+      "PermittedAttachmentFileExtensions": [ ".pdf", ".txt" ]
+    }
+}
+```
+
 ## [7.18.2] - 2024-01-18
 ### Bugfix
 - Fix startup crashing when case management did not have `Elsa:Server:BaseUrl` and `Elsa:Server:BasePath` app settings configured.

--- a/src/Indice.Features.Cases.AspNetCore/CasesApiConstants.cs
+++ b/src/Indice.Features.Cases.AspNetCore/CasesApiConstants.cs
@@ -33,6 +33,9 @@ public static class CasesApiConstants
     /// <summary>The default name for the ReferenceNumber sequence.</summary>
     public const string ReferenceNumberSequence = "ReferenceNumberSequence";
 
+    /// <summary>The default permitted file extensions to check when uploading an attachment to an existing case.</summary>
+    public static IReadOnlyCollection<string> DefaultPermittedAttachmentFileExtensions = new HashSet<string> { ".pdf", ".jpeg", ".jpg", ".tif", ".tiff" };
+
     /// <summary>Cases API policies.</summary>
     public static class Policies
     {

--- a/src/Indice.Features.Cases.AspNetCore/CasesApiFeatureExtensions.cs
+++ b/src/Indice.Features.Cases.AspNetCore/CasesApiFeatureExtensions.cs
@@ -134,6 +134,7 @@ public static class CasesApiFeatureExtensions
             options.UserClaimType = casesApiOptions.UserClaimType;
             options.GroupIdClaimType = casesApiOptions.GroupIdClaimType;
             options.GroupName = casesApiOptions.GroupName;
+            options.PermittedAttachmentFileExtensions = casesApiOptions.PermittedAttachmentFileExtensions;
         }).AddSingleton(casesApiOptions);
 
         // Post configure MVC options.

--- a/src/Indice.Features.Cases.AspNetCore/CasesApiFeatureExtensions.cs
+++ b/src/Indice.Features.Cases.AspNetCore/CasesApiFeatureExtensions.cs
@@ -3,7 +3,6 @@ using Elsa;
 using Elsa.Activities.Http.Services;
 using Elsa.Activities.UserTask.Extensions;
 using Elsa.Persistence.EntityFramework.Core.Extensions;
-using Elsa.Persistence.Specifications;
 using Elsa.Retention.Contracts;
 using Elsa.Retention.Extensions;
 using Elsa.Retention.Specifications;
@@ -66,6 +65,7 @@ public static class CasesApiFeatureExtensions
             options.UserClaimType = casesApiOptions.UserClaimType;
             options.GroupIdClaimType = casesApiOptions.GroupIdClaimType;
             options.GroupName = casesApiOptions.GroupName;
+            options.PermittedAttachmentFileExtensions = casesApiOptions.PermittedAttachmentFileExtensions ?? options.PermittedAttachmentFileExtensions;
         }).AddSingleton(casesApiOptions);
 
         // Post configure MVC options.
@@ -134,7 +134,7 @@ public static class CasesApiFeatureExtensions
             options.UserClaimType = casesApiOptions.UserClaimType;
             options.GroupIdClaimType = casesApiOptions.GroupIdClaimType;
             options.GroupName = casesApiOptions.GroupName;
-            options.PermittedAttachmentFileExtensions = casesApiOptions.PermittedAttachmentFileExtensions;
+            options.PermittedAttachmentFileExtensions = casesApiOptions.PermittedAttachmentFileExtensions ?? options.PermittedAttachmentFileExtensions;
         }).AddSingleton(casesApiOptions);
 
         // Post configure MVC options.

--- a/src/Indice.Features.Cases.AspNetCore/CasesApiOptions.cs
+++ b/src/Indice.Features.Cases.AspNetCore/CasesApiOptions.cs
@@ -32,6 +32,9 @@ public abstract class CasesApiOptions
 
     /// <summary>Enables the Case `ReferenceNumber` feature. Defaults to <see langword="false"/>.</summary>
     public bool ReferenceNumberEnabled { get; set; }
+
+    /// <summary>Specifies the permitted file extensions to check when uploading an attachment to an existing case.</summary>
+    public IReadOnlyCollection<string> PermittedAttachmentFileExtensions { get; set; } = CasesApiConstants.DefaultPermittedAttachmentFileExtensions;
 }
 
 /// <summary>

--- a/src/Indice.Features.Cases.AspNetCore/Controllers/AdminCasesController.cs
+++ b/src/Indice.Features.Cases.AspNetCore/Controllers/AdminCasesController.cs
@@ -89,7 +89,9 @@ internal class AdminCasesController : ControllerBase
         }
         var fileExtension = Path.GetExtension(file.FileName)?.ToLowerInvariant();
         if (!_options.PermittedAttachmentFileExtensions.Contains(fileExtension)) {
-            throw new Exception("File type is not acceptable.");
+            return BadRequest(new ValidationProblemDetails(new Dictionary<string, string[]> {
+                { $"{nameof(fileExtension)}", new[] { "File type extension is not acceptable." } }
+            }));
         }
         var attachmentId = await _adminCaseMessageService.Send(caseId, User, new Message { File = file });
         return Ok(new CasesAttachmentLink { Id = attachmentId.GetValueOrDefault() });

--- a/src/Indice.Features.Cases.AspNetCore/Controllers/MyCasesController.cs
+++ b/src/Indice.Features.Cases.AspNetCore/Controllers/MyCasesController.cs
@@ -8,6 +8,7 @@ using Indice.Types;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 
 namespace Indice.Features.Cases.Controllers;
 
@@ -28,18 +29,21 @@ internal class MyCasesController : ControllerBase
     private readonly ICasePdfService _casePdfService;
     private readonly ICaseEventService _caseEventService;
     private readonly IMyCaseMessageService _caseMessageService;
+    private readonly MyCasesApiOptions _options;
 
     public MyCasesController(
         IMyCaseService myCaseService,
         ICaseTemplateService caseTemplateService,
         ICasePdfService casePdfService,
         IMyCaseMessageService caseMessageService,
-        ICaseEventService caseEventService) {
+        ICaseEventService caseEventService,
+        IOptions<MyCasesApiOptions> options) {
         _myCaseService = myCaseService ?? throw new ArgumentNullException(nameof(myCaseService));
         _caseTemplateService = caseTemplateService ?? throw new ArgumentNullException(nameof(caseTemplateService));
         _casePdfService = casePdfService ?? throw new ArgumentNullException(nameof(casePdfService));
         _caseMessageService = caseMessageService ?? throw new ArgumentNullException(nameof(caseMessageService));
         _caseEventService = caseEventService ?? throw new ArgumentNullException(nameof(caseEventService));
+        _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
     }
 
     /// <summary>Get the list of the customer's cases.</summary>
@@ -89,6 +93,12 @@ internal class MyCasesController : ControllerBase
         if (file == null) {
             ModelState.AddModelError(nameof(file), "File is empty.");
             return BadRequest(new ValidationProblemDetails(ModelState));
+        }
+        var fileExtension = Path.GetExtension(file.FileName)?.ToLowerInvariant();
+        if (!_options.PermittedAttachmentFileExtensions.Contains(fileExtension)) {
+            return BadRequest(new ValidationProblemDetails(new Dictionary<string, string[]> {
+                { $"{nameof(fileExtension)}", new[] { "File type extension is not acceptable." } }
+            }));
         }
         var attachmentId = await _caseMessageService.Send(caseId, User, new Message { File = file });
         return Ok(new CasesAttachmentLink { Id = attachmentId.GetValueOrDefault() });


### PR DESCRIPTION
Adds **PermittedAttachmentFileExtensions** config property in **CasesApiOptions** (base, **AdminCasesApiOptions** or **MyCasesApiOptions**) which specifies the permitted file extensions to check when uploading an attachment to an existing case. 

- Replaces hardcoded file extension checks in **UploadAdminCaseAttachment** of **AdminCasesController** to use the new **PermittedAttachmentFileExtensions**.
- **Breaking change:** Adds file extension checks in **UploadCaseAttachment** of **MyCasesController** to use the new **PermittedAttachmentFileExtensions**.
- If no **PermittedAttachmentFileExtensions** are provided in project level, the default values will be used.
- In case of failure, **400 Bad Request** will be returned.