### PR TITLE
Use hard-coded base address for Apifon services

### DIFF
--- a/src/Indice.Services/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Indice.Services/Extensions/IServiceCollectionExtensions.cs
@@ -120,10 +120,7 @@ public static class IndiceServicesServiceCollectionExtensions
         services.TryAddTransient<ISmsServiceFactory, DefaultSmsServiceFactory>();
         var options = new SmsServiceApifonOptions();
         configure?.Invoke(options);
-        var httpClientBuilder = services.AddHttpClient<ISmsService, SmsServiceApifon>(nameof(SmsServiceApifon))
-                                        .ConfigureHttpClient(httpClient => {
-                                            httpClient.BaseAddress = new Uri("https://ars.apifon.com/services/api/v1/sms/");
-                                        });
+        var httpClientBuilder = services.AddHttpClient<ISmsService, SmsServiceApifon>();
         if (options.ConfigurePrimaryHttpMessageHandler is not null) {
             httpClientBuilder.ConfigurePrimaryHttpMessageHandler(options.ConfigurePrimaryHttpMessageHandler);
         }
@@ -139,11 +136,7 @@ public static class IndiceServicesServiceCollectionExtensions
         services.TryAddTransient<ISmsServiceFactory, DefaultSmsServiceFactory>();
         var options = new SmsServiceApifonOptions();
         configure?.Invoke(options);
-        var httpClientBuilder = services
-            .AddHttpClient<ISmsService, SmsServiceApifonIM>(nameof(SmsServiceApifonIM))
-            .ConfigureHttpClient(httpClient => {
-                httpClient.BaseAddress = new Uri($"{SmsServiceApifonIM.APIFON_BASE_URL}{SmsServiceApifonIM.SERVICE_ENDPOINT}");
-            });
+        var httpClientBuilder = services.AddHttpClient<ISmsService, SmsServiceApifonIM>();
         if (options?.ConfigurePrimaryHttpMessageHandler is not null) {
             httpClientBuilder.ConfigurePrimaryHttpMessageHandler(options.ConfigurePrimaryHttpMessageHandler);
         }

--- a/src/Indice.Services/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Indice.Services/Extensions/IServiceCollectionExtensions.cs
@@ -120,7 +120,7 @@ public static class IndiceServicesServiceCollectionExtensions
         services.TryAddTransient<ISmsServiceFactory, DefaultSmsServiceFactory>();
         var options = new SmsServiceApifonOptions();
         configure?.Invoke(options);
-        var httpClientBuilder = services.AddHttpClient<ISmsService, SmsServiceApifon>()
+        var httpClientBuilder = services.AddHttpClient<ISmsService, SmsServiceApifon>(nameof(SmsServiceApifon))
                                         .ConfigureHttpClient(httpClient => {
                                             httpClient.BaseAddress = new Uri("https://ars.apifon.com/services/api/v1/sms/");
                                         });
@@ -140,7 +140,7 @@ public static class IndiceServicesServiceCollectionExtensions
         var options = new SmsServiceApifonOptions();
         configure?.Invoke(options);
         var httpClientBuilder = services
-            .AddHttpClient<ISmsService, SmsServiceApifonIM>()
+            .AddHttpClient<ISmsService, SmsServiceApifonIM>(nameof(SmsServiceApifonIM))
             .ConfigureHttpClient(httpClient => {
                 httpClient.BaseAddress = new Uri($"{SmsServiceApifonIM.APIFON_BASE_URL}{SmsServiceApifonIM.SERVICE_ENDPOINT}");
             });

--- a/src/Indice.Services/SmsServiceApifon.cs
+++ b/src/Indice.Services/SmsServiceApifon.cs
@@ -35,6 +35,10 @@ public class SmsServiceApifon : ISmsService
         }
     }
 
+    /// <summary>The Apifon base URL address.</summary>
+    internal static readonly string APIFON_BASE_URL = "https://ars.apifon.com";
+    /// <summary>The Apifon IM service gateway endpoint.</summary>
+    internal static readonly string SERVICE_ENDPOINT = "/services/api/v1/sms/send";
     /// <summary>The settings required to configure the service.</summary>
     protected SmsServiceApifonSettings Settings { get; }
     /// <summary>The <see cref="System.Net.Http.HttpClient"/>.</summary>
@@ -66,11 +70,11 @@ public class SmsServiceApifon : ISmsService
         }
         // https://docs.apifon.com/apireference.html#sms-request
         var payload = ApifonRequest.Create(sender?.Id ?? Settings.Sender ?? Settings.SenderName!, recipients, body!);
-        var signature = payload.Sign(Settings.ApiKey!, HttpMethod.Post.ToString(), "/services/api/v1/sms/send");
+        var signature = payload.Sign(Settings.ApiKey!, HttpMethod.Post.ToString(), SERVICE_ENDPOINT);
         var request = new HttpRequestMessage {
             Content = new StringContent(payload.ToJson(), Encoding.UTF8, "application/json"),
             Method = HttpMethod.Post,
-            RequestUri = new Uri(HttpClient.BaseAddress!, "send")
+            RequestUri = new Uri($"{APIFON_BASE_URL}{SERVICE_ENDPOINT}")
         };
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
         request.Headers.Add("X-ApifonWS-Date", payload.RequestDate.ToString("r"));

--- a/src/Indice.Services/SmsServiceApifonIM.cs
+++ b/src/Indice.Services/SmsServiceApifonIM.cs
@@ -17,8 +17,6 @@ namespace Indice.Services;
 /// </summary>
 public class SmsServiceApifonIM : ISmsService
 {
-    /// <summary>The Apifon base URL address.</summary>
-    internal static readonly string APIFON_BASE_URL = "https://ars.apifon.com";
     /// <summary>The Apifon IM service gateway endpoint.</summary>
     internal static readonly string SERVICE_ENDPOINT = "/services/api/v1/im/send";
     /// <summary>The settings required to configure the service.</summary>
@@ -71,7 +69,7 @@ public class SmsServiceApifonIM : ISmsService
         var request = new HttpRequestMessage {
             Content = new StringContent(payload.ToJson(), Encoding.UTF8, MediaTypeNames.Application.Json),
             Method = HttpMethod.Post,
-            RequestUri = HttpClient.BaseAddress
+            RequestUri = new Uri($"{SmsServiceApifon.APIFON_BASE_URL}{SERVICE_ENDPOINT}")
         };
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(MediaTypeNames.Application.Json));
         request.Headers.Add("X-ApifonWS-Date", payload.RequestDate.ToString("r"));


### PR DESCRIPTION
In order to use both `Apifon` and `ApifonIM` service concurrently we should hard-code the specific URIs in HttpClient's base address.