### PR TITLE
Add UsernameHistory feature in Identity

### DIFF
--- a/src/Indice.Features.Identity.Core/Constants.cs
+++ b/src/Indice.Features.Identity.Core/Constants.cs
@@ -87,4 +87,6 @@ public class IdentityServerFeatures
     public const string SignInLogs = nameof(SignInLogs);
     /// <summary>Impossible travel.</summary>
     public const string ImpossibleTravel = nameof(ImpossibleTravel);
+    /// <summary>Username changes history.</summary>
+    public const string UsernameHistory = nameof(UsernameHistory);
 }

--- a/src/Indice.Features.Identity.Core/Data/IdentityDbContext.cs
+++ b/src/Indice.Features.Identity.Core/Data/IdentityDbContext.cs
@@ -34,6 +34,8 @@ public class IdentityDbContext<TUser, TRole> : IdentityDbContext<TUser, TRole, s
     public DbSet<UserDevice> UserDevices { get; set; }
     /// <summary>Application settings stored in the database.</summary>
     public DbSet<DbAppSetting> AppSettings { get; set; }
+    /// <summary>Stores all previous usernames of a user for auditing purposes.</summary>
+    public DbSet<UserUsername> UserUsernameHistory { get; set; }
 
     /// <summary>Configures schema needed for the Identity framework.</summary>
     /// <param name="builder">Class used to create and apply a set of data model conventions.</param>
@@ -45,6 +47,7 @@ public class IdentityDbContext<TUser, TRole> : IdentityDbContext<TUser, TRole, s
         builder.Entity<IdentityUserRole<string>>().ToTable("UserRole", "auth");
         builder.Entity<IdentityUserToken<string>>().ToTable("UserToken", "auth");
         builder.Entity<IdentityUserLogin<string>>().ToTable("UserLogin", "auth");
+        builder.ApplyConfiguration(new UserUsernameMap<TUser>());
         builder.ApplyConfiguration(new UserMap<TUser>());
         builder.ApplyConfiguration(new UserPasswordMap<TUser>());
         builder.ApplyConfiguration(new UserDeviceMap<TUser>());

--- a/src/Indice.Features.Identity.Core/Data/Mappings/UserUsernameMap.cs
+++ b/src/Indice.Features.Identity.Core/Data/Mappings/UserUsernameMap.cs
@@ -1,0 +1,18 @@
+﻿using Indice.Features.Identity.Core.Data.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Indice.Features.Identity.Core.Data.Mappings;
+
+internal class UserUsernameMap<TUser> : IEntityTypeConfiguration<UserUsername> where TUser : User
+{
+    public void Configure(EntityTypeBuilder<UserUsername> builder) {
+        builder.ToTable(nameof(UserUsername), "auth");
+        builder.HasKey(x => x.Id);
+        builder
+            .HasOne<TUser>()
+            .WithMany()
+            .HasForeignKey(x => x.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/Indice.Features.Identity.Core/Data/Models/UserUsername.cs
+++ b/src/Indice.Features.Identity.Core/Data/Models/UserUsername.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Indice.Features.Identity.Core.Data.Models;
+
+/// <summary>
+/// Represents a username changelog entry for auditing purposes
+/// </summary>
+public class UserUsername
+{
+    /// <summary>Constructs a new instance of <see cref="UserUsername"/> with a new Guid Id.</summary>
+    public UserUsername() {
+        Id = Guid.NewGuid();
+    }
+
+    /// <summary>
+    /// Primary key
+    /// </summary>
+    public Guid Id { get; set; }
+    /// <summary>
+    /// The Id of the related user
+    /// </summary>
+    public string UserId { get; set; }
+    /// <summary>
+    /// Previous username used by the related user
+    /// </summary>
+    public string PreviousUsername { get; set; }
+    /// <summary>
+    /// The date of the username change event
+    /// </summary>
+    public DateTimeOffset DateCreated { get; set; }
+}

--- a/src/Indice.Features.Identity.Core/Data/Stores/ExtendedUserStore.cs
+++ b/src/Indice.Features.Identity.Core/Data/Stores/ExtendedUserStore.cs
@@ -223,4 +223,19 @@ public class ExtendedUserStore<TContext, TUser, TRole> : UserStore<TUser, TRole,
         }
         return IdentityResult.Success;
     }
+
+    /// <inheritdoc/>
+    public async Task SetUsernameChangeAsync(TUser user, string previousUsername, DateTimeOffset dateCreated, CancellationToken cancellationToken = default) {
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+
+        await Context.Set<UserUsername>()
+            .AddAsync(new UserUsername {
+                UserId = user.Id,
+                DateCreated = dateCreated,
+                PreviousUsername = previousUsername
+            }, cancellationToken);
+
+        await SaveChanges(cancellationToken);
+    }
 }

--- a/src/Indice.Features.Identity.Core/Data/Stores/IExtendedUserStore.cs
+++ b/src/Indice.Features.Identity.Core/Data/Stores/IExtendedUserStore.cs
@@ -32,4 +32,13 @@ public interface IExtendedUserStore<TUser> where TUser : User
     /// <param name="timestamp">The <see cref="DateTimeOffset"/> value that the user signed in. Defaults to <see cref="DateTimeOffset.UtcNow"/>.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled.</param>
     Task SetLastSignInDateAsync(TUser user, DateTimeOffset? timestamp, CancellationToken cancellationToken);
+    /// <summary>
+    /// Sets the previous username in history for the specified user
+    /// </summary>
+    /// <param name="user"></param>
+    /// <param name="previousUsername"></param>
+    /// <param name="dateCreated"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    Task SetUsernameChangeAsync(TUser user, string previousUsername, DateTimeOffset dateCreated, CancellationToken cancellationToken = default);
 }


### PR DESCRIPTION
## What is this feature about?
This feature introduces an optional table for tracking username changes across users, based on the UserId.
It functions as a username changelog history, for auditing purposes.

## How to enable it?
You need to configure it like this:
```
"IdentityServer": {
  "Features": {
    "UsernameHistory": true
  }
}
```

## SQL script for manual migration (if needed)
```
SET ANSI_NULLS ON
GO

SET QUOTED_IDENTIFIER ON
GO

CREATE TABLE [auth].[UserUsername](
	[Id] [uniqueidentifier] NOT NULL,
	[UserId] [nvarchar](450) NULL,
	[PreviousUsername] [nvarchar](max) NULL,
	[DateCreated] [datetimeoffset](7) NOT NULL,
 CONSTRAINT [PK_UserUsername] PRIMARY KEY CLUSTERED 
(
	[Id] ASC
)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON, OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF) ON [PRIMARY]
) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
GO

ALTER TABLE [auth].[UserUsername]  WITH CHECK ADD  CONSTRAINT [FK_UserUsername_User_UserId] FOREIGN KEY([UserId])
REFERENCES [auth].[User] ([Id])
ON DELETE CASCADE
GO

ALTER TABLE [auth].[UserUsername] CHECK CONSTRAINT [FK_UserUsername_User_UserId]
GO
```
