### PR TITLE
Add missing option in AddCasesManagement

### DIFF
--- a/src/Indice.Features.Cases.AspNetCore/CasesApiFeatureExtensions.cs
+++ b/src/Indice.Features.Cases.AspNetCore/CasesApiFeatureExtensions.cs
@@ -161,6 +161,10 @@ public static class CasesApiFeatureExtensions
             options.UserClaimType = casesAdminOptions.UserClaimType;
             options.GroupIdClaimType = casesAdminOptions.GroupIdClaimType;
             options.ReferenceNumberEnabled = casesAdminOptions.ReferenceNumberEnabled;
+            
+            options.RequiredScope = casesAdminOptions.RequiredScope;
+            options.TinClaimType = casesAdminOptions.TinClaimType;
+            options.ReferenceIdClaimType = casesAdminOptions.ReferenceIdClaimType;
         });
 
         return mvcBuilder;


### PR DESCRIPTION
Add missing option in AddCasesManagement this was needed for cases where the RequiredScope was other that the default, 