### PR TITLE
Main activity changes in BusinessRegistryRecord type

### DIFF
--- a/src/Indice.Features.GovGr/CHANGELOG.md
+++ b/src/Indice.Features.GovGr/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- ## [Unreleased] -->
 
-## [rc28] - 2025-05-06
+## [8.0.0-rc28] - 2025-05-06
 - The MainActivityDescription property of the BusinessRegistryRecord type contains the actual description of the main activity (and not the description of its kind)
 - The MainActivityKind property of the BusinessRegistryRecord type was deleted because the scope/context of BusinessRegistryRecord is always the main activity
 

--- a/src/Indice.Features.GovGr/CHANGELOG.md
+++ b/src/Indice.Features.GovGr/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- ## [Unreleased] -->
 
+## [rc28] - 2025-05-06
+- The MainActivityDescription property of the BusinessRegistryRecord type contains the actual description of the main activity (and not the description of its kind)
+- The MainActivityKind property of the BusinessRegistryRecord type was deleted because the scope/context of BusinessRegistryRecord is always the main activity
+
 ## [7.23.0] - 2024-05-29
 ### Added
 - Add Bancapp GCloud Integration, jumped to 7.23.0 to match other Indice Packages

--- a/src/Indice.Features.GovGr/GovGrBusinessRegistryClient.cs
+++ b/src/Indice.Features.GovGr/GovGrBusinessRegistryClient.cs
@@ -46,8 +46,7 @@ internal class GovGrBusinessRegistryClient : IBusinessRegistryService
                 City = user.postalAreaDescription
             },
             MainActivityCode = mainFirmActivity?.firmActCode,
-            MainActivityDescription = mainFirmActivity?.firmActKindDescr,
-            MainActivityKind = mainFirmActivity?.firmActKind,
+            MainActivityDescription = mainFirmActivity?.firmActDescr,
             RegisterDate = user.registDate,
             StopDate = user.stopDate,
             FirmFlagDescription = user.firmFlagDescr,

--- a/src/Indice.Features.GovGr/Models/BusinessRegistryRecord.cs
+++ b/src/Indice.Features.GovGr/Models/BusinessRegistryRecord.cs
@@ -23,8 +23,6 @@ public class BusinessRegistryRecord
     public decimal? MainActivityCode { get; set; }
     /// <summary>Περιγραφή κύριας δραστηριότητας Taxis </summary>
     public string? MainActivityDescription { get; set; }
-    /// <summary>Τύπος Δραστηριότητας (Πάντα 1) </summary>
-    public string? MainActivityKind { get; set; }
     /// <summary>Διεύθυνση</summary>
     public BusinessRegistryAddress? Address { get; set; }
     /// <summary>ΗΜ/ΝΙΑ ΕΝΑΡΞΗΣ</summary>


### PR DESCRIPTION
* The `MainActivityKind` was removed because we always return the main activity (so the string "1" is redundant)

* The `MainActivityDescription` property contains the actual description of the main activity (and not the "ΚΥΡΙΑ" which is the description of the activity kind)