### PR TITLE
Add MFA session tracking to UserDevice and update logic

### DIFF
--- a/src/Indice.Features.Identity.Core/Data/Models/UserDevice.cs
+++ b/src/Indice.Features.Identity.Core/Data/Models/UserDevice.cs
@@ -60,6 +60,8 @@ public class UserDevice
     public DeviceClientType? ClientType { get; set; }
     /// <summary>The date until the client is remembered by the system and MFA is not asked.</summary>
     public DateTimeOffset? MfaSessionExpirationDate { get; set; }
+    /// <summary>Determines whether the device has an active MFA session. This is the period of time that the device is remembered by the system and MFA is not asked.</summary>
+    public bool MfaSessionActive => !MfaSessionExpirationDate.HasValue || MfaSessionExpirationDate <= DateTimeOffset.UtcNow;
     /// <summary>The user associated with this device.</summary>
     public virtual User? User { get; set; }
 }

--- a/src/Indice.Features.Identity.UI/Pages/Mfa.cs
+++ b/src/Indice.Features.Identity.UI/Pages/Mfa.cs
@@ -152,7 +152,7 @@ public abstract class BaseMfaModel : BasePageModel
             AllowDowngradeAuthenticationMethod = allowDowngradeAuthenticationMethod,
             ReturnUrl = returnUrl,
             User = user,
-            IsExistingBrowser = browserDevice is not null,
+            IsExistingBrowser = browserDevice?.MfaSessionActive ?? false,
             Error = authenticationMethod == null ? "MFA is enabled but there is no active two factor authentication method configured. Please contact your administrator." : null
         };
     }


### PR DESCRIPTION
- Introduced `MfaSessionActive` property in `UserDevice` to determine active MFA sessions based on expiration date.
- Updated `BaseMfaModel` to use `MfaSessionActive` for checking existing browsers, enhancing session validation.


fixes old issue with the legacy identity packages as discussed here: https://github.com/indice-co/Indice.Platform/pull/451