### PR TITLE
Potential fix for code scanning alert no. 1331: Useless assignment to local variable

### DIFF
--- a/src/Indice.Services/FileServiceAzureStorage.cs
+++ b/src/Indice.Services/FileServiceAzureStorage.cs
@@ -141,9 +141,8 @@ public class FileServiceAzureStorage : IFileService
 
         var copyAction = async (BlobClient sourceBlob, BlobClient destBlob) => {
             var copyOperation = await destBlob.StartCopyFromUriAsync(sourceBlob.Uri);
-            var copiedContentLength = 0L;
             while (copyOperation.HasCompleted == false) {
-                copiedContentLength = await copyOperation.WaitForCompletionAsync();
+                await copyOperation.WaitForCompletionAsync();
                 await Task.Delay(100);
             }
             await sourceBlob.DeleteAsync();


### PR DESCRIPTION
Potential fix for [https://github.com/indice-co/Indice.Platform/security/code-scanning/1331](https://github.com/indice-co/Indice.Platform/security/code-scanning/1331)

To fix the issue, we will remove the assignment to `copiedContentLength` on line 146. The method call `await copyOperation.WaitForCompletionAsync()` will remain, as its side effects are necessary for the program's functionality. This change ensures that the code is cleaner and avoids maintaining an unused variable.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
