### PR TITLE
[Feature] JsonStringArrayEnumFlagsConverter - Adjusted for JSON deserialization when property declaration is nullable

### DIFF
--- a/src/Indice.Common/Extensions/TypeExtensions.cs
+++ b/src/Indice.Common/Extensions/TypeExtensions.cs
@@ -8,9 +8,10 @@ public static class TypeExtensions
 {
     /// <summary>Determines whether a type is decorated with <see cref="FlagsAttribute"/>.</summary>
     /// <param name="type">The type to check.</param>
+    /// <remarks>Also checks for nullable flag enums.</remarks>
     public static bool IsFlagsEnum(this Type type) =>
-        (type.IsEnum && type.GetCustomAttributes(typeof(FlagsAttribute), inherit: false).Any()) ||
-        (Nullable.GetUnderlyingType(type)?.IsEnum == true && Nullable.GetUnderlyingType(type)!.GetCustomAttributes(typeof(FlagsAttribute), inherit: false).Any());
+        (type.IsEnum && type.GetCustomAttributes(typeof(FlagsAttribute), inherit: false).Length != 0) ||
+        (Nullable.GetUnderlyingType(type)?.IsEnum == true && Nullable.GetUnderlyingType(type)!.GetCustomAttributes(typeof(FlagsAttribute), inherit: false).Length != 0);
 
     
     /// <summary>Determines whether a type is anonymous.</summary>

--- a/src/Indice.Common/Serialization/JsonStringArrayEnumFlagsConverter.cs
+++ b/src/Indice.Common/Serialization/JsonStringArrayEnumFlagsConverter.cs
@@ -9,11 +9,11 @@ namespace Indice.Serialization;
 public class JsonStringArrayEnumFlagsConverterFactory : JsonConverterFactory
 {
     /// <inheritdoc />
-    public override bool CanConvert(Type typeToConvert) => typeToConvert.IsFlagsEnum() || Nullable.GetUnderlyingType(typeToConvert)?.IsFlagsEnum() == true;
+    public override bool CanConvert(Type typeToConvert) => typeToConvert.IsFlagsEnum();
 
     /// <inheritdoc />
     public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options) {
-        var converterType = typeof(JsonStringArrayEnumFlagsConverter<>).MakeGenericType(typeToConvert.IsFlagsEnum() ? typeToConvert : Nullable.GetUnderlyingType(typeToConvert)!);
+        var converterType = typeof(JsonStringArrayEnumFlagsConverter<>).MakeGenericType(typeToConvert);
         var converter = Activator.CreateInstance(converterType)!;
         return (JsonConverter)converter;
     }
@@ -21,7 +21,7 @@ public class JsonStringArrayEnumFlagsConverterFactory : JsonConverterFactory
 
 /// <summary>A custom JSON converter which transforms <see cref="Enum"/> flags to string array.</summary>
 /// <typeparam name="TEnum">The type of the enum.</typeparam>
-internal class JsonStringArrayEnumFlagsConverter<TEnum> : JsonConverter<TEnum?>
+internal class JsonStringArrayEnumFlagsConverter<TEnum> : JsonConverter<TEnum>
 {
     /// <inheritdoc />
     /// <remarks>https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-converters-how-to?pivots=dotnet-6-0#error-handling</remarks>

--- a/src/Indice.Common/Serialization/JsonStringArrayEnumFlagsConverter.cs
+++ b/src/Indice.Common/Serialization/JsonStringArrayEnumFlagsConverter.cs
@@ -9,11 +9,11 @@ namespace Indice.Serialization;
 public class JsonStringArrayEnumFlagsConverterFactory : JsonConverterFactory
 {
     /// <inheritdoc />
-    public override bool CanConvert(Type typeToConvert) => typeToConvert.IsFlagsEnum();
+    public override bool CanConvert(Type typeToConvert) => typeToConvert.IsFlagsEnum() || Nullable.GetUnderlyingType(typeToConvert)?.IsFlagsEnum() == true;
 
     /// <inheritdoc />
     public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options) {
-        var converterType = typeof(JsonStringArrayEnumFlagsConverter<>).MakeGenericType(typeToConvert);
+        var converterType = typeof(JsonStringArrayEnumFlagsConverter<>).MakeGenericType(typeToConvert.IsFlagsEnum() ? typeToConvert : Nullable.GetUnderlyingType(typeToConvert)!);
         var converter = Activator.CreateInstance(converterType)!;
         return (JsonConverter)converter;
     }

--- a/test/Indice.Common.Tests/JsonStringArrayEnumFlagsConverterTests.cs
+++ b/test/Indice.Common.Tests/JsonStringArrayEnumFlagsConverterTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json;
+﻿using System;
+using System.Text.Json;
 using Indice.Serialization;
 using Xunit;
 
@@ -10,7 +11,7 @@ public class JsonStringArrayEnumFlagsConverterTests
         Options = new JsonSerializerOptions {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         };
-        Options.Converters.Add(new JsonStringArrayEnumFlagsConverterFactory());
+        Options.Converters.Insert(0, new JsonStringArrayEnumFlagsConverterFactory());
     }
 
     public JsonSerializerOptions Options { get; }
@@ -51,7 +52,26 @@ public class JsonStringArrayEnumFlagsConverterTests
         };
         var expectedJson = @"{""id"":1,""name"":""Sales Christmas 2021"",""deliveryChannel"":null}";
         var campaignJson = JsonSerializer.Serialize(campaign, Options);
-        Assert.Equal(campaignJson, expectedJson);
+        Assert.Equal(expectedJson, campaignJson);
+    }
+
+    [Fact]
+    public void CanDeserializeEnumFlagsToStringArrayWhenNullable() {
+        var expectedCampaign = new Campaign2 {
+            Id = 1,
+            Name = "Sales Christmas 2021"
+        };
+        var expectedCampaign2 = new Campaign2 {
+            Id = 1,
+            Name = "Sales Christmas 2021",
+            DeliveryChannel = CampaignDeliveryChannel.Inbox | CampaignDeliveryChannel.PushNotification
+        };
+        var json = @"{""id"":1,""name"":""Sales Christmas 2021"",""deliveryChannel"":null}";
+        var json2 = @"{""id"":1,""name"":""Sales Christmas 2021"",""deliveryChannel"": [""Inbox"", ""PushNotification""]}";
+        var campaign = JsonSerializer.Deserialize<Campaign2>(json, Options);
+        var campaign2 = JsonSerializer.Deserialize<Campaign2>(json2, Options);
+        Assert.Equal(expectedCampaign.DeliveryChannel, campaign.DeliveryChannel);
+        Assert.Equal(expectedCampaign2.DeliveryChannel, campaign2.DeliveryChannel);
     }
 }
 


### PR DESCRIPTION
Refactor JsonStringArrayEnumFlagsConverter logic
- `CreateConverter` methods now handle both non-nullable and nullable flags enums.
- Updated `JsonStringArrayEnumFlagsConverter` to inherit from `JsonConverter<TEnum>` instead on the nullable type so that nullables can passthrough generics.
- Adjusted JsonStringArrayEnumFlagsConverter tests for converter registration order in `JsonSerializerOptions`.
- Corrected parameter order in assertions for clarity.
- Added a new test for deserializing nullable enum flags to string arrays.