### PR TITLE
[messaging] Imporved Channel selector logic for handling lowercase template content keys

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -11,7 +11,7 @@
       <VersionPrefixIdentity>$(VersionPrefixBase).1</VersionPrefixIdentity>
       <VersionPrefixIdentityUI>$(VersionPrefixBase).1</VersionPrefixIdentityUI>
       <VersionPrefixCases>$(VersionPrefixBase).0</VersionPrefixCases>
-      <VersionPrefixMessages>$(VersionPrefixBase).0</VersionPrefixMessages>
+      <VersionPrefixMessages>$(VersionPrefixBase).1</VersionPrefixMessages>
       <VersionPrefixMultitenancy>$(VersionPrefixBase).0</VersionPrefixMultitenancy>
       <VersionPrefixRisk>$(VersionPrefixBase).0</VersionPrefixRisk>
       <VersionPrefixMedia>$(VersionPrefixBase).0</VersionPrefixMedia>

--- a/src/Indice.Features.Messages.Core/Manager/NotificationsManager.cs
+++ b/src/Indice.Features.Messages.Core/Manager/NotificationsManager.cs
@@ -199,7 +199,10 @@ public class NotificationsManager(
             request.Data ??= template.Data;
             var content = template.Content;
             if (request.MessageTemplateChannels.HasValue && request.MessageTemplateChannels != MessageChannelKind.None) {
-                var channels = request.MessageTemplateChannels.Value.GetFlagValues().Select(f => f.ToString());
+                var channels = request.MessageTemplateChannels.Value
+                                    .GetFlagValues()
+                                    .Select(f => f.ToString())
+                                    .ToHashSet(StringComparer.OrdinalIgnoreCase);
                 content = new (template.Content.Where(cnt => channels.Contains(cnt.Key)));
                 if (content.Count == 0) {
                     return CreateCampaignResult.Fail($"Content was empty after applying the messageTemplateChannels to the selected Template with Id:({request.MessageTemplateId})");


### PR DESCRIPTION
Template content keys where saved to template store as lowercase `email`,`sms`, etc. and although the `MessageContentDictionary` is always initialized with an OrdinalIgnoreCase string comparer the logic bypassed it when filtering for preferences. cc @spapoutsis 