### PR TITLE
Feature/case management/introduce label only cases app widget

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,7 +6,7 @@
       <VersionPrefixCore>$(VersionPrefixBase).0</VersionPrefixCore>
       <VersionPrefixIdentity>$(VersionPrefixBase).0</VersionPrefixIdentity>
       <VersionPrefixIdentityUI>$(VersionPrefixBase).0</VersionPrefixIdentityUI>
-      <VersionPrefixCases>$(VersionPrefixBase).0</VersionPrefixCases>
+      <VersionPrefixCases>$(VersionPrefixBase).1</VersionPrefixCases>
       <VersionPrefixMessages>$(VersionPrefixBase).0</VersionPrefixMessages>
       <VersionPrefixMultitenancy>$(VersionPrefixBase).0</VersionPrefixMultitenancy>
       <VersionPrefixRisk>$(VersionPrefixBase).0</VersionPrefixRisk>

--- a/src/Indice.Features.Cases.App/src/app/features/cases/case-detail-page/case-form/case-form.component.ts
+++ b/src/Indice.Features.Cases.App/src/app/features/cases/case-detail-page/case-form/case-form.component.ts
@@ -18,6 +18,7 @@ import { FileWidgetComponent } from 'src/app/shared/ajsf/json-schema-frameworks/
 import { LookupSelectorWidgetComponent } from 'src/app/shared/ajsf/json-schema-frameworks/tailwind-framework/lookup-selector-widget/lookup-selector-widget.component';
 import { WysiwygWidgetComponent } from 'src/app/shared/ajsf/json-schema-frameworks/tailwind-framework/wysiwyg-widget/wysiwyg-widget.component';
 import { HrefWidgetComponent } from 'src/app/shared/ajsf/json-schema-frameworks/tailwind-framework/href-widget/href-widget.component';
