### PR TITLE
Add locale claim to user on Register

### DIFF
--- a/src/Indice.Features.Identity.UI/Pages/Register.cs
+++ b/src/Indice.Features.Identity.UI/Pages/Register.cs
@@ -187,6 +187,11 @@ public abstract class BaseRegisterModel : BasePageModel
             });
         }
         user.Claims.Add(new() {
+            ClaimType = JwtClaimTypes.Locale,
+            ClaimValue = RequestCulture.Culture.TwoLetterISOLanguageName,
+            UserId = user.Id
+        });
+        user.Claims.Add(new() {
             ClaimType = BasicClaimTypes.ConsentCommercial,
             ClaimValue = input.HasAcceptedTerms ? bool.TrueString.ToLower() : bool.FalseString.ToLower(),
             UserId = user.Id


### PR DESCRIPTION
This update introduces a new claim of type `JwtClaimTypes.Locale` to the user's claims list. The claim captures the user's locale information from `RequestCulture.Culture.TwoLetterISOLanguageName`, enhancing the user's claim data with their language preference.