### PR TITLE
Enhance TryGetLastActor to support HTTP request input

### DIFF
--- a/src/Indice.Features.Cases.Workflows/Activities/HttpEndpointWithValidation.cs
+++ b/src/Indice.Features.Cases.Workflows/Activities/HttpEndpointWithValidation.cs
@@ -6,6 +6,8 @@ using Elsa.Activities.Http.Models;
 using Elsa.ActivityResults;
 using Elsa.Attributes;
 using Elsa.Services.Models;
+using Indice.Features.Cases.Workflows.Extensions;
+using Indice.Features.Cases.Workflows.Models;
 using Indice.Serialization;
 using Json.More;
 using Json.Schema;
@@ -35,6 +37,7 @@ public class HttpEndpointWithValidation : HttpEndpoint
     private IActivityExecutionResult ExecuteInternal(ActivityExecutionContext context) {
         Output = context.GetInput<HttpRequestModel>()!;
         context.JournalData.Add("Inbound Request", Output);
+        context.TrySetLastActor();
 
         // Skip validation when there is no Schema
         if (Schema is null) {

--- a/src/Indice.Features.Cases.Workflows/Extensions/ActivityExecutionContextExtensions.cs
+++ b/src/Indice.Features.Cases.Workflows/Extensions/ActivityExecutionContextExtensions.cs
@@ -1,20 +1,31 @@
-﻿using System.Security.Claims;
+﻿using Elsa.Activities.Http.Models;
+using System.Text.Json.Nodes;
 using Elsa.Services.Models;
-using Indice.Features.Cases.Workflows.Integrations;
 using Indice.Features.Cases.Workflows.Models;
-using Microsoft.AspNetCore.Http;
+using System.Text.Json;
 
 namespace Indice.Features.Cases.Workflows.Extensions;
 
 /// <summary>Extensions for <see cref="ActivityExecutionContext"/>.</summary>
 public static class ActivityExecutionContextExtensions
 {
-    /// <summary>Try to get the last actor from the Workflow context variable "RunAsSystemUser" or the Last Actor from the Variables.</summary>
+    /// <summary>Try to get the last actor either from the HTTP request body with an "actor" field
+    /// or the Workflow context variable "RunAsSystemUser" or the Last Actor from the Variables.</summary>
     public static Actor TryGetLastActor(this ActivityExecutionContext context) {
+        if (context.Input is HttpRequestModel { RawBody: not null } request) {
+            var body = JsonNode.Parse(request.RawBody);
+            var actorNode = body?["actor"];
+            var tempActor = actorNode?.Deserialize<Actor>();
+            if (tempActor is not null) {
+                return tempActor;
+            }
+        }
+
         var runAsSystemUser = context.GetVariable<bool>("RunAsSystemUser");
-        return runAsSystemUser
-            ? Actor.Create(CasesClaimsPrincipalExtensions.SystemUser())
-            : context.GetVariable<Actor>(CasesWorkflowConstants.WorkflowVariables.Actor.Current) 
-              ?? Actor.Create(CasesClaimsPrincipalExtensions.SystemUser()); // TODO[2025-07-07]: Remove this eventually
+        if (runAsSystemUser) {
+            return Actor.Create(CasesClaimsPrincipalExtensions.SystemUser());
+        }
+        return context.GetVariable<Actor>(CasesWorkflowConstants.WorkflowVariables.Actor.Current)
+            ?? Actor.Create(CasesClaimsPrincipalExtensions.SystemUser()); // TODO[2025-07-07]: Remove this eventually
     }
 }

--- a/src/Indice.Features.Cases.Workflows/Extensions/ActivityExecutionContextExtensions.cs
+++ b/src/Indice.Features.Cases.Workflows/Extensions/ActivityExecutionContextExtensions.cs
@@ -9,24 +9,38 @@ namespace Indice.Features.Cases.Workflows.Extensions;
 /// <summary>Extensions for <see cref="ActivityExecutionContext"/>.</summary>
 public static class ActivityExecutionContextExtensions
 {
-    /// <summary>Try to get the last actor either from the HTTP request body with an "actor" field
-    /// or the Workflow context variable "RunAsSystemUser" or the Last Actor from the Variables.</summary>
-    public static Actor TryGetLastActor(this ActivityExecutionContext context) {
+    /// <summary>
+    /// Try to get the last actor either either from Workflow context variable "RunAsSystemUser", or the Last Actor from the Variables.
+    /// </summary>
+    /// <param name="context">The activity execution context.</param>
+    /// <returns>The last actor or a system user actor if none is found.</returns>
+    public static Actor TryGetLastActor(this ActivityExecutionContext context)
+    {
         var forceRunAsSystemUser = context.GetVariable<bool>("RunAsSystemUser");
-        if (forceRunAsSystemUser) {
+        if (forceRunAsSystemUser)
+        {
             return Actor.Create(CasesClaimsPrincipalExtensions.SystemUser());
         }
+        var actor = 
+        context.GetVariable<Actor>(CasesWorkflowConstants.WorkflowVariables.Actor.Current)
+            ?? Actor.Create(CasesClaimsPrincipalExtensions.SystemUser()); // TODO[2025-07-07]: Remove this eventually
+        return actor;
+    }
 
-        if (context.Input is HttpRequestModel { RawBody: not null } request) {
+    /// <summary>
+    /// Attempts to set the last actor in the workflow context by extracting it from the HTTP request body.
+    /// </summary>
+    /// <param name="context">The activity execution context.</param>
+    public static void TrySetLastActor(this ActivityExecutionContext context)
+    {
+        if (context.Input is HttpRequestModel { RawBody: not null } request)
+        {
             var body = JsonNode.Parse(request.RawBody);
             var actorNode = body?["actor"];
-            var tempActor = actorNode?.Deserialize<Actor>();
-            if (tempActor is not null) {
-                return tempActor;
+            var currentActor = actorNode?.Deserialize<Actor>();
+            if (currentActor is not null) {
+                context.SetVariable(CasesWorkflowConstants.WorkflowVariables.Actor.Current, currentActor);
             }
         }
-        
-        return context.GetVariable<Actor>(CasesWorkflowConstants.WorkflowVariables.Actor.Current)
-            ?? Actor.Create(CasesClaimsPrincipalExtensions.SystemUser()); // TODO[2025-07-07]: Remove this eventually
     }
 }

--- a/src/Indice.Features.Cases.Workflows/Extensions/ActivityExecutionContextExtensions.cs
+++ b/src/Indice.Features.Cases.Workflows/Extensions/ActivityExecutionContextExtensions.cs
@@ -12,6 +12,11 @@ public static class ActivityExecutionContextExtensions
     /// <summary>Try to get the last actor either from the HTTP request body with an "actor" field
     /// or the Workflow context variable "RunAsSystemUser" or the Last Actor from the Variables.</summary>
     public static Actor TryGetLastActor(this ActivityExecutionContext context) {
+        var forceRunAsSystemUser = context.GetVariable<bool>("RunAsSystemUser");
+        if (forceRunAsSystemUser) {
+            return Actor.Create(CasesClaimsPrincipalExtensions.SystemUser());
+        }
+
         if (context.Input is HttpRequestModel { RawBody: not null } request) {
             var body = JsonNode.Parse(request.RawBody);
             var actorNode = body?["actor"];
@@ -20,11 +25,7 @@ public static class ActivityExecutionContextExtensions
                 return tempActor;
             }
         }
-
-        var runAsSystemUser = context.GetVariable<bool>("RunAsSystemUser");
-        if (runAsSystemUser) {
-            return Actor.Create(CasesClaimsPrincipalExtensions.SystemUser());
-        }
+        
         return context.GetVariable<Actor>(CasesWorkflowConstants.WorkflowVariables.Actor.Current)
             ?? Actor.Create(CasesClaimsPrincipalExtensions.SystemUser()); // TODO[2025-07-07]: Remove this eventually
     }

--- a/src/Indice.Features.Identity.Core/CHANGELOG.md
+++ b/src/Indice.Features.Identity.Core/CHANGELOG.md
@@ -8,12 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [8.0.0-rc26] - 2025-04-22
 ### Added 
 - Support for confugurable per user Two Factor enforcement policy.
-
-### Code Changes
-Remove from program.cs the following code:
-```csharp
-app.UseSession();
-```
+- Removed session state dependency from the library. So unless your app requires session then you must remove `app.UseSession()`.
 
 ### Migrations
 Add new column in user table.

--- a/src/Indice.Features.Identity.Core/CHANGELOG.md
+++ b/src/Indice.Features.Identity.Core/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added 
 - Support for confugurable per user Two Factor enforcement policy.
 
+### Code Changes
+Remove from program.cs the following code:
+```csharp
+app.UseSession();
+```
+
 ### Migrations
 Add new column in user table.
 


### PR DESCRIPTION
Updated the `TryGetLastActor` method in `ActivityExecutionContextExtensions.cs` to retrieve the last actor from the HTTP request body if an "actor" field is present. If not, it falls back to the Workflow context variable "RunAsSystemUser" and the last actor from the Variables. Adjusted using directives and updated comments to reflect these changes.