### PR TITLE
Enhance getFileTemplate method for CDN URL handling

### DIFF
--- a/src/Indice.Features.Messages.App/src/app/shared/services/file-utilities.service.ts
+++ b/src/Indice.Features.Messages.App/src/app/shared/services/file-utilities.service.ts
@@ -22,8 +22,12 @@ export class FileUtilitiesService {
         return '../../../assets/images/pdf-icon.png';
       case '.pptx': 
         return '../../../assets/images/pptx-icon.png';
-      default:
-        return file.permaLink + `?size=${size || ''}`;
+      default: {
+        if (size) {
+          return settings.api_url + '/media-root' + file.path + `?size=${size || ''}`;
+        }
+        return file.permaLink;
+      }
     }
   }
 

--- a/src/Indice.Features.Messages.App/src/app/shared/services/file-utilities.service.ts
+++ b/src/Indice.Features.Messages.App/src/app/shared/services/file-utilities.service.ts
@@ -24,7 +24,7 @@ export class FileUtilitiesService {
         return '../../../assets/images/pptx-icon.png';
       default: {
         if (size) {
-          return settings.api_url + '/media-root' + file.path + `?size=${size || ''}`;
+          return settings.api_url + '/media-root' + file.path + `?size=${size}`;
         }
         return file.permaLink;
       }


### PR DESCRIPTION
Modified the default case in the getFileTemplate method of the FileUtilitiesService class. Now, it checks if a size is provided. If size is present, it constructs a URL using settings.api_url, /media-root, and file.path with the size query parameter. If size is not provided, it returns file.permaLink. This change improves the handling of media file URLs based on different conditions.