### PR TITLE
Make ApifonIM service supports only Viber

### DIFF
--- a/src/Indice.Services/SmsServiceApifon.cs
+++ b/src/Indice.Services/SmsServiceApifon.cs
@@ -163,6 +163,8 @@ internal class ApifonResponse
 
 internal class ApifonRequest
 {
+    public ApifonRequest() { }
+
     public ApifonRequest(string from, string[] to, string message) {
         foreach (var subNumber in to) {
             Subscribers.Add(new Subscriber { To = subNumber });

--- a/src/Indice.Services/SmsServiceApifon.cs
+++ b/src/Indice.Services/SmsServiceApifon.cs
@@ -65,7 +65,7 @@ public class SmsServiceApifon : ISmsService
             throw new ArgumentException("Invalid recipients. Recipients cannot contain letters.", nameof(recipients));
         }
         // https://docs.apifon.com/apireference.html#sms-request
-        var payload = new ApifonRequest(sender?.Id ?? Settings.Sender ?? Settings.SenderName!, recipients, body!);
+        var payload = ApifonRequest.Create(sender?.Id ?? Settings.Sender ?? Settings.SenderName!, recipients, body!);
         var signature = payload.Sign(Settings.ApiKey!, HttpMethod.Post.ToString(), "/services/api/v1/sms/send");
         var request = new HttpRequestMessage {
             Content = new StringContent(payload.ToJson(), Encoding.UTF8, "application/json"),
@@ -163,14 +163,14 @@ internal class ApifonResponse
 
 internal class ApifonRequest
 {
-    public ApifonRequest() { }
-
-    public ApifonRequest(string from, string[] to, string message) {
+    public static ApifonRequest Create(string from, string[] to, string message) {
+        var request = new ApifonRequest();
         foreach (var subNumber in to) {
-            Subscribers.Add(new Subscriber { To = subNumber });
+            request.Subscribers.Add(new Subscriber { To = subNumber });
         }
-        Message.From = from;
-        Message.Text = message;
+        request.Message.From = from;
+        request.Message.Text = message;
+        return request;
     }
 
     [JsonPropertyName("message")]

--- a/src/Indice.Services/SmsServiceApifonIM.cs
+++ b/src/Indice.Services/SmsServiceApifonIM.cs
@@ -113,9 +113,7 @@ public class SmsServiceApifonIM : ISmsService
     /// <summary>Checks the implementation if supports the given <paramref name="deliveryChannel"/>.</summary>
     /// <param name="deliveryChannel">A string representing the delivery channel. i.e 'SMS'</param>
     /// <returns></returns>
-    public bool Supports(string deliveryChannel) => 
-        "SMS".Equals(deliveryChannel, StringComparison.OrdinalIgnoreCase) || 
-        "Viber".Equals(deliveryChannel, StringComparison.OrdinalIgnoreCase);
+    public bool Supports(string deliveryChannel) => "Viber".Equals(deliveryChannel, StringComparison.OrdinalIgnoreCase);
 
     /// <summary>Get default JSON serializer options: CamelCase, ignore null values.</summary>
     protected static JsonSerializerOptions GetJsonSerializerOptions() => new JsonSerializerOptions {


### PR DESCRIPTION
- Make `ApifonIM` service supports only Viber so the `ISmsServiceFactory` can resolve both `Apifon` and `ApifonIM` based on `SMS` or `Viber` delivery channel.
- Respect `ViberFallbackEnabled` option in `ApifonIM`