+import { LabelOnlyComponent } from 'src/app/shared/ajsf/json-schema-frameworks/tailwind-framework/label-only/label-only.component';
 
 @Component({
   selector: 'app-case-form',
@@ -47,7 +48,8 @@ export class CaseFormComponent implements OnChanges, OnInit, OnDestroy {
     "number": InputWidgetComponent,
     "textarea": TextAreaWidgetComponent,
     "wysiwyg": WysiwygWidgetComponent,
-    "href": HrefWidgetComponent
+    "href": HrefWidgetComponent,
+    "label-only": LabelOnlyComponent
   };
   // Add custom framework
   public framework = {

--- a/src/Indice.Features.Cases.App/src/app/shared/ajsf/json-schema-frameworks/tailwind-framework/label-only/label-only.component.html
+++ b/src/Indice.Features.Cases.App/src/app/shared/ajsf/json-schema-frameworks/tailwind-framework/label-only/label-only.component.html
@@ -7,6 +7,6 @@
         [innerHTML]="options?.title">
     </h2>
     <div class="mt-1">
-        <p>{{ controlValue }}</p>
+        <p>{{ displayValue }}</p>
     </div>
 </div>

--- a/src/Indice.Features.Cases.App/src/app/shared/ajsf/json-schema-frameworks/tailwind-framework/label-only/label-only.component.html
+++ b/src/Indice.Features.Cases.App/src/app/shared/ajsf/json-schema-frameworks/tailwind-framework/label-only/label-only.component.html
@@ -1,6 +1,6 @@
 <div [class]="options?.htmlClass || ''">
     <h2 *ngIf="options?.title"
-        class="block text-sm bold-label"
+        class="block text-sm"
         [attr.for]="'control' + layoutNode?._id"
         [class]="options?.labelHtmlClass || ''"
         [style.display]="options?.notitle ? 'none' : ''"

--- a/src/Indice.Features.Cases.App/src/app/shared/ajsf/json-schema-frameworks/tailwind-framework/label-only/label-only.component.html
+++ b/src/Indice.Features.Cases.App/src/app/shared/ajsf/json-schema-frameworks/tailwind-framework/label-only/label-only.component.html
@@ -1,0 +1,12 @@
+<div [class]="options?.htmlClass || ''">
+    <h2 *ngIf="options?.title"
+        class="block text-sm bold-label"
+        [attr.for]="'control' + layoutNode?._id"
+        [class]="options?.labelHtmlClass || ''"
+        [style.display]="options?.notitle ? 'none' : ''"
+        [innerHTML]="options?.title">
+    </h2>
+    <div class="mt-1">
+        <p>{{ controlValue }}</p>
+    </div>
+</div>

--- a/src/Indice.Features.Cases.App/src/app/shared/ajsf/json-schema-frameworks/tailwind-framework/label-only/label-only.component.scss
+++ b/src/Indice.Features.Cases.App/src/app/shared/ajsf/json-schema-frameworks/tailwind-framework/label-only/label-only.component.scss
@@ -1,0 +1,3 @@
+.bold-label {
+    font-weight: bold;
+}

--- a/src/Indice.Features.Cases.App/src/app/shared/ajsf/json-schema-frameworks/tailwind-framework/label-only/label-only.component.scss
+++ b/src/Indice.Features.Cases.App/src/app/shared/ajsf/json-schema-frameworks/tailwind-framework/label-only/label-only.component.scss
@@ -1,3 +1,3 @@
-.bold-label {
-    font-weight: bold;
+h2 {
+    margin-top: 20px;
 }

--- a/src/Indice.Features.Cases.App/src/app/shared/ajsf/json-schema-frameworks/tailwind-framework/label-only/label-only.component.spec.ts
+++ b/src/Indice.Features.Cases.App/src/app/shared/ajsf/json-schema-frameworks/tailwind-framework/label-only/label-only.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LabelOnlyComponent } from './label-only.component';
+
+describe('LabelOnlyComponent', () => {
+  let component: LabelOnlyComponent;
+  let fixture: ComponentFixture<LabelOnlyComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ LabelOnlyComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(LabelOnlyComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/Indice.Features.Cases.App/src/app/shared/ajsf/json-schema-frameworks/tailwind-framework/label-only/label-only.component.ts
+++ b/src/Indice.Features.Cases.App/src/app/shared/ajsf/json-schema-frameworks/tailwind-framework/label-only/label-only.component.ts
@@ -1,6 +1,20 @@
 import { JsonSchemaFormService } from '@ajsf-extended/core';
 import { Component, Input, OnInit } from '@angular/core';
 
+/**
+ * Cases UI widget component for usage in Layout.json.
+ * Displays form input data as a simple label.
+ * 
+ * @example
+ * ```
+  {
+    "title": "Πεδίο",
+    "labelHtmlClass": "font-bold",
+    "type": "label-only",
+    "flex": "1 1 50px"
+  },
+ * ```
+ */
 @Component({
   selector: 'app-label-only',
   templateUrl: './label-only.component.html',
@@ -25,5 +39,50 @@ export class LabelOnlyComponent implements OnInit {
   ngOnInit() {
     this.options = this.layoutNode.options || {};
     this.jsf.initializeControl(this);
+    this.trySetEnumType();
+    this.trySetCurrencyType();
+  }
+
+  /**
+ * Configures label to be in currency format if passed as extraType option
+ * 
+ * @example
+ * ```
+  {
+    "key": "amount",
+    "labelHtmlClass": "font-bold",
+    "type": "label-only",
+    "extraType": "currency",
+    "flex": "1 1 280px",
+    "title": "Αμοθντ"
+  }
+ * ```
+ */
+  private trySetCurrencyType() {
+    if (this.layoutNode.options.extraType == 'currency') {
+      this.controlValue = parseFloat(this.formControl.value).toLocaleString('el');
+      this.jsf.updateValue(this, this.controlValue);
+    }
+  }
+
+  /** Attempts to set enumeration to corresponding values if exist*/
+  private trySetEnumType() {
+    if (this.hasEnumType()) {
+      (this.options.enum as string[]).forEach((enumValue, index) => {
+        if (this.controlValue === enumValue) {
+          this.controlValue = this.options.enumNames[index];
+          this.jsf.updateValue(this, this.controlValue);
+        }
+      });
+    }
+  }
+
+/** Checks whether layoutNode contains enumeration values */
+  private hasEnumType(): boolean {
+    return this.options.enum &&
+      this.options.enumNames &&
+      Array.isArray(this.options.enum) &&
+      Array.isArray(this.options.enumNames) &&
+      this.options.enum.length === this.options.enumNames.length;
   }
 }

--- a/src/Indice.Features.Cases.App/src/app/shared/ajsf/json-schema-frameworks/tailwind-framework/label-only/label-only.component.ts
+++ b/src/Indice.Features.Cases.App/src/app/shared/ajsf/json-schema-frameworks/tailwind-framework/label-only/label-only.component.ts
@@ -1,0 +1,29 @@
+import { JsonSchemaFormService } from '@ajsf-extended/core';
+import { Component, Input, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-label-only',
+  templateUrl: './label-only.component.html',
+  styleUrls: ['./label-only.component.scss']
+})
+export class LabelOnlyComponent implements OnInit {
+  formControl: any;
+  controlName: string | undefined;
+  controlValue: string | undefined;
+  controlDisabled = false;
+  boundControl = false;
+  options: any;
+  autoCompleteList: string[] = [];
+  @Input() layoutNode: any;
+  @Input() layoutIndex: number[] = [];
+  @Input() dataIndex: number[] = [];
+
+  constructor(
+    private jsf: JsonSchemaFormService
+  ) { }
+
+  ngOnInit() {
+    this.options = this.layoutNode.options || {};
+    this.jsf.initializeControl(this);
+  }
+}

--- a/src/Indice.Features.Cases.App/src/app/shared/ajsf/json-schema-frameworks/tailwind-framework/label-only/label-only.component.ts
+++ b/src/Indice.Features.Cases.App/src/app/shared/ajsf/json-schema-frameworks/tailwind-framework/label-only/label-only.component.ts
@@ -8,7 +8,7 @@ import { Component, Input, OnInit } from '@angular/core';
  * @example
  * ```
   {
-    "title": "Πεδίο",
+    "title": "Field",
     "labelHtmlClass": "font-bold",
     "type": "label-only",
     "flex": "1 1 50px"
@@ -54,7 +54,7 @@ export class LabelOnlyComponent implements OnInit {
     "type": "label-only",
     "extraType": "currency",
     "flex": "1 1 280px",
-    "title": "Αμοθντ"
+    "title": "Amount"
   }
  * ```
  */

--- a/src/Indice.Features.Cases.App/src/app/shared/ajsf/json-schema-frameworks/tailwind-framework/tailwind-framework.component.ts
+++ b/src/Indice.Features.Cases.App/src/app/shared/ajsf/json-schema-frameworks/tailwind-framework/tailwind-framework.component.ts
@@ -254,6 +254,9 @@ export class TailwindFrameworkComponent implements OnInit, OnChanges {
       case 'fieldset':
         this.widgetOptions.title = this.options.title;
         return null;
+      case 'label-only':
+        this.widgetOptions.title = this.options.title;
+        return null;
       default:
         this.widgetOptions.title = null;
         return this.jsf.setItemTitle(this);

--- a/src/Indice.Features.Cases.App/src/app/shared/ajsf/json-schema-frameworks/tailwind-framework/tailwind-framework.component.ts
+++ b/src/Indice.Features.Cases.App/src/app/shared/ajsf/json-schema-frameworks/tailwind-framework/tailwind-framework.component.ts
@@ -173,6 +173,13 @@ export class TailwindFrameworkComponent implements OnInit, OnChanges {
           break;
         // Containers - arrays and fieldsets
         case 'array':
+          this.options.messageLocation = 'top';
+          if (this.widgetOptions.readonly) {
+            this.widgetOptions.addable = false;
+            this.widgetOptions.orderable = false;
+            this.widgetOptions.removable = false;
+          }
+          break;
         case 'fieldset':
         case 'section':
         case 'conditional':
@@ -193,6 +200,13 @@ export class TailwindFrameworkComponent implements OnInit, OnChanges {
           break;
         // 'Add' buttons - references
         case '$ref':
+          // Apply max items on parent readonly array.
+          // This will disable Add button from showing up.
+          var parentNode = this.jsf.getParentNode(this);
+          if (parentNode?.type == 'array' && parentNode?.options?.readonly) {
+            this.widgetOptions.maxItems = parentNode.options.listItems;
+            break;
+          }
           this.widgetOptions.fieldHtmlClass = addClasses(
             this.widgetOptions.fieldHtmlClass, 'btn btn-info float-right m-2');
           this.widgetOptions.fieldHtmlClass = addClasses(
@@ -256,6 +270,7 @@ export class TailwindFrameworkComponent implements OnInit, OnChanges {
         return null;
       case 'label-only':
         this.widgetOptions.title = this.options.title;
+        this.widgetOptions.extraType = this.options.extraType;
         return null;
       default:
         this.widgetOptions.title = null;

--- a/src/Indice.Features.Cases.App/src/app/shared/shared.module.ts
+++ b/src/Indice.Features.Cases.App/src/app/shared/shared.module.ts
@@ -30,8 +30,7 @@ import { WysiwygWidgetComponent } from './ajsf/json-schema-frameworks/tailwind-f
 import { DeleteQueryModalComponent } from './components/delete-query-modal/delete-query-modal.component';
 import { TranslateModule } from '@ngx-translate/core';
 import { HrefWidgetComponent } from './ajsf/json-schema-frameworks/tailwind-framework/href-widget/href-widget.component';
-
-
+import { LabelOnlyComponent } from './ajsf/json-schema-frameworks/tailwind-framework/label-only/label-only.component';
 
 @NgModule({
   declarations: [
@@ -59,6 +58,7 @@ import { HrefWidgetComponent } from './ajsf/json-schema-frameworks/tailwind-fram
     LookupSelectorWidgetComponent,
     WysiwygWidgetComponent,
     HrefWidgetComponent,
+    LabelOnlyComponent,
     // pipes
     BeautifyBooleanPipe
   ],

--- a/src/Indice.Features.Cases.UI/CHANGELOG.md
+++ b/src/Indice.Features.Cases.UI/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.19.1] - 2024-02-14
+### Added
+- `label-only` widget component to handle form input data as a simple label in cases BackOffice. Supports _enum_, _currency_ & _bool_ type conversions.
+- **Disables** Add button from _readonly array_ types & other improvements.
+
 ## [7.4.1] - 2023-08-29
 ### Added
 - `href` widget component to handle links in cases backoffice.

--- a/src/Indice.Features.Cases.UI/CHANGELOG.md
+++ b/src/Indice.Features.Cases.UI/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [7.19.1] - 2024-02-14
+## [7.20.1] - 2024-02-14
 ### Added
 - `label-only` widget component to handle form input data as a simple label in cases BackOffice. Supports _enum_, _currency_ & _bool_ type conversions.
 - **Disables** Add button from _readonly array_ types & other improvements.


### PR DESCRIPTION
- **New** Cases UI widget component (**label-only**) for usage in _Layout.json_. Displays form input data as a simple label. Supports enum & currency type conversions.
- **Disables** _Add button_ from _readonly_ array types in Cases UI.
- Other _readonly_ array type improvements.