### PR TITLE
fix console runtime error when creating a campaign

### DIFF
--- a/src/Indice.Features.Messages.App/src/app/features/campaigns/create/campaign-create.component.ts
+++ b/src/Indice.Features.Messages.App/src/app/features/campaigns/create/campaign-create.component.ts
@@ -12,7 +12,6 @@ import { CreateCampaignRequest, MessagesApiClient, Period, Hyperlink, Campaign, 
 import { CampaignAttachmentsComponent } from './steps/attachments/campaign-attachments.component';
 import { map, mergeMap } from 'rxjs/operators';
 import { of } from 'rxjs';
-import { settings } from 'src/app/core/models/settings';
 
 @Component({
     selector: 'app-campaign-create',

--- a/src/Indice.Features.Messages.App/src/app/features/campaigns/create/steps/preview/campaign-preview.component.ts
+++ b/src/Indice.Features.Messages.App/src/app/features/campaigns/create/steps/preview/campaign-preview.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { AbstractControl, UntypedFormControl, UntypedFormGroup } from '@angular/forms';
+import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
 
 import { CampaignPreview } from './campaign-preview';
 
@@ -23,6 +23,13 @@ export class CampaignPreviewComponent implements OnInit {
     public form!: UntypedFormGroup;
 
     public ngOnInit(): void {
+        this._initForm();
+    }
+
+    private _initForm(): void {
+        this.form = new UntypedFormGroup({
+          published: new UntypedFormControl(false)
+        });
     }
 
 }


### PR DESCRIPTION
Fix console error: "ERROR RuntimeError: NG01052: formGroup expects a FormGroup instance. Please pass one in." which is displayed when pressing "create campaign" button.