### PR TITLE
[HealthChecks] Replace custom WriteResponse

### DIFF
--- a/src/Indice.AspNetCore.Builder/ServiceDefaultsExtensions.cs
+++ b/src/Indice.AspNetCore.Builder/ServiceDefaultsExtensions.cs
@@ -219,7 +219,6 @@ public static class ServiceDefaultsExtensions
     private static JsonSerializerOptions CreateJsonOptions() {
         var options = new JsonSerializerOptions {
             WriteIndented = true,
-            Encoder = JavaScriptEncoder.Create(UnicodeRanges.All),
             AllowTrailingCommas = true,
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull

--- a/src/Indice.AspNetCore.Builder/ServiceDefaultsExtensions.cs
+++ b/src/Indice.AspNetCore.Builder/ServiceDefaultsExtensions.cs
@@ -1,10 +1,11 @@
 using System.Reflection;
 using System.Text.Json;
-using System.Text;
+using System.Text.Json.Serialization;
 using Azure.Monitor.OpenTelemetry.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
@@ -13,7 +14,6 @@ using OpenTelemetry.Exporter;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
-using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.Extensions.Hosting;
 
@@ -205,41 +205,23 @@ public static class ServiceDefaultsExtensions
 
         return app;
     }
+
     private static Task WriteResponse(HttpContext context, HealthReport healthReport) {
+        var responseJson = JsonSerializer.Serialize(healthReport, _jsonSerializerOptions.Value);
         context.Response.ContentType = "application/json; charset=utf-8";
+        return context.Response.WriteAsync(responseJson);
+    }
 
-        var options = new JsonWriterOptions { Indented = true };
+    private static readonly Lazy<JsonSerializerOptions> _jsonSerializerOptions = new(CreateJsonOptions);
 
-        using var memoryStream = new MemoryStream();
-        using (var jsonWriter = new Utf8JsonWriter(memoryStream, options)) {
-            jsonWriter.WriteStartObject();
-            jsonWriter.WriteString("status", healthReport.Status.ToString());
-            jsonWriter.WriteStartObject("results");
-
-            foreach (var healthReportEntry in healthReport.Entries) {
-                jsonWriter.WriteStartObject(healthReportEntry.Key);
-                jsonWriter.WriteString("status",
-                    healthReportEntry.Value.Status.ToString());
-                jsonWriter.WriteString("description",
-                    healthReportEntry.Value.Description);
-                jsonWriter.WriteStartObject("data");
-
-                foreach (var item in healthReportEntry.Value.Data) {
-                    jsonWriter.WritePropertyName(item.Key);
-
-                    JsonSerializer.Serialize(jsonWriter, item.Value,
-                        item.Value?.GetType() ?? typeof(object));
-                }
-
-                jsonWriter.WriteEndObject();
-                jsonWriter.WriteEndObject();
-            }
-
-            jsonWriter.WriteEndObject();
-            jsonWriter.WriteEndObject();
-        }
-
-        return context.Response.WriteAsync(
-            Encoding.UTF8.GetString(memoryStream.ToArray()));
+    private static JsonSerializerOptions CreateJsonOptions() {
+        var options = new JsonSerializerOptions {
+            WriteIndented = true,
+            AllowTrailingCommas = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        };
+        options.Converters.Add(new JsonStringEnumConverter());
+        return options;
     }
 }

--- a/src/Indice.AspNetCore.Builder/ServiceDefaultsExtensions.cs
+++ b/src/Indice.AspNetCore.Builder/ServiceDefaultsExtensions.cs
@@ -1,6 +1,8 @@
 using System.Reflection;
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.Unicode;
 using Azure.Monitor.OpenTelemetry.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
@@ -217,6 +219,7 @@ public static class ServiceDefaultsExtensions
     private static JsonSerializerOptions CreateJsonOptions() {
         var options = new JsonSerializerOptions {
             WriteIndented = true,
+            Encoder = JavaScriptEncoder.Create(UnicodeRanges.All),
             AllowTrailingCommas = true,
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull


### PR DESCRIPTION
Replace custom WriteResponse method to built-in one, in order for the HealthChecks.UI to be able to consume the proper response JSON structure.