### PR TITLE
Increase max claim types from 3 to 4 in users search

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -19,7 +19,7 @@
       <VersionPrefixAspNet>$(VersionPrefixBase).0</VersionPrefixAspNet>
       <VersionPrefix>$(VersionPrefixBase).0</VersionPrefix>
       
-      <VersionSuffix>rc29</VersionSuffix>
+      <VersionSuffix>rc30</VersionSuffix>
       <Authors>Constantinos Leftheris</Authors>
       <GenerateDocumentationFile>true</GenerateDocumentationFile>
       <LangVersion>Latest</LangVersion>

--- a/src/Indice.Features.Identity.Server/Manager/UserHandlers.cs
+++ b/src/Indice.Features.Identity.Server/Manager/UserHandlers.cs
@@ -64,7 +64,7 @@ internal static class UserHandlers
                 LastSignInDate = user.LastSignInDate,
                 PasswordExpirationDate = user.PasswordExpirationDate
             };
-        if (expandClaims?.Length > 3) {
+        if (expandClaims?.Length > 4) {
             return TypedResults.ValidationProblem(ValidationErrors.AddError(nameof(expandClaims), "Cannot expand more than three claim types"));
         }
         foreach (var claimType in expandClaims ?? []) {


### PR DESCRIPTION
Updated the validation logic to allow expanding up to 4 claim types in the `expandClaims` parameter, enhancing flexibility in user claim handling.
And version bump to rc30