### PR TITLE
[identity] MFA Enhancements

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -19,7 +19,7 @@
       <VersionPrefixAspNet>$(VersionPrefixBase).0</VersionPrefixAspNet>
       <VersionPrefix>$(VersionPrefixBase).0</VersionPrefix>
       
-      <VersionSuffix>rc27</VersionSuffix>
+      <VersionSuffix>rc28</VersionSuffix>
       <Authors>Constantinos Leftheris</Authors>
       <GenerateDocumentationFile>true</GenerateDocumentationFile>
       <LangVersion>Latest</LangVersion>

--- a/src/Indice.Features.Identity.AdminUI.App/src/app/features/users/edit/user-store.service.ts
+++ b/src/Indice.Features.Identity.AdminUI.App/src/app/features/users/edit/user-store.service.ts
@@ -3,228 +3,229 @@ import { Injectable } from '@angular/core';
 import { Observable, AsyncSubject } from 'rxjs';
 import { map } from 'rxjs/operators';
 import {
-    IdentityApiService, SingleUserInfo, RoleInfoResultSet, RoleInfo, ClaimTypeInfo, ClaimTypeInfoResultSet, UpdateUserRequest, ClaimInfo, CreateClaimRequest, BasicClaimInfo,
-    UserClientInfo, UserClientInfoResultSet, UpdateUserClaimRequest, SetPasswordRequest, SetUserBlockRequest, UserLoginProviderInfo, DeviceInfo, DeviceInfoResultSet, UserLoginProviderInfoResultSet
+  IdentityApiService, SingleUserInfo, RoleInfoResultSet, RoleInfo, ClaimTypeInfo, ClaimTypeInfoResultSet, UpdateUserRequest, ClaimInfo, CreateClaimRequest, BasicClaimInfo,
+  UserClientInfo, UserClientInfoResultSet, UpdateUserClaimRequest, SetPasswordRequest, SetUserBlockRequest, UserLoginProviderInfo, DeviceInfo, DeviceInfoResultSet, UserLoginProviderInfoResultSet
 } from 'src/app/core/services/identity-api.service';
 import { ClaimType } from './details/models/claim-type.model';
 
 @Injectable()
 export class UserStore {
-    private _user: AsyncSubject<SingleUserInfo>;
-    private _allRoles: AsyncSubject<RoleInfo[]>;
-    private _allClaims: AsyncSubject<ClaimTypeInfo[]>;
-    private _userApplications: AsyncSubject<UserClientInfo[]>;
-    private _userDevices: AsyncSubject<DeviceInfo[]>;
-    private _userExternalLogins: AsyncSubject<UserLoginProviderInfo[]>;
+  private _user: AsyncSubject<SingleUserInfo>;
+  private _allRoles: AsyncSubject<RoleInfo[]>;
+  private _allClaims: AsyncSubject<ClaimTypeInfo[]>;
+  private _userApplications: AsyncSubject<UserClientInfo[]>;
+  private _userDevices: AsyncSubject<DeviceInfo[]>;
+  private _userExternalLogins: AsyncSubject<UserLoginProviderInfo[]>;
 
-    constructor(private _api: IdentityApiService) { }
+  constructor(private _api: IdentityApiService) { }
 
-    public getUser(userId: string): Observable<SingleUserInfo> {
-        if (!this._user) {
-            this._user = new AsyncSubject<SingleUserInfo>();
-            this._api.getUser(userId).subscribe((user: SingleUserInfo) => {
-                this._user.next(user);
-                this._user.complete();
-            });
+  public getUser(userId: string): Observable<SingleUserInfo> {
+    if (!this._user) {
+      this._user = new AsyncSubject<SingleUserInfo>();
+      this._api.getUser(userId).subscribe((user: SingleUserInfo) => {
+        this._user.next(user);
+        this._user.complete();
+      });
+    }
+    return this._user;
+  }
+
+  public updateUser(user: SingleUserInfo, requiredClaims: ClaimType[], bypassEmailAsUserNamePolicy: boolean = false): Observable<void> {
+    const claims = requiredClaims ? requiredClaims.map((claim: ClaimType) => {
+      return {
+        type: claim.name,
+        value: claim.value
+      } as BasicClaimInfo;
+    }) : null;
+    return this._api.updateUser(user.id, {
+      email: user.email,
+      phoneNumber: user.phoneNumber,
+      twoFactorEnabled: user.twoFactorEnabled,
+      twoFactorPolicy: user.twoFactorPolicy,
+      userName: user.userName,
+      passwordExpirationPolicy: user.passwordExpirationPolicy,
+      isAdmin: user.isAdmin,
+      emailConfirmed: user.emailConfirmed,
+      phoneNumberConfirmed: user.phoneNumberConfirmed,
+      claims,
+      bypassEmailAsUserNamePolicy
+    } as UpdateUserRequest).pipe(map((updatedUser: SingleUserInfo) => {
+      user.claims = [...updatedUser.claims];
+      this._user.next(user);
+      this._user.complete();
+    }));
+  }
+
+  public deleteUser(userId: string): Observable<void> {
+    return this._api.deleteUser(userId);
+  }
+
+  public blockUser(userId: string): Observable<void> {
+    this.getUser(userId).subscribe((user: SingleUserInfo) => {
+      user.blocked = true;
+      this._user.next(user);
+      this._user.complete();
+    });
+    return this._api.setUserBlock(userId, {
+      blocked: true
+    } as SetUserBlockRequest);
+  }
+
+  public unblockUser(userId: string): Observable<void> {
+    this.getUser(userId).subscribe((user: SingleUserInfo) => {
+      user.blocked = false;
+      this._user.next(user);
+      this._user.complete();
+    });
+    return this._api.setUserBlock(userId, {
+      blocked: false
+    } as SetUserBlockRequest);
+  }
+
+  public unlockUser(userId: string): Observable<void> {
+    this.getUser(userId).subscribe((user: SingleUserInfo) => {
+      user.lockoutEnd = null;
+      user.isLocked = false;
+      user.accessFailedCount = 0;
+      this._user.next(user);
+      this._user.complete();
+    });
+    return this._api.unlockUser(userId);
+  }
+
+  public resetPassword(userId: string, password: string, changePasswordAfterFirstSignIn: boolean, bypassPasswordValidation: boolean): Observable<void> {
+    this.getUser(userId).subscribe((user: SingleUserInfo) => {
+      this._user.next(user);
+      this._user.complete();
+    });
+    return this._api.setPassword(userId, {
+      password,
+      changePasswordAfterFirstSignIn,
+      bypassPasswordValidation
+    } as SetPasswordRequest);
+  }
+
+  public addUserRole(userId: string, role: RoleInfo): Observable<void> {
+    this.getUser(userId).subscribe((user: SingleUserInfo) => {
+      user.roles.push(role.name);
+      this._user.next(user);
+      this._user.complete();
+    });
+    return this._api.addUserRole(userId, role.id);
+  }
+
+  public deleteUserRole(userId: string, role: RoleInfo): Observable<void> {
+    this.getUser(userId).subscribe((user: SingleUserInfo) => {
+      const index = user.roles.indexOf(role.name, 0);
+      if (index > -1) {
+        user.roles.splice(index, 1);
+      }
+      this._user.next(user);
+      this._user.complete();
+    });
+    return this._api.deleteUserRole(userId, role.id);
+  }
+
+  public addClaim(userId: string, claim: ClaimInfo): Observable<void> {
+    return this._api.addUserClaim(userId, {
+      type: claim.type,
+      value: claim.value
+    } as CreateClaimRequest).pipe(map((createdClaim: ClaimInfo) => {
+      this.getUser(userId).subscribe((user: SingleUserInfo) => {
+        user.claims.push(createdClaim);
+        this._user.next(user);
+        this._user.complete();
+      });
+    }));
+  }
+
+  public updateUserClaim(userId: string, claimId: number, value: string): Observable<void> {
+    return this._api.updateUserClaim(userId, claimId, {
+      claimValue: value
+    } as UpdateUserClaimRequest).pipe(map(_ => {
+      this.getUser(userId).subscribe((user: SingleUserInfo) => {
+        const claim = user.claims.find(x => x.id === claimId);
+        claim.value = value;
+        this._user.next(user);
+        this._user.complete();
+      });
+    }));
+  }
+
+  public deleteUserClaim(userId: string, claimId: number): Observable<void> {
+    return this._api.deleteUserClaim(claimId, userId).pipe(map(_ => {
+      this.getUser(userId).subscribe((user: SingleUserInfo) => {
+        const claim = user.claims.find(x => x.id === claimId);
+        const index = user.claims.indexOf(claim, 0);
+        if (index > -1) {
+          user.claims.splice(index, 1);
         }
-        return this._user;
-    }
+        this._user.next(user);
+        this._user.complete();
+      });
+    }));
+  }
 
-    public updateUser(user: SingleUserInfo, requiredClaims: ClaimType[], bypassEmailAsUserNamePolicy: boolean = false): Observable<void> {
-        const claims = requiredClaims ? requiredClaims.map((claim: ClaimType) => {
-            return {
-                type: claim.name,
-                value: claim.value
-            } as BasicClaimInfo;
-        }) : null;
-        return this._api.updateUser(user.id, {
-            email: user.email,
-            phoneNumber: user.phoneNumber,
-            twoFactorEnabled: user.twoFactorEnabled,
-            userName: user.userName,
-            passwordExpirationPolicy: user.passwordExpirationPolicy,
-            isAdmin: user.isAdmin,
-            emailConfirmed: user.emailConfirmed,
-            phoneNumberConfirmed: user.phoneNumberConfirmed,
-            claims,
-            bypassEmailAsUserNamePolicy
-        } as UpdateUserRequest).pipe(map((updatedUser: SingleUserInfo) => {
-            user.claims = [...updatedUser.claims];
-            this._user.next(user);
-            this._user.complete();
-        }));
+  public getUserApplications(userId: string): Observable<UserClientInfo[]> {
+    if (!this._userApplications) {
+      this._userApplications = new AsyncSubject<UserClientInfo[]>();
+      this._api.getUserApplications(userId).subscribe((response: UserClientInfoResultSet) => {
+        this._userApplications.next(response.items);
+        this._userApplications.complete();
+      });
     }
+    return this._userApplications;
+  }
 
-    public deleteUser(userId: string): Observable<void> {
-        return this._api.deleteUser(userId);
+  public getUserDevices(userId: string): Observable<DeviceInfo[]> {
+    if (!this._userDevices) {
+      this._userDevices = new AsyncSubject<DeviceInfo[]>();
+      this._api.getUserDevices(userId).subscribe((response: DeviceInfoResultSet) => {
+        this._userDevices.next(response.items);
+        this._userDevices.complete();
+      });
     }
+    return this._userDevices;
+  }
 
-    public blockUser(userId: string): Observable<void> {
-        this.getUser(userId).subscribe((user: SingleUserInfo) => {
-            user.blocked = true;
-            this._user.next(user);
-            this._user.complete();
-        });
-        return this._api.setUserBlock(userId, {
-            blocked: true
-        } as SetUserBlockRequest);
-    }
+  public deleteUserDevice(userId: string, deviceId: string): Observable<void> {
+    return this._api.deleteUserDevice(userId, deviceId);
+  }
 
-    public unblockUser(userId: string): Observable<void> {
-        this.getUser(userId).subscribe((user: SingleUserInfo) => {
-            user.blocked = false;
-            this._user.next(user);
-            this._user.complete();
-        });
-        return this._api.setUserBlock(userId, {
-            blocked: false
-        } as SetUserBlockRequest);
+  public getUserExternalLogins(userId: string): Observable<UserLoginProviderInfo[]> {
+    if (!this._userExternalLogins) {
+      this._userExternalLogins = new AsyncSubject<UserLoginProviderInfo[]>();
+      this._api.getUserExternalLogins(userId).subscribe((response: UserLoginProviderInfoResultSet) => {
+        this._userExternalLogins.next(response.items);
+        this._userExternalLogins.complete();
+      });
     }
+    return this._userExternalLogins;
+  }
 
-    public unlockUser(userId: string): Observable<void> {
-        this.getUser(userId).subscribe((user: SingleUserInfo) => {
-            user.lockoutEnd = null;
-            user.isLocked = false;
-            user.accessFailedCount = 0;
-            this._user.next(user);
-            this._user.complete();
-        });
-        return this._api.unlockUser(userId);
-    }
+  public deleteUserExternalLogin(userId: string, provider: string): Observable<void> {
+    return this._api.deleteUserExternalLogin(userId, provider);
+  }
 
-    public resetPassword(userId: string, password: string, changePasswordAfterFirstSignIn: boolean, bypassPasswordValidation: boolean): Observable<void> {
-        this.getUser(userId).subscribe((user: SingleUserInfo) => {
-            this._user.next(user);
-            this._user.complete();
-        });
-        return this._api.setPassword(userId, {
-            password,
-            changePasswordAfterFirstSignIn,
-            bypassPasswordValidation
-        } as SetPasswordRequest);
+  public getAllRoles(): Observable<RoleInfo[]> {
+    if (!this._allRoles) {
+      this._allRoles = new AsyncSubject<RoleInfo[]>();
+      this._api.getRoles(1, 2147483647, 'name+', undefined).subscribe((response: RoleInfoResultSet) => {
+        this._allRoles.next(response.items);
+        this._allRoles.complete();
+      });
     }
+    return this._allRoles;
+  }
 
-    public addUserRole(userId: string, role: RoleInfo): Observable<void> {
-        this.getUser(userId).subscribe((user: SingleUserInfo) => {
-            user.roles.push(role.name);
-            this._user.next(user);
-            this._user.complete();
-        });
-        return this._api.addUserRole(userId, role.id);
+  public getAllClaims(): Observable<ClaimTypeInfo[]> {
+    if (!this._allClaims) {
+      this._allClaims = new AsyncSubject<ClaimTypeInfo[]>();
+      this._api.getClaimTypes(1, 2147483647, 'name+', undefined).subscribe((response: ClaimTypeInfoResultSet) => {
+        this._allClaims.next(response.items);
+        this._allClaims.complete();
+      });
     }
-
-    public deleteUserRole(userId: string, role: RoleInfo): Observable<void> {
-        this.getUser(userId).subscribe((user: SingleUserInfo) => {
-            const index = user.roles.indexOf(role.name, 0);
-            if (index > -1) {
-                user.roles.splice(index, 1);
-            }
-            this._user.next(user);
-            this._user.complete();
-        });
-        return this._api.deleteUserRole(userId, role.id);
-    }
-
-    public addClaim(userId: string, claim: ClaimInfo): Observable<void> {
-        return this._api.addUserClaim(userId, {
-            type: claim.type,
-            value: claim.value
-        } as CreateClaimRequest).pipe(map((createdClaim: ClaimInfo) => {
-            this.getUser(userId).subscribe((user: SingleUserInfo) => {
-                user.claims.push(createdClaim);
-                this._user.next(user);
-                this._user.complete();
-            });
-        }));
-    }
-
-    public updateUserClaim(userId: string, claimId: number, value: string): Observable<void> {
-        return this._api.updateUserClaim(userId, claimId, {
-            claimValue: value
-        } as UpdateUserClaimRequest).pipe(map(_ => {
-            this.getUser(userId).subscribe((user: SingleUserInfo) => {
-                const claim = user.claims.find(x => x.id === claimId);
-                claim.value = value;
-                this._user.next(user);
-                this._user.complete();
-            });
-        }));
-    }
-
-    public deleteUserClaim(userId: string, claimId: number): Observable<void> {
-        return this._api.deleteUserClaim(claimId, userId).pipe(map(_ => {
-            this.getUser(userId).subscribe((user: SingleUserInfo) => {
-                const claim = user.claims.find(x => x.id === claimId);
-                const index = user.claims.indexOf(claim, 0);
-                if (index > -1) {
-                    user.claims.splice(index, 1);
-                }
-                this._user.next(user);
-                this._user.complete();
-            });
-        }));
-    }
-
-    public getUserApplications(userId: string): Observable<UserClientInfo[]> {
-        if (!this._userApplications) {
-            this._userApplications = new AsyncSubject<UserClientInfo[]>();
-            this._api.getUserApplications(userId).subscribe((response: UserClientInfoResultSet) => {
-                this._userApplications.next(response.items);
-                this._userApplications.complete();
-            });
-        }
-        return this._userApplications;
-    }
-
-    public getUserDevices(userId: string): Observable<DeviceInfo[]> {
-        if (!this._userDevices) {
-            this._userDevices = new AsyncSubject<DeviceInfo[]>();
-            this._api.getUserDevices(userId).subscribe((response: DeviceInfoResultSet) => {
-                this._userDevices.next(response.items);
-                this._userDevices.complete();
-            });
-        }
-        return this._userDevices;
-    }
-
-    public deleteUserDevice(userId: string, deviceId: string): Observable<void> {
-        return this._api.deleteUserDevice(userId, deviceId);
-    }
-
-    public getUserExternalLogins(userId: string): Observable<UserLoginProviderInfo[]> {
-        if (!this._userExternalLogins) {
-            this._userExternalLogins = new AsyncSubject<UserLoginProviderInfo[]>();
-            this._api.getUserExternalLogins(userId).subscribe((response: UserLoginProviderInfoResultSet) => {
-                this._userExternalLogins.next(response.items);
-                this._userExternalLogins.complete();
-            });
-        }
-        return this._userExternalLogins;
-    }
-
-    public deleteUserExternalLogin(userId: string, provider: string): Observable<void> {
-        return this._api.deleteUserExternalLogin(userId, provider);
-    }
-
-    public getAllRoles(): Observable<RoleInfo[]> {
-        if (!this._allRoles) {
-            this._allRoles = new AsyncSubject<RoleInfo[]>();
-            this._api.getRoles(1, 2147483647, 'name+', undefined).subscribe((response: RoleInfoResultSet) => {
-                this._allRoles.next(response.items);
-                this._allRoles.complete();
-            });
-        }
-        return this._allRoles;
-    }
-
-    public getAllClaims(): Observable<ClaimTypeInfo[]> {
-        if (!this._allClaims) {
-            this._allClaims = new AsyncSubject<ClaimTypeInfo[]>();
-            this._api.getClaimTypes(1, 2147483647, 'name+', undefined).subscribe((response: ClaimTypeInfoResultSet) => {
-                this._allClaims.next(response.items);
-                this._allClaims.complete();
-            });
-        }
-        return this._allClaims;
-    }
+    return this._allClaims;
+  }
 }

--- a/src/Indice.Features.Identity.Core/Data/Models/UserDevice.cs
+++ b/src/Indice.Features.Identity.Core/Data/Models/UserDevice.cs
@@ -61,7 +61,7 @@ public class UserDevice
     /// <summary>The date until the client is remembered by the system and MFA is not asked.</summary>
     public DateTimeOffset? MfaSessionExpirationDate { get; set; }
     /// <summary>Determines whether the device has an active MFA session. This is the period of time that the device is remembered by the system and MFA is not asked.</summary>
-    public bool MfaSessionActive => !MfaSessionExpirationDate.HasValue || MfaSessionExpirationDate <= DateTimeOffset.UtcNow;
+    public bool MfaSessionActive() => !MfaSessionExpirationDate.HasValue || MfaSessionExpirationDate >= DateTimeOffset.UtcNow;
     /// <summary>The user associated with this device.</summary>
     public virtual User? User { get; set; }
 }

--- a/src/Indice.Features.Identity.Core/Events/UserDeletedEvent.cs
+++ b/src/Indice.Features.Identity.Core/Events/UserDeletedEvent.cs
@@ -1,0 +1,13 @@
+﻿using Indice.Events;
+using Indice.Features.Identity.Core.Events.Models;
+
+namespace Indice.Features.Identity.Core.Events;
+
+/// <summary>An event that is raised when a user is deleted form the system.</summary>
+/// <remarks>Creates a new instance of <see cref="UserBlockedEvent"/>.</remarks>
+/// <param name="user">The user context.</param>
+public class UserDeletedEvent(UserEventContext user) : IPlatformEvent
+{
+    /// <summary>The user context.</summary>
+    public UserEventContext User { get; } = user;
+}

--- a/src/Indice.Features.Identity.Core/ExtendedSignInManager.cs
+++ b/src/Indice.Features.Identity.Core/ExtendedSignInManager.cs
@@ -145,7 +145,7 @@ public class ExtendedSignInManager<TUser> : SignInManager<TUser> where TUser : U
     /// <inheritdoc/>
     protected override async Task<SignInResult> SignInOrTwoFactorAsync(TUser user, bool isPersistent, string? loginProvider = null, bool bypassTwoFactor = false) {
         var isExternalLogin = !string.IsNullOrWhiteSpace(loginProvider) && (await _authenticationSchemeProvider.GetExternalSchemesAsync()).Select(scheme => scheme.Name).Contains(loginProvider);
-        var deviceId = await Context.ResolveDeviceIdAsync();
+        var deviceId = Context.ResolveDeviceId();
         
         var result = await _signInGuard.IsSuspiciousLogin(Context!, user);
         if (result.Warning == SignInWarning.ImpossibleTravel && _signInGuard.ImpossibleTravelDetector?.FlowType == ImpossibleTravelFlowType.DenyLogin) {
@@ -292,7 +292,7 @@ public class ExtendedSignInManager<TUser> : SignInManager<TUser> where TUser : U
 
     /// <inheritdoc/>
     public override async Task RememberTwoFactorClientAsync(TUser user) {
-        var deviceId = await Context.ResolveDeviceIdAsync();
+        var deviceId = Context.ResolveDeviceId();
         var principal = await StoreRememberClient(user, deviceId);
         await Context.SignInAsync(IdentityConstants.TwoFactorRememberMeScheme, principal, new AuthenticationProperties { IsPersistent = true });
     }
@@ -300,10 +300,9 @@ public class ExtendedSignInManager<TUser> : SignInManager<TUser> where TUser : U
     /// <inheritdoc/>
     public override async Task<bool> IsTwoFactorClientRememberedAsync(TUser user) {
         var userId = await ExtendedUserManager.GetUserIdAsync(user);
-        var result = await Context.AuthenticateAsync(IdentityConstants.TwoFactorRememberMeScheme);
-        var isRemembered = result?.Principal is not null && result.Principal.FindFirstValue(Options.ClaimsIdentity.UserIdClaimType) == userId;
-        var deviceId = await Context.ResolveDeviceIdAsync();
-        deviceId = deviceId.IsEmpty ? new MfaDeviceIdentifier(result?.Principal?.FindFirstValue(BasicClaimTypes.DeviceId)) : deviceId;
+        var info = await RetrieveTwoFactorInfoAsync();
+        var isRemembered = info is not null && info.UserId == userId;
+        var deviceId = info?.DeviceId ?? MfaDeviceIdentifier.Empty;
         if (!deviceId.IsEmpty && (isRemembered || (!isRemembered && RememberTrustedBrowserAcrossSessions))) {
             var device = await ExtendedUserManager.GetDeviceByIdAsync(user, deviceId.Value!);
             isRemembered = device is not null &&
@@ -353,7 +352,13 @@ public class ExtendedSignInManager<TUser> : SignInManager<TUser> where TUser : U
     /// <summary>Gets the current device id from context (broser cookie or form post)</summary>
     /// <param name="user"></param>
     /// <returns>The device identifier</returns>
-    public ValueTask<MfaDeviceIdentifier> GetMfaDeviceIdentifier(TUser user) => Context.ResolveDeviceIdAsync();
+    public async Task<MfaDeviceIdentifier> GetMfaDeviceIdentifierAsync(TUser user) {
+        var info = await RetrieveTwoFactorInfoAsync();
+        if (info is null || info.UserId != user.Id) {
+            return Context.ResolveDeviceId();
+        }
+        return info.DeviceId;
+    }
     #endregion
 
     #region Helper Methods

--- a/src/Indice.Features.Identity.Core/ExtendedSignInManager.cs
+++ b/src/Indice.Features.Identity.Core/ExtendedSignInManager.cs
@@ -413,10 +413,7 @@ public class ExtendedSignInManager<TUser> : SignInManager<TUser> where TUser : U
     private ClaimsPrincipal ClaimsPrincipalFromTwoFactorInfo(string userId, MfaDeviceIdentifier deviceId, string? loginProvider) {
         var identity = new ClaimsIdentity(IdentityConstants.TwoFactorUserIdScheme);
         identity.AddClaim(new Claim(Options.ClaimsIdentity.UserIdClaimType, userId));
-        identity.AddClaim(new Claim(JwtClaimTypes.AuthenticationMethod, "pwd"));
-        if (loginProvider != null) {
-            identity.AddClaim(new Claim(ClaimTypes.AuthenticationMethod, loginProvider));
-        }
+        identity.AddClaim(new Claim(JwtClaimTypes.AuthenticationMethod, loginProvider ?? "pwd"));
         if (!deviceId.IsEmpty) { 
             identity.AddClaim(new Claim(BasicClaimTypes.DeviceId, deviceId.Value!));
         }
@@ -490,19 +487,19 @@ public class ExtendedSignInManager<TUser> : SignInManager<TUser> where TUser : U
         }
         await ResetLockout(user);
         List<Claim> claims = [ 
-            new(JwtClaimTypes.AuthenticationMethod, "pwd"), 
+            new(JwtClaimTypes.AuthenticationMethod, twoFactorInfo.LoginProvider ?? "pwd"), 
             new(JwtClaimTypes.AuthenticationMethod, "mfa") 
         ];
         if (twoFactorInfo.LoginProvider is not null) {
-            claims.Add(new Claim(ClaimTypes.AuthenticationMethod, twoFactorInfo.LoginProvider));
             await Context.SignOutAsync(IdentityConstants.ExternalScheme);
+            await Context.SignOutAsync(IdentityServerConstants.ExternalCookieAuthenticationScheme);
         }
         if (!twoFactorInfo.DeviceId.IsEmpty) {
             claims.Add(new Claim(BasicClaimTypes.DeviceId, twoFactorInfo.DeviceId.Value!));
         }
         await Context.SignOutAsync(IdentityConstants.TwoFactorUserIdScheme);
         if (await ShouldSignInForExtendedValidationAsync(user)) {
-            return await DoPartialSignInAsync(user, twoFactorInfo.DeviceId, ["pwd", "mfa"]);
+            return await DoPartialSignInAsync(user, twoFactorInfo.DeviceId, [twoFactorInfo.LoginProvider ?? "pwd", "mfa"]);
         }
         await SignInWithClaimsAsync(user, isPersistent, claims);
         return SignInResult.Success;

--- a/src/Indice.Features.Identity.Core/ExtendedSignInManager.cs
+++ b/src/Indice.Features.Identity.Core/ExtendedSignInManager.cs
@@ -145,7 +145,7 @@ public class ExtendedSignInManager<TUser> : SignInManager<TUser> where TUser : U
     /// <inheritdoc/>
     protected override async Task<SignInResult> SignInOrTwoFactorAsync(TUser user, bool isPersistent, string? loginProvider = null, bool bypassTwoFactor = false) {
         var isExternalLogin = !string.IsNullOrWhiteSpace(loginProvider) && (await _authenticationSchemeProvider.GetExternalSchemesAsync()).Select(scheme => scheme.Name).Contains(loginProvider);
-        var deviceId = Context.ResolveDeviceId();
+        var deviceId = await GetMfaDeviceIdentifierAsync(user);
         
         var result = await _signInGuard.IsSuspiciousLogin(Context!, user);
         if (result.Warning == SignInWarning.ImpossibleTravel && _signInGuard.ImpossibleTravelDetector?.FlowType == ImpossibleTravelFlowType.DenyLogin) {
@@ -292,7 +292,7 @@ public class ExtendedSignInManager<TUser> : SignInManager<TUser> where TUser : U
 
     /// <inheritdoc/>
     public override async Task RememberTwoFactorClientAsync(TUser user) {
-        var deviceId = Context.ResolveDeviceId();
+        var deviceId = await GetMfaDeviceIdentifierAsync(user);
         var principal = await StoreRememberClient(user, deviceId);
         await Context.SignInAsync(IdentityConstants.TwoFactorRememberMeScheme, principal, new AuthenticationProperties { IsPersistent = true });
     }
@@ -300,19 +300,19 @@ public class ExtendedSignInManager<TUser> : SignInManager<TUser> where TUser : U
     /// <inheritdoc/>
     public override async Task<bool> IsTwoFactorClientRememberedAsync(TUser user) {
         var userId = await ExtendedUserManager.GetUserIdAsync(user);
-        var info = await RetrieveTwoFactorInfoAsync();
-        var isRemembered = info is not null && info.UserId == userId;
-        var deviceId = info?.DeviceId ?? MfaDeviceIdentifier.Empty;
-        if (!deviceId.IsEmpty && (isRemembered || (!isRemembered && RememberTrustedBrowserAcrossSessions))) {
+        var deviceId = await GetMfaDeviceIdentifierAsync(user);
+        if (!deviceId.IsEmpty) {
             var device = await ExtendedUserManager.GetDeviceByIdAsync(user, deviceId.Value!);
-            isRemembered = device is not null &&
-                           device.MfaSessionExpirationDate.HasValue &&
-                           device.MfaSessionExpirationDate.Value > DateTimeOffset.UtcNow;
+            if (device == null) {
+                return false;
+            }
+            var isRemembered = device.MfaSessionActive() || (device.IsTrusted && RememberTrustedBrowserAcrossSessions);
             if (RequireMfaWhenUserHasTrustedBrowserButExpiredPassword) {
                 isRemembered = isRemembered && !user.HasExpiredPassword();
             }
+            return isRemembered;
         }
-        return isRemembered;
+        return false;
     }
 
     /// <inheritdoc/>
@@ -353,11 +353,11 @@ public class ExtendedSignInManager<TUser> : SignInManager<TUser> where TUser : U
     /// <param name="user"></param>
     /// <returns>The device identifier</returns>
     public async Task<MfaDeviceIdentifier> GetMfaDeviceIdentifierAsync(TUser user) {
-        var info = await RetrieveTwoFactorInfoAsync();
-        if (info is null || info.UserId != user.Id) {
+        var result = await Context.AuthenticateAsync(IdentityConstants.TwoFactorRememberMeScheme);
+        if (!result.Succeeded || result.Principal?.FindSubjectId() != user.Id) {
             return Context.ResolveDeviceId();
         }
-        return info.DeviceId;
+        return new MfaDeviceIdentifier(result.Principal.FindFirstValue(BasicClaimTypes.DeviceId));
     }
     #endregion
 

--- a/src/Indice.Features.Identity.Core/ExtendedSignInManager.cs
+++ b/src/Indice.Features.Identity.Core/ExtendedSignInManager.cs
@@ -144,13 +144,13 @@ public class ExtendedSignInManager<TUser> : SignInManager<TUser> where TUser : U
 
     /// <inheritdoc/>
     protected override async Task<SignInResult> SignInOrTwoFactorAsync(TUser user, bool isPersistent, string? loginProvider = null, bool bypassTwoFactor = false) {
-        var isExternalLogin = !string.IsNullOrWhiteSpace(loginProvider) && (await _authenticationSchemeProvider.GetExternalSchemesAsync()).Select(scheme => scheme.Name).Contains(loginProvider);
         var deviceId = await GetMfaDeviceIdentifierAsync(user);
         
         var result = await _signInGuard.IsSuspiciousLogin(Context!, user);
         if (result.Warning == SignInWarning.ImpossibleTravel && _signInGuard.ImpossibleTravelDetector?.FlowType == ImpossibleTravelFlowType.DenyLogin) {
             return SignInResult.Failed;
         }
+
         var mfaImplicitlyPassed = false;
         if (!bypassTwoFactor && await IsTfaEnabled(user)) {
             if (result.Warning == SignInWarning.ImpossibleTravel || !await IsTwoFactorClientRememberedAsync(user)) {
@@ -160,41 +160,36 @@ public class ExtendedSignInManager<TUser> : SignInManager<TUser> where TUser : U
             }
             mfaImplicitlyPassed = true;
         }
-        if (user is User) {
-            var userDevice = !deviceId.IsEmpty ? user.Devices?.FirstOrDefault(x => x.DeviceId == deviceId.Value) : null;
-            if (userDevice is not null) {
-                userDevice.LastSignInDate = DateTimeOffset.UtcNow;
-                await ExtendedUserManager.UpdateDeviceAsync(user, userDevice);
+
+        var userDevice = !deviceId.IsEmpty ? user.Devices?.FirstOrDefault(x => x.DeviceId == deviceId.Value) : null;
+        if (userDevice is not null) {
+            userDevice.LastSignInDate = DateTimeOffset.UtcNow;
+            await ExtendedUserManager.UpdateDeviceAsync(user, userDevice);
+        }
+        if (RememberExpirationType == MfaExpirationType.Sliding) {
+            var authenticateResult = await Context.AuthenticateAsync(IdentityConstants.TwoFactorRememberMeScheme);
+            if (authenticateResult.Succeeded && authenticateResult.Principal is not null) {
+                await RememberTwoFactorClientAsync(user);
             }
-            if (RememberExpirationType == MfaExpirationType.Sliding) {
-                var authenticateResult = await Context.AuthenticateAsync(IdentityConstants.TwoFactorRememberMeScheme);
-                if (authenticateResult.Succeeded && authenticateResult.Principal is not null) {
-                    await RememberTwoFactorClientAsync(user);
-                }
-            }
+        }
+
+        List<string> authenticationMethods = [loginProvider ?? "pwd"];
+        if (mfaImplicitlyPassed) {
+            authenticationMethods.Add("mfa");
         }
         if (await ShouldSignInForExtendedValidationAsync(user)) {
-            var authenticationMethods = new List<string> { "pwd" };
-            if (mfaImplicitlyPassed) {
-                authenticationMethods.Add("mfa");
-            }
             return await DoPartialSignInAsync(user, deviceId, [.. authenticationMethods]);
         }
-        if (loginProvider is null) {
-            var additionalClaims = new List<Claim> {
-                new(JwtClaimTypes.AuthenticationMethod, "pwd")
-            };
-            if (!deviceId.IsEmpty) {
-                additionalClaims.Add(new Claim(BasicClaimTypes.DeviceId, deviceId.Value!));
-            }
-            if (mfaImplicitlyPassed) {
-                additionalClaims.Add(new Claim(JwtClaimTypes.AuthenticationMethod, "mfa"));
-            }
-            await SignInWithClaimsAsync(user, isPersistent, additionalClaims);
-        } else {
+        if (loginProvider != null) {
+            // Cleanup external cookie
             await Context.SignOutAsync(IdentityConstants.ExternalScheme);
-            await SignInAsync(user, isPersistent, loginProvider);
+            await Context.SignOutAsync(IdentityServerConstants.ExternalCookieAuthenticationScheme);   
         }
+        List<Claim> additionalClaims = [.. authenticationMethods.Select(amr => new Claim(JwtClaimTypes.AuthenticationMethod, amr))];
+        if (!deviceId.IsEmpty) {
+            additionalClaims.Add(new (BasicClaimTypes.DeviceId, deviceId.Value!));
+        }
+        await SignInWithClaimsAsync(user, isPersistent, additionalClaims);
         return SignInResult.Success;
     }
 
@@ -313,12 +308,6 @@ public class ExtendedSignInManager<TUser> : SignInManager<TUser> where TUser : U
             return isRemembered;
         }
         return false;
-    }
-
-    /// <inheritdoc/>
-    public override async Task<SignInResult> ExternalLoginSignInAsync(string loginProvider, string providerKey, bool isPersistent, bool bypassTwoFactor) {
-        await Context.SignOutAsync(IdentityServerConstants.ExternalCookieAuthenticationScheme);
-        return await base.ExternalLoginSignInAsync(loginProvider, providerKey, isPersistent, bypassTwoFactor);
     }
 
     #endregion

--- a/src/Indice.Features.Identity.Core/ExtendedSignInManager.cs
+++ b/src/Indice.Features.Identity.Core/ExtendedSignInManager.cs
@@ -306,10 +306,10 @@ public class ExtendedSignInManager<TUser> : SignInManager<TUser> where TUser : U
             if (device == null) {
                 return false;
             }
-            var isRemembered = device.MfaSessionActive() || (device.IsTrusted && RememberTrustedBrowserAcrossSessions);
-            if (RequireMfaWhenUserHasTrustedBrowserButExpiredPassword) {
-                isRemembered = isRemembered && !user.HasExpiredPassword();
+            if (RequireMfaWhenUserHasTrustedBrowserButExpiredPassword && user.HasExpiredPassword()) {
+                return false;
             }
+            var isRemembered = device.MfaSessionActive() || (device.IsTrusted && RememberTrustedBrowserAcrossSessions);
             return isRemembered;
         }
         return false;

--- a/src/Indice.Features.Identity.Core/ExtendedSignInManager.cs
+++ b/src/Indice.Features.Identity.Core/ExtendedSignInManager.cs
@@ -145,7 +145,7 @@ public class ExtendedSignInManager<TUser> : SignInManager<TUser> where TUser : U
     /// <inheritdoc/>
     protected override async Task<SignInResult> SignInOrTwoFactorAsync(TUser user, bool isPersistent, string? loginProvider = null, bool bypassTwoFactor = false) {
         var isExternalLogin = !string.IsNullOrWhiteSpace(loginProvider) && (await _authenticationSchemeProvider.GetExternalSchemesAsync()).Select(scheme => scheme.Name).Contains(loginProvider);
-        var deviceId = Context.ResolveDeviceId();
+        var deviceId = await Context.ResolveDeviceIdAsync();
         
         var result = await _signInGuard.IsSuspiciousLogin(Context!, user);
         if (result.Warning == SignInWarning.ImpossibleTravel && _signInGuard.ImpossibleTravelDetector?.FlowType == ImpossibleTravelFlowType.DenyLogin) {
@@ -292,7 +292,7 @@ public class ExtendedSignInManager<TUser> : SignInManager<TUser> where TUser : U
 
     /// <inheritdoc/>
     public override async Task RememberTwoFactorClientAsync(TUser user) {
-        var deviceId = Context.ResolveDeviceId();
+        var deviceId = await Context.ResolveDeviceIdAsync();
         var principal = await StoreRememberClient(user, deviceId);
         await Context.SignInAsync(IdentityConstants.TwoFactorRememberMeScheme, principal, new AuthenticationProperties { IsPersistent = true });
     }
@@ -302,7 +302,7 @@ public class ExtendedSignInManager<TUser> : SignInManager<TUser> where TUser : U
         var userId = await ExtendedUserManager.GetUserIdAsync(user);
         var result = await Context.AuthenticateAsync(IdentityConstants.TwoFactorRememberMeScheme);
         var isRemembered = result?.Principal is not null && result.Principal.FindFirstValue(Options.ClaimsIdentity.UserIdClaimType) == userId;
-        var deviceId = Context.ResolveDeviceId();
+        var deviceId = await Context.ResolveDeviceIdAsync();
         deviceId = deviceId.IsEmpty ? new MfaDeviceIdentifier(result?.Principal?.FindFirstValue(BasicClaimTypes.DeviceId)) : deviceId;
         if (!deviceId.IsEmpty && (isRemembered || (!isRemembered && RememberTrustedBrowserAcrossSessions))) {
             var device = await ExtendedUserManager.GetDeviceByIdAsync(user, deviceId.Value!);
@@ -353,7 +353,7 @@ public class ExtendedSignInManager<TUser> : SignInManager<TUser> where TUser : U
     /// <summary>Gets the current device id from context (broser cookie or form post)</summary>
     /// <param name="user"></param>
     /// <returns>The device identifier</returns>
-    public MfaDeviceIdentifier GetMfaDeviceIdentifier(TUser user) => Context.ResolveDeviceId();
+    public ValueTask<MfaDeviceIdentifier> GetMfaDeviceIdentifier(TUser user) => Context.ResolveDeviceIdAsync();
     #endregion
 
     #region Helper Methods

--- a/src/Indice.Features.Identity.Core/ExtendedSignInManager.cs
+++ b/src/Indice.Features.Identity.Core/ExtendedSignInManager.cs
@@ -37,7 +37,6 @@ public class ExtendedSignInManager<TUser> : SignInManager<TUser> where TUser : U
     private readonly ISignInGuard<TUser> _signInGuard;
     private readonly IPlatformEventService _eventService;
     private readonly IUserRequirementProvider<TUser> _userRequirementProvider;
-    private readonly IHttpContextAccessor _httpContextAccessor;
 
     /// <summary>Creates a new instance of <see cref="SignInManager{TUser}" /></summary>
     /// <param name="userManager">An instance of <see cref="ExtendedUserManager{TUser}"/> used to retrieve users from and persist users.</param>
@@ -70,7 +69,6 @@ public class ExtendedSignInManager<TUser> : SignInManager<TUser> where TUser : U
     ) : base(userManager, httpContextAccessor, claimsFactory, optionsAccessor, logger, schemes, confirmation) {
         _authenticationSchemeProvider = authenticationSchemeProvider ?? throw new ArgumentNullException(nameof(authenticationSchemeProvider));
         _userStore = userStore ?? throw new ArgumentNullException(nameof(userStore));
-        _httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
         _signInGuard = signInGuard ?? throw new ArgumentNullException(nameof(signInGuard));
         _eventService = eventService ?? throw new ArgumentNullException(nameof(eventService));
         _userRequirementProvider = userRequirementProvider ?? throw new ArgumentNullException(nameof(userRequirementProvider));
@@ -147,9 +145,9 @@ public class ExtendedSignInManager<TUser> : SignInManager<TUser> where TUser : U
     /// <inheritdoc/>
     protected override async Task<SignInResult> SignInOrTwoFactorAsync(TUser user, bool isPersistent, string? loginProvider = null, bool bypassTwoFactor = false) {
         var isExternalLogin = !string.IsNullOrWhiteSpace(loginProvider) && (await _authenticationSchemeProvider.GetExternalSchemesAsync()).Select(scheme => scheme.Name).Contains(loginProvider);
-        var deviceId = _httpContextAccessor.HttpContext.ResolveDeviceId();
+        var deviceId = Context.ResolveDeviceId();
         
-        var result = await _signInGuard.IsSuspiciousLogin(_httpContextAccessor.HttpContext!, user);
+        var result = await _signInGuard.IsSuspiciousLogin(Context!, user);
         if (result.Warning == SignInWarning.ImpossibleTravel && _signInGuard.ImpossibleTravelDetector?.FlowType == ImpossibleTravelFlowType.DenyLogin) {
             return SignInResult.Failed;
         }
@@ -159,9 +157,8 @@ public class ExtendedSignInManager<TUser> : SignInManager<TUser> where TUser : U
                 var userId = await ExtendedUserManager.GetUserIdAsync(user);
                 await Context.SignInAsync(IdentityConstants.TwoFactorUserIdScheme, ClaimsPrincipalFromTwoFactorInfo(userId, deviceId, loginProvider));
                 return SignInResult.TwoFactorRequired;
-            } else {
-                mfaImplicitlyPassed = true;
             }
+            mfaImplicitlyPassed = true;
         }
         if (user is User) {
             var userDevice = !deviceId.IsEmpty ? user.Devices?.FirstOrDefault(x => x.DeviceId == deviceId.Value) : null;
@@ -206,7 +203,7 @@ public class ExtendedSignInManager<TUser> : SignInManager<TUser> where TUser : U
         user.LastSignInDate = DateTimeOffset.UtcNow;
         await ExtendedUserManager.UpdateAsync(user);
         await base.SignInWithClaimsAsync(user, authenticationProperties, additionalClaims);
-        var result = await _signInGuard.IsSuspiciousLogin(_httpContextAccessor.HttpContext, user);
+        var result = await _signInGuard.IsSuspiciousLogin(Context, user);
         await _eventService.Publish(UserLoginEvent.Success(
             UserEventContext.InitializeFromUser(user),
             result.Warning,
@@ -268,7 +265,7 @@ public class ExtendedSignInManager<TUser> : SignInManager<TUser> where TUser : U
         if (!attempt.Succeeded) {
             return attempt;
         }
-        var result = await _signInGuard.IsSuspiciousLogin(_httpContextAccessor.HttpContext, user);
+        var result = await _signInGuard.IsSuspiciousLogin(Context, user);
         await _eventService.Publish(UserPasswordLoginEvent.Success(UserEventContext.InitializeFromUser(user), result.Warning));
         if (ExpireBlacklistedPasswordsOnSignIn) {
             var blacklistPasswordValidator = ExtendedUserManager.PasswordValidators.OfType<NonCommonPasswordValidator<TUser>>().FirstOrDefault();
@@ -295,7 +292,7 @@ public class ExtendedSignInManager<TUser> : SignInManager<TUser> where TUser : U
 
     /// <inheritdoc/>
     public override async Task RememberTwoFactorClientAsync(TUser user) {
-        var deviceId = _httpContextAccessor.HttpContext.ResolveDeviceId();
+        var deviceId = Context.ResolveDeviceId();
         var principal = await StoreRememberClient(user, deviceId);
         await Context.SignInAsync(IdentityConstants.TwoFactorRememberMeScheme, principal, new AuthenticationProperties { IsPersistent = true });
     }
@@ -305,9 +302,10 @@ public class ExtendedSignInManager<TUser> : SignInManager<TUser> where TUser : U
         var userId = await ExtendedUserManager.GetUserIdAsync(user);
         var result = await Context.AuthenticateAsync(IdentityConstants.TwoFactorRememberMeScheme);
         var isRemembered = result?.Principal is not null && result.Principal.FindFirstValue(Options.ClaimsIdentity.UserIdClaimType) == userId;
-        var deviceId = _httpContextAccessor.HttpContext.ResolveDeviceId();
-        if (!string.IsNullOrWhiteSpace(deviceId.Value) && (isRemembered || (!isRemembered && RememberTrustedBrowserAcrossSessions))) {
-            var device = await ExtendedUserManager.GetDeviceByIdAsync(user, deviceId.Value);
+        var deviceId = Context.ResolveDeviceId();
+        deviceId = deviceId.IsEmpty ? new MfaDeviceIdentifier(result?.Principal?.FindFirstValue(BasicClaimTypes.DeviceId)) : deviceId;
+        if (!deviceId.IsEmpty && (isRemembered || (!isRemembered && RememberTrustedBrowserAcrossSessions))) {
+            var device = await ExtendedUserManager.GetDeviceByIdAsync(user, deviceId.Value!);
             isRemembered = device is not null &&
                            device.MfaSessionExpirationDate.HasValue &&
                            device.MfaSessionExpirationDate.Value > DateTimeOffset.UtcNow;
@@ -342,12 +340,12 @@ public class ExtendedSignInManager<TUser> : SignInManager<TUser> where TUser : U
     /// <param name="user">The user instance.</param>
     /// <param name="scheme">Authenticates the current request using the specified scheme.</param>
     public async Task<AuthenticationProperties?> AutoSignIn(TUser user, string scheme) {
-        var authenticateResult = await _httpContextAccessor.HttpContext!.AuthenticateAsync(scheme);
+        var authenticateResult = await Context!.AuthenticateAsync(scheme);
         AuthenticationProperties? authenticationProperties = default;
         if (authenticateResult.Succeeded) {
             authenticationProperties = authenticateResult.Properties;
             await SignInWithClaimsAsync(user, authenticationProperties, authenticateResult.Principal.Claims.Where(x => x.Type == JwtClaimTypes.AuthenticationMethod || x.Type == BasicClaimTypes.DeviceId));
-            await _httpContextAccessor.HttpContext!.SignOutAsync(scheme);
+            await Context!.SignOutAsync(scheme);
         }
         return authenticationProperties;
     }
@@ -355,7 +353,7 @@ public class ExtendedSignInManager<TUser> : SignInManager<TUser> where TUser : U
     /// <summary>Gets the current device id from context (broser cookie or form post)</summary>
     /// <param name="user"></param>
     /// <returns>The device identifier</returns>
-    public MfaDeviceIdentifier GetMfaDeviceIdentifier(TUser user) => _httpContextAccessor.HttpContext.ResolveDeviceId();
+    public MfaDeviceIdentifier GetMfaDeviceIdentifier(TUser user) => Context.ResolveDeviceId();
     #endregion
 
     #region Helper Methods
@@ -391,7 +389,7 @@ public class ExtendedSignInManager<TUser> : SignInManager<TUser> where TUser : U
     /// <param name="user">The user to check</param>
     /// <returns>True in case of extended validaton requirement</returns>
     public Task<bool> ShouldSignInForExtendedValidationAsync(TUser user) => 
-        _userRequirementProvider.RequiresValidationAsync(_httpContextAccessor.HttpContext!, user);
+        _userRequirementProvider.RequiresValidationAsync(Context!, user);
 
     private async Task<bool> IsTfaEnabled(TUser user)
         => ExtendedUserManager.SupportsUserTwoFactor && user.TwoFactorEnabled && (await ExtendedUserManager.GetValidTwoFactorProvidersAsync(user)).Count > 0;
@@ -464,6 +462,9 @@ public class ExtendedSignInManager<TUser> : SignInManager<TUser> where TUser : U
         var userId = await ExtendedUserManager.GetUserIdAsync(user);
         var deviceIdentity = new ClaimsIdentity(IdentityConstants.TwoFactorRememberMeScheme);
         deviceIdentity.AddClaim(new Claim(Options.ClaimsIdentity.UserIdClaimType, userId));
+        if (!deviceId.IsEmpty) { 
+            deviceIdentity.AddClaim(new Claim(BasicClaimTypes.DeviceId, deviceId.Value!));
+        }
         if (ExtendedUserManager.SupportsUserSecurityStamp) {
             deviceIdentity.AddClaim(new Claim(Options.ClaimsIdentity.SecurityStampClaimType, user.SecurityStamp ?? string.Empty));
         }

--- a/src/Indice.Features.Identity.Core/ExtendedUserManager.cs
+++ b/src/Indice.Features.Identity.Core/ExtendedUserManager.cs
@@ -464,7 +464,7 @@ public partial class ExtendedUserManager<TUser> : UserManager<TUser> where TUser
         return await ReplaceClaimAsync(user, BasicClaimTypes.MaxDevicesCount, maxDevicesCount.ToString());
     }
 
-    /// <summary>Get the devices registered by the specified user.</summary>
+    /// <summary>Get a device registered by the specified user using the specified deviceId.</summary>
     /// <param name="user">The user instance.</param>
     /// <param name="deviceId">The id of the device to look for.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled.</param>

--- a/src/Indice.Features.Identity.Core/ExtendedUserManager.cs
+++ b/src/Indice.Features.Identity.Core/ExtendedUserManager.cs
@@ -111,7 +111,7 @@ public partial class ExtendedUserManager<TUser> : UserManager<TUser> where TUser
         return base.UpdateAsync(user);
     }
 
-    /// </inheritdoc />
+    /// <inheritdoc />
     public override async Task<IdentityResult> DeleteAsync(TUser user) {
         var result = await base.DeleteAsync(user);
         if (result.Succeeded) {

--- a/src/Indice.Features.Identity.Core/ExtendedUserManager.cs
+++ b/src/Indice.Features.Identity.Core/ExtendedUserManager.cs
@@ -111,6 +111,15 @@ public partial class ExtendedUserManager<TUser> : UserManager<TUser> where TUser
         return base.UpdateAsync(user);
     }
 
+    /// </inheritdoc />
+    public override async Task<IdentityResult> DeleteAsync(TUser user) {
+        var result = await base.DeleteAsync(user);
+        if (result.Succeeded) {
+            await _eventService.Publish(new UserDeletedEvent(UserEventContext.InitializeFromUser(user)));
+        }
+        return result;
+    }
+
     /// <inheritdoc />
     public async override Task<IdentityResult> ChangePasswordAsync(TUser user, string currentPassword, string newPassword) {
         var result = await base.ChangePasswordAsync(user, currentPassword, newPassword);

--- a/src/Indice.Features.Identity.Core/Extensions/HttpContextExtensions.cs
+++ b/src/Indice.Features.Identity.Core/Extensions/HttpContextExtensions.cs
@@ -14,18 +14,16 @@ public static class HttpContextExtensions
 {
     /// <summary>Tries to resolve the device id using the current http request. <see cref="HttpContext"/>.</summary>
     /// <param name="httpContext">Encapsulates all HTTP-specific information about an individual HTTP request.</param>
-    public static async ValueTask<MfaDeviceIdentifier> ResolveDeviceIdAsync(this HttpContext? httpContext) {
+    public static MfaDeviceIdentifier ResolveDeviceId(this HttpContext? httpContext) {
         var request = httpContext?.Request;
         if (request is not null) {
-            return new MfaDeviceIdentifier(await FindDeviceIdAsync(httpContext!), FindRegistrationId(httpContext!));
+            return new MfaDeviceIdentifier(FindDeviceId(httpContext!), FindRegistrationId(httpContext!));
         }
         return MfaDeviceIdentifier.Empty;
     }
 
-    private static async ValueTask<string?> FindDeviceIdAsync(HttpContext httpContext) {
-        if (httpContext is null) {
-            throw new ArgumentNullException(nameof(httpContext));
-        }
+    private static string? FindDeviceId(HttpContext httpContext) {
+        ArgumentNullException.ThrowIfNull(httpContext);
         var deviceId = default(StringValues);
         var requestHasDeviceId = httpContext.Request.HasFormContentType && (
             httpContext.Request.Form.TryGetValue("DeviceId", out deviceId) ||
@@ -37,15 +35,18 @@ public static class HttpContextExtensions
             requestHasDeviceId = MfaDeviceIdentifier.ValidateDeviceId(deviceId);
         }
         if (!requestHasDeviceId) {
-            deviceId = httpContext.User.FindFirstValue(BasicClaimTypes.DeviceId);
-            requestHasDeviceId = MfaDeviceIdentifier.ValidateDeviceId(deviceId);
+            deviceId = FindDeviceId(httpContext.User);
         }
-        if (!requestHasDeviceId) {
-            var result = await httpContext.AuthenticateAsync(IdentityConstants.TwoFactorRememberMeScheme);
-            deviceId = result.Principal?.FindFirstValue(BasicClaimTypes.DeviceId);
-            requestHasDeviceId = MfaDeviceIdentifier.ValidateDeviceId(deviceId);
+        return requestHasDeviceId ? deviceId.ToString() : default;
+    }
+
+    private static string? FindDeviceId(ClaimsPrincipal claimsPrincipal) {
+        ArgumentNullException.ThrowIfNull(claimsPrincipal);
+        var deviceId = claimsPrincipal.FindFirstValue(BasicClaimTypes.DeviceId);
+        if (!MfaDeviceIdentifier.ValidateDeviceId(deviceId)) {
+            return null;
         }
-        return requestHasDeviceId ? deviceId.ToString().Trim() : default;
+        return deviceId!.Trim();
     }
 
     private static Guid? FindRegistrationId(HttpContext httpContext) {

--- a/src/Indice.Features.Identity.Core/Extensions/HttpContextExtensions.cs
+++ b/src/Indice.Features.Identity.Core/Extensions/HttpContextExtensions.cs
@@ -2,8 +2,11 @@
 using Indice.Features.Identity.Core.DeviceAuthentication.Configuration;
 using Indice.Features.Identity.Core.Models;
 using Indice.Security;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Primitives;
+using Polly;
 
 namespace Indice.Features.Identity.Core.Extensions;
 
@@ -12,15 +15,15 @@ public static class HttpContextExtensions
 {
     /// <summary>Tries to resolve the device id using the <see cref="HttpContext"/>.</summary>
     /// <param name="httpContext">Encapsulates all HTTP-specific information about an individual HTTP request.</param>
-    public static MfaDeviceIdentifier ResolveDeviceId(this HttpContext? httpContext) {
+    public static async ValueTask<MfaDeviceIdentifier> ResolveDeviceIdAsync(this HttpContext? httpContext) {
         var request = httpContext?.Request;
         if (request is not null) {
-            return new MfaDeviceIdentifier(GetDeviceId(httpContext!), GetRegistrationId(httpContext!));
+            return new MfaDeviceIdentifier(await GetDeviceIdAsync(httpContext!), GetRegistrationId(httpContext!));
         }
         return MfaDeviceIdentifier.Empty;
     }
 
-    private static string? GetDeviceId(HttpContext httpContext) {
+    private static async ValueTask<string?> GetDeviceIdAsync(HttpContext httpContext) {
         if (httpContext is null) {
             throw new ArgumentNullException(nameof(httpContext));
         }
@@ -36,6 +39,11 @@ public static class HttpContextExtensions
         }
         if (!hasDeviceId) {
             deviceId = httpContext.User.FindFirstValue(BasicClaimTypes.DeviceId);
+            hasDeviceId = !string.IsNullOrWhiteSpace(deviceId);
+        }
+        if (!hasDeviceId) {
+            var result = await httpContext.AuthenticateAsync(IdentityConstants.TwoFactorRememberMeScheme);
+            deviceId = result.Principal?.FindFirstValue(BasicClaimTypes.DeviceId);
             hasDeviceId = !string.IsNullOrWhiteSpace(deviceId);
         }
         return hasDeviceId ? deviceId.ToString() : default;

--- a/src/Indice.Features.Identity.Core/Extensions/HttpContextExtensions.cs
+++ b/src/Indice.Features.Identity.Core/Extensions/HttpContextExtensions.cs
@@ -31,21 +31,41 @@ public static class HttpContextExtensions
             httpContext.Request.Form.TryGetValue("DeviceId", out deviceId) ||
             httpContext.Request.Form.TryGetValue("Input.DeviceId", out deviceId) ||
             httpContext.Request.Form.TryGetValue(RegistrationRequestParameters.DeviceId, out deviceId) 
-        ) && !string.IsNullOrWhiteSpace(deviceId);
+        ) && MfaDeviceIdentifier.ValidateDeviceId(deviceId);
         if (!hasDeviceId && httpContext.Items.TryGetValue("deviceId", out var deviceIdObject)) {
             deviceId = deviceIdObject?.ToString();
-            hasDeviceId = !string.IsNullOrWhiteSpace(deviceId);
+            hasDeviceId = MfaDeviceIdentifier.ValidateDeviceId(deviceId);
         }
         if (!hasDeviceId) {
             deviceId = httpContext.User.FindFirstValue(BasicClaimTypes.DeviceId);
-            hasDeviceId = !string.IsNullOrWhiteSpace(deviceId);
+            hasDeviceId = MfaDeviceIdentifier.ValidateDeviceId(deviceId);
         }
         if (!hasDeviceId) {
             var result = await httpContext.AuthenticateAsync(IdentityConstants.TwoFactorRememberMeScheme);
             deviceId = result.Principal?.FindFirstValue(BasicClaimTypes.DeviceId);
-            hasDeviceId = !string.IsNullOrWhiteSpace(deviceId);
+            hasDeviceId = MfaDeviceIdentifier.ValidateDeviceId(deviceId);
         }
-        return hasDeviceId ? deviceId.ToString() : default;
+        return hasDeviceId ? deviceId.ToString().Trim() : default;
+    }
+
+    /// <summary>
+    /// Validates the device id.
+    /// </summary>
+    /// <param name="deviceId">The input device id as a string</param>
+    /// <returns>True if the device id is valid. Otherwize false</returns>
+    private static bool ValidateDeviceId(string? deviceId) {
+        // Do the flollowing checks:
+        // - check for empty
+        // - check for null
+        // - check format can be either one of the following
+        //   - valid guid (using Guid.TryParse)
+        //   - a valid browser fingerprint format `{sha256}.{browerName}`.
+        //     Usually fingerprint hash is a sha256 that is 64 characters long in string representation.
+        //     Also in order to avoid colisions with same browser engine different vendors
+        //     we suffix the browser fingerprint with the browser name separated with the dot `.` character.
+        return !string.IsNullOrWhiteSpace(deviceId) &&
+               (Guid.TryParse(deviceId, out _) ||
+                deviceId.Length > 65 && deviceId.IndexOf('.') > 0 && deviceId.Split('.')[0].Length == 65);
     }
 
     private static Guid? GetRegistrationId(HttpContext httpContext) {

--- a/src/Indice.Features.Identity.Core/Extensions/HttpContextExtensions.cs
+++ b/src/Indice.Features.Identity.Core/Extensions/HttpContextExtensions.cs
@@ -12,63 +12,43 @@ namespace Indice.Features.Identity.Core.Extensions;
 /// <summary>Helper methods on <see cref="HttpContent"/>.</summary>
 public static class HttpContextExtensions
 {
-    /// <summary>Tries to resolve the device id using the <see cref="HttpContext"/>.</summary>
+    /// <summary>Tries to resolve the device id using the current http request. <see cref="HttpContext"/>.</summary>
     /// <param name="httpContext">Encapsulates all HTTP-specific information about an individual HTTP request.</param>
     public static async ValueTask<MfaDeviceIdentifier> ResolveDeviceIdAsync(this HttpContext? httpContext) {
         var request = httpContext?.Request;
         if (request is not null) {
-            return new MfaDeviceIdentifier(await GetDeviceIdAsync(httpContext!), GetRegistrationId(httpContext!));
+            return new MfaDeviceIdentifier(await FindDeviceIdAsync(httpContext!), FindRegistrationId(httpContext!));
         }
         return MfaDeviceIdentifier.Empty;
     }
 
-    private static async ValueTask<string?> GetDeviceIdAsync(HttpContext httpContext) {
+    private static async ValueTask<string?> FindDeviceIdAsync(HttpContext httpContext) {
         if (httpContext is null) {
             throw new ArgumentNullException(nameof(httpContext));
         }
         var deviceId = default(StringValues);
-        var hasDeviceId = httpContext.Request.HasFormContentType && (
+        var requestHasDeviceId = httpContext.Request.HasFormContentType && (
             httpContext.Request.Form.TryGetValue("DeviceId", out deviceId) ||
             httpContext.Request.Form.TryGetValue("Input.DeviceId", out deviceId) ||
             httpContext.Request.Form.TryGetValue(RegistrationRequestParameters.DeviceId, out deviceId) 
         ) && MfaDeviceIdentifier.ValidateDeviceId(deviceId);
-        if (!hasDeviceId && httpContext.Items.TryGetValue("deviceId", out var deviceIdObject)) {
+        if (!requestHasDeviceId && httpContext.Items.TryGetValue("deviceId", out var deviceIdObject)) {
             deviceId = deviceIdObject?.ToString();
-            hasDeviceId = MfaDeviceIdentifier.ValidateDeviceId(deviceId);
+            requestHasDeviceId = MfaDeviceIdentifier.ValidateDeviceId(deviceId);
         }
-        if (!hasDeviceId) {
+        if (!requestHasDeviceId) {
             deviceId = httpContext.User.FindFirstValue(BasicClaimTypes.DeviceId);
-            hasDeviceId = MfaDeviceIdentifier.ValidateDeviceId(deviceId);
+            requestHasDeviceId = MfaDeviceIdentifier.ValidateDeviceId(deviceId);
         }
-        if (!hasDeviceId) {
+        if (!requestHasDeviceId) {
             var result = await httpContext.AuthenticateAsync(IdentityConstants.TwoFactorRememberMeScheme);
             deviceId = result.Principal?.FindFirstValue(BasicClaimTypes.DeviceId);
-            hasDeviceId = MfaDeviceIdentifier.ValidateDeviceId(deviceId);
+            requestHasDeviceId = MfaDeviceIdentifier.ValidateDeviceId(deviceId);
         }
-        return hasDeviceId ? deviceId.ToString().Trim() : default;
+        return requestHasDeviceId ? deviceId.ToString().Trim() : default;
     }
 
-    /// <summary>
-    /// Validates the device id.
-    /// </summary>
-    /// <param name="deviceId">The input device id as a string</param>
-    /// <returns>True if the device id is valid. Otherwize false</returns>
-    private static bool ValidateDeviceId(string? deviceId) {
-        // Do the flollowing checks:
-        // - check for empty
-        // - check for null
-        // - check format can be either one of the following
-        //   - valid guid (using Guid.TryParse)
-        //   - a valid browser fingerprint format `{sha256}.{browerName}`.
-        //     Usually fingerprint hash is a sha256 that is 64 characters long in string representation.
-        //     Also in order to avoid colisions with same browser engine different vendors
-        //     we suffix the browser fingerprint with the browser name separated with the dot `.` character.
-        return !string.IsNullOrWhiteSpace(deviceId) &&
-               (Guid.TryParse(deviceId, out _) ||
-                deviceId.Length > 65 && deviceId.IndexOf('.') > 0 && deviceId.Split('.')[0].Length == 65);
-    }
-
-    private static Guid? GetRegistrationId(HttpContext httpContext) {
+    private static Guid? FindRegistrationId(HttpContext httpContext) {
         var registrationId = default(Guid);
         var hasRegistrationId = httpContext.Request.HasFormContentType &&
                                 httpContext.Request.Form.TryGetValue(RegistrationRequestParameters.RegistrationId, out var registrationIdText) &&

--- a/src/Indice.Features.Identity.Core/Extensions/HttpContextExtensions.cs
+++ b/src/Indice.Features.Identity.Core/Extensions/HttpContextExtensions.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Primitives;
-using Polly;
 
 namespace Indice.Features.Identity.Core.Extensions;
 

--- a/src/Indice.Features.Identity.Core/Extensions/HttpContextExtensions.cs
+++ b/src/Indice.Features.Identity.Core/Extensions/HttpContextExtensions.cs
@@ -2,9 +2,7 @@
 using Indice.Features.Identity.Core.DeviceAuthentication.Configuration;
 using Indice.Features.Identity.Core.Models;
 using Indice.Security;
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Primitives;
 
 namespace Indice.Features.Identity.Core.Extensions;

--- a/src/Indice.Features.Identity.Core/Extensions/HttpContextExtensions.cs
+++ b/src/Indice.Features.Identity.Core/Extensions/HttpContextExtensions.cs
@@ -25,19 +25,21 @@ public static class HttpContextExtensions
     private static string? FindDeviceId(HttpContext httpContext) {
         ArgumentNullException.ThrowIfNull(httpContext);
         var deviceId = default(StringValues);
-        var requestHasDeviceId = httpContext.Request.HasFormContentType && (
+        var found = httpContext.Request.HasFormContentType && (
             httpContext.Request.Form.TryGetValue("DeviceId", out deviceId) ||
             httpContext.Request.Form.TryGetValue("Input.DeviceId", out deviceId) ||
             httpContext.Request.Form.TryGetValue(RegistrationRequestParameters.DeviceId, out deviceId) 
         ) && MfaDeviceIdentifier.ValidateDeviceId(deviceId);
-        if (!requestHasDeviceId && httpContext.Items.TryGetValue("deviceId", out var deviceIdObject)) {
-            deviceId = deviceIdObject?.ToString();
-            requestHasDeviceId = MfaDeviceIdentifier.ValidateDeviceId(deviceId);
+        if (found) {
+            return deviceId.ToString();
         }
-        if (!requestHasDeviceId) {
-            deviceId = FindDeviceId(httpContext.User);
+        if (httpContext.Items.TryGetValue("deviceId", out var deviceIdObject) && MfaDeviceIdentifier.ValidateDeviceId(deviceIdObject?.ToString())) {
+            return deviceIdObject!.ToString();
         }
-        return requestHasDeviceId ? deviceId.ToString() : default;
+        if (httpContext.User is not null) {
+            return FindDeviceId(httpContext.User);
+        }
+        return null;
     }
 
     private static string? FindDeviceId(ClaimsPrincipal claimsPrincipal) {

--- a/src/Indice.Features.Identity.Core/Models/MfaDeviceIdentifier.cs
+++ b/src/Indice.Features.Identity.Core/Models/MfaDeviceIdentifier.cs
@@ -1,10 +1,15 @@
-﻿namespace Indice.Features.Identity.Core.Models;
+﻿using System.Text.RegularExpressions;
+
+namespace Indice.Features.Identity.Core.Models;
 
 /// <summary>Models an MFA device identifier.</summary>
 /// <param name="Value">The device id.</param>
 /// <param name="RegistrationId">The device registration id.</param>
-public record MfaDeviceIdentifier(string? Value, Guid? RegistrationId = null)
+public sealed partial record MfaDeviceIdentifier(string? Value, Guid? RegistrationId = null)
 {
+    private static readonly Regex _deviceIdFormat = DevideIdentifierFormat();
+    private static readonly MfaDeviceIdentifier _empty = new(string.Empty, null);
+
     /// <summary>Determines if there is a value for <see cref="RegistrationId"/>.</summary>
     public bool HasRegistrationId => RegistrationId.HasValue;
 
@@ -14,5 +19,45 @@ public record MfaDeviceIdentifier(string? Value, Guid? RegistrationId = null)
     /// <summary>
     /// Empty MfaDeviceIdentifier
     /// </summary>
-    public static MfaDeviceIdentifier Empty { get; } = new MfaDeviceIdentifier(Value: null);
+    public static MfaDeviceIdentifier Empty => _empty;
+
+    /// <summary>
+    /// Validates the device id.
+    /// </summary>
+    /// <param name="deviceId">The input device id as a string</param>
+    /// <returns>True if the device id is valid. Otherwize false</returns>
+    /// <remarks>
+    /// the device id can be either one of the following:
+    /// <list type="bullet">
+    ///   <item>valid guid (using Guid.TryParse)</item>
+    ///   <item>a valid browser fingerprint format `{hash128}.{browerName}`.
+    ///     Usually fingerprint hash is a sha256 that is 64 characters long in hex string representation.
+    ///     Also in order to avoid colisions with same browser engine different vendors
+    ///     we suffix the browser fingerprint with the browser name separated with the dot `.` character.
+    ///   </item>
+    /// </list>
+    /// </remarks>
+    public static bool ValidateDeviceId(string? deviceId) {
+        // Do the flollowing checks:
+        // - check for empty
+        // - check for null
+        // - check format can be either one of the following
+        //   - valid guid (using Guid.TryParse)
+        //   - a valid browser fingerprint format `{hash128}.{browerName}`.
+        //     Usually fingerprint hash is a md5 that is 32 characters long in hex string representation.
+        //     Also in order to avoid colisions with same browser engine different vendors
+        //     we suffix the browser fingerprint with the browser name separated with the dot `.` character.
+        return !string.IsNullOrWhiteSpace(deviceId) &&
+               (Guid.TryParse(deviceId, out _) ||
+                _deviceIdFormat.IsMatch(deviceId));
+    }
+
+    [GeneratedRegex(@"^([a-fA-F0-9]{32})(\.[a-zA-Z0-9\-]+)?$")]
+    private static partial Regex DevideIdentifierFormat();
+
+    /// <inheritdoc />
+    public override int GetHashCode() => Value?.GetHashCode() ?? string.Empty.GetHashCode();
+
+    /// <inheritdoc />
+    public bool Equals(MfaDeviceIdentifier? other) => GetHashCode().Equals(other?.GetHashCode() ?? -1);
 }

--- a/src/Indice.Features.Identity.Core/Models/MfaDeviceIdentifier.cs
+++ b/src/Indice.Features.Identity.Core/Models/MfaDeviceIdentifier.cs
@@ -53,7 +53,7 @@ public sealed partial record MfaDeviceIdentifier(string? Value, Guid? Registrati
     }
 
     [GeneratedRegex(@"^([a-fA-F0-9]{32})(\.[a-zA-Z0-9\-]+)?$")]
-    private static partial Regex DevideIdentifierFormat();
+    public static partial Regex DevideIdentifierFormat();
 
     /// <inheritdoc />
     public override int GetHashCode() => Value?.GetHashCode() ?? string.Empty.GetHashCode();

--- a/src/Indice.Features.Identity.SignInLogs/Enrichers/DeviceIdEnricher.cs
+++ b/src/Indice.Features.Identity.SignInLogs/Enrichers/DeviceIdEnricher.cs
@@ -23,13 +23,14 @@ public sealed class DeviceIdEnricher : ISignInLogEntryEnricher
     public SignInLogEnricherRunType RunType => SignInLogEnricherRunType.Synchronous;
 
     /// <inheritdoc />
-    public async ValueTask EnrichAsync(SignInLogEntry logEntry) {
-        var device = await _httpContextAccessor.HttpContext.ResolveDeviceId();
+    public ValueTask EnrichAsync(SignInLogEntry logEntry) {
+        var device = _httpContextAccessor.HttpContext.ResolveDeviceId();
         logEntry.DeviceId = device.Value;
         if (device.HasRegistrationId) {
             logEntry.ExtraData.UserDevice = new SignInLogEntryUserDevice {
                 Id = device.RegistrationId.Value
             };
         }
+        return ValueTask.CompletedTask;
     }
 }

--- a/src/Indice.Features.Identity.SignInLogs/Enrichers/DeviceIdEnricher.cs
+++ b/src/Indice.Features.Identity.SignInLogs/Enrichers/DeviceIdEnricher.cs
@@ -24,7 +24,7 @@ public sealed class DeviceIdEnricher : ISignInLogEntryEnricher
 
     /// <inheritdoc />
     public async ValueTask EnrichAsync(SignInLogEntry logEntry) {
-        var device = await _httpContextAccessor.HttpContext.ResolveDeviceIdAsync();
+        var device = await _httpContextAccessor.HttpContext.ResolveDeviceId();
         logEntry.DeviceId = device.Value;
         if (device.HasRegistrationId) {
             logEntry.ExtraData.UserDevice = new SignInLogEntryUserDevice {

--- a/src/Indice.Features.Identity.SignInLogs/Enrichers/DeviceIdEnricher.cs
+++ b/src/Indice.Features.Identity.SignInLogs/Enrichers/DeviceIdEnricher.cs
@@ -23,14 +23,13 @@ public sealed class DeviceIdEnricher : ISignInLogEntryEnricher
     public SignInLogEnricherRunType RunType => SignInLogEnricherRunType.Synchronous;
 
     /// <inheritdoc />
-    public ValueTask EnrichAsync(SignInLogEntry logEntry) {
-        var device = _httpContextAccessor.HttpContext.ResolveDeviceId();
+    public async ValueTask EnrichAsync(SignInLogEntry logEntry) {
+        var device = await _httpContextAccessor.HttpContext.ResolveDeviceIdAsync();
         logEntry.DeviceId = device.Value;
         if (device.HasRegistrationId) {
             logEntry.ExtraData.UserDevice = new SignInLogEntryUserDevice {
                 Id = device.RegistrationId.Value
             };
         }
-        return ValueTask.CompletedTask;
     }
 }

--- a/src/Indice.Features.Identity.UI/Pages/Mfa.cs
+++ b/src/Indice.Features.Identity.UI/Pages/Mfa.cs
@@ -138,7 +138,7 @@ public abstract class BaseMfaModel : BasePageModel
         var user = await SignInManager.GetTwoFactorAuthenticationUserAsync() ?? throw new InvalidOperationException("User cannot be null");
         var authenticationMethod = await AuthenticationMethodProvider.GetRequiredAuthenticationMethod(user, tryDowngradeAuthenticationMethod);
         var allowDowngradeAuthenticationMethod = Configuration.GetIdentityOption<bool?>($"{nameof(IdentityOptions.SignIn)}:Mfa", "AllowDowngradeAuthenticationMethod") ?? false;
-        var deviceIdentifier = await HttpContext.ResolveDeviceIdAsync();
+        var deviceIdentifier = await SignInManager.GetMfaDeviceIdentifierAsync(user);
         UserDevice? browserDevice = null;
         if (!string.IsNullOrWhiteSpace(deviceIdentifier.Value)) {
             browserDevice = await UserManager.GetDeviceByIdAsync(user, deviceIdentifier.Value);

--- a/src/Indice.Features.Identity.UI/Pages/Mfa.cs
+++ b/src/Indice.Features.Identity.UI/Pages/Mfa.cs
@@ -138,7 +138,7 @@ public abstract class BaseMfaModel : BasePageModel
         var user = await SignInManager.GetTwoFactorAuthenticationUserAsync() ?? throw new InvalidOperationException("User cannot be null");
         var authenticationMethod = await AuthenticationMethodProvider.GetRequiredAuthenticationMethod(user, tryDowngradeAuthenticationMethod);
         var allowDowngradeAuthenticationMethod = Configuration.GetIdentityOption<bool?>($"{nameof(IdentityOptions.SignIn)}:Mfa", "AllowDowngradeAuthenticationMethod") ?? false;
-        var deviceIdentifier = HttpContext.ResolveDeviceId();
+        var deviceIdentifier = await HttpContext.ResolveDeviceIdAsync();
         UserDevice? browserDevice = null;
         if (!string.IsNullOrWhiteSpace(deviceIdentifier.Value)) {
             browserDevice = await UserManager.GetDeviceByIdAsync(user, deviceIdentifier.Value);

--- a/src/Indice.Features.Identity.UI/Pages/Mfa.cs
+++ b/src/Indice.Features.Identity.UI/Pages/Mfa.cs
@@ -2,7 +2,6 @@ using IdentityServer4.Services;
 using Indice.AspNetCore.Filters;
 using Indice.Features.Identity.Core;
 using Indice.Features.Identity.Core.Data.Models;
-using Indice.Features.Identity.Core.Extensions;
 using Indice.Features.Identity.Core.Totp;
 using Indice.Features.Identity.UI.Models;
 using Indice.Services;
@@ -152,7 +151,7 @@ public abstract class BaseMfaModel : BasePageModel
             AllowDowngradeAuthenticationMethod = allowDowngradeAuthenticationMethod,
             ReturnUrl = returnUrl,
             User = user,
-            IsExistingBrowser = browserDevice?.MfaSessionActive ?? false,
+            IsExistingBrowser = browserDevice?.MfaSessionActive() ?? false,
             Error = authenticationMethod == null ? "MFA is enabled but there is no active two factor authentication method configured. Please contact your administrator." : null
         };
     }

--- a/test/Indice.Features.Identity.Tests/MfaDeviceIdentiyfierTests.cs
+++ b/test/Indice.Features.Identity.Tests/MfaDeviceIdentiyfierTests.cs
@@ -1,0 +1,44 @@
+﻿using Indice.Features.Identity.Core.Models;
+using Xunit;
+
+namespace Indice.Features.Identity.Tests;
+public class MfaDeviceIdentiyfierTests
+{
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void MfaDeviceIdentifier_Empty(string deviceIdText) {
+        var deviceId = new MfaDeviceIdentifier(deviceIdText);
+        Assert.True(deviceId.IsEmpty);
+        Assert.False(deviceId.HasRegistrationId);
+        Assert.Equal(MfaDeviceIdentifier.Empty, deviceId);
+    }
+
+    [Theory]
+    [InlineData("f4b0c1a2-3d4e-5f6a-7b8c-9d0e1f2a3b4c")]
+    [InlineData("f4b0c1a23d4e5f6a7b8c9d0e1f2a3b4c")]
+    [InlineData("F4B0C1A23D4E5F6A7B8C9D0E1F2A3B4C")]
+    public void MfaDeviceIdentifier_ValidGuid(string guidText) {
+        Assert.True(MfaDeviceIdentifier.ValidateDeviceId(guidText));
+        var deviceId = new MfaDeviceIdentifier(guidText);
+        Assert.False(deviceId.IsEmpty);
+    }
+
+    [Theory]
+    [InlineData("2916aff63921d0f8d242619473bd60d5.Edge")]
+    [InlineData("a5012912ea952907e1ee9093a52e33e8.Chrome")]
+    [InlineData("A5012912EA952907E1EE9093A52E33E8")]
+    public void MfaDeviceIdentifier_ValidFormat(string text) {
+        Assert.True(MfaDeviceIdentifier.ValidateDeviceId(text));
+        var deviceId = new MfaDeviceIdentifier(text);
+        Assert.False(deviceId.IsEmpty);
+    }
+
+    [Theory]
+    [InlineData("2916aff63921d0aSDAf8d242619473bd60d5.Edge")]
+    [InlineData("a5012912ea952907e1ee9093a52eadsasdas33e8&Chrome")]
+    [InlineData("A5012912EA952907E1EE--9093A52E33E8")]
+    public void MfaDeviceIdentifier_InvalidValidFormat(string guidText) {
+        Assert.False(MfaDeviceIdentifier.ValidateDeviceId(guidText));
+    }
+}


### PR DESCRIPTION
Updates regarding **deviceid** resolution and MFA remember browser device.

Also enhance the returned Authentication methods claim so that it respects the origin and nature of the login.

- When external login happens as the first factor then this should show up as the provider name `microsoft` or the keyword `external` instead of `pwd` which stands for password that never happened.
- When 2FA login happens this should show up as **first factor** plus the **TokenProviderName** plus the keyword **mfa**. `["pwd", "mfa", "sms"]` or `["pwd", "mfa", "authenticator"]` or `["mfa", "trusted-device"]`
