### PR TITLE
Add CacheKeyPrefix to AddApiAuthenticationDefaults

### DIFF
--- a/src/Indice.AspNetCore.Builder/WebApplicationBuilderExtensions.cs
+++ b/src/Indice.AspNetCore.Builder/WebApplicationBuilderExtensions.cs
@@ -110,7 +110,9 @@ public static class WebApplicationBuilderExtensions
             options.ClientSecret = builder.Configuration.GetApiSecret("Introspection");
             // Enable caching so we avoid perform a round-trip to the introspection endpoint for each incoming request. 
             options.EnableCaching = true;
-            // Add cache key to avoid caching the same token for different apis (eg in case of Redis)
+            // Having multiple instances of the same application with distributed cache configured (Redis, Sql) is not an issue.
+            // Having same distributed cache configuration for difference applications, regardless of instance count, is a problem.
+            // Add cache key to avoid caching the same token for different api hosts
             options.CacheKeyPrefix = $"{options.ClientId}_";
             options.CacheDuration = TimeSpan.FromMinutes(5); // 5 minutes is the default. Should potentially go back up to defaults.
         });

--- a/src/Indice.AspNetCore.Builder/WebApplicationBuilderExtensions.cs
+++ b/src/Indice.AspNetCore.Builder/WebApplicationBuilderExtensions.cs
@@ -110,6 +110,8 @@ public static class WebApplicationBuilderExtensions
             options.ClientSecret = builder.Configuration.GetApiSecret("Introspection");
             // Enable caching so we avoid perform a round-trip to the introspection endpoint for each incoming request. 
             options.EnableCaching = true;
+            // Add cache key to avoid caching the same token for different apis (eg in case of Redis)
+            options.CacheKeyPrefix = options.ClientId;
             options.CacheDuration = TimeSpan.FromMinutes(5); // 5 minutes is the default. Should potentially go back up to defaults.
         });
         builder.Services.AddScopeTransformation();

--- a/src/Indice.AspNetCore.Builder/WebApplicationBuilderExtensions.cs
+++ b/src/Indice.AspNetCore.Builder/WebApplicationBuilderExtensions.cs
@@ -111,7 +111,7 @@ public static class WebApplicationBuilderExtensions
             // Enable caching so we avoid perform a round-trip to the introspection endpoint for each incoming request. 
             options.EnableCaching = true;
             // Add cache key to avoid caching the same token for different apis (eg in case of Redis)
-            options.CacheKeyPrefix = options.ClientId;
+            options.CacheKeyPrefix = $"{options.ClientId}_";
             options.CacheDuration = TimeSpan.FromMinutes(5); // 5 minutes is the default. Should potentially go back up to defaults.
         });
         builder.Services.AddScopeTransformation();


### PR DESCRIPTION
- Having multiple instances of the same application with distributed cache configured (Redis, Sql) is not an issue.
- Having same distributed cache configuration for difference applications, regardless of instance count, is a problem.
- Add cache key to avoid caching the same token for different api hosts