### PR TITLE
[identity] Refactor custom password validation to not use the ErrorDescriber by injection but via the userManager that has it already

### DIFF
--- a/src/Indice.Features.Identity.Core/ExtendedIdentityErrorDescriber.cs
+++ b/src/Indice.Features.Identity.Core/ExtendedIdentityErrorDescriber.cs
@@ -95,21 +95,77 @@ public class ExtendedIdentityErrorDescriber : IdentityErrorDescriber
     /// <summary>Your password must meet the minimum number of unique chars required.</summary>
     public virtual string PasswordRequiresUniqueCharsRequirement(int uniqueChars) => string.Format(IdentityResources.Culture, ExtendedIdentityErrorResources.PasswordRequiresUniqueCharsRequirement, uniqueChars);
     /// <summary>Your password must contain a non-alphanumeric character, which is required by the password policy.</summary>
-    public virtual string PasswordRequiresNonAlphanumericRequirement => ExtendedIdentityErrorResources.PasswordRequiresNonAlphanumericRequirement;
+    public virtual string PasswordRequiresNonAlphanumericRequirement() => ExtendedIdentityErrorResources.PasswordRequiresNonAlphanumericRequirement;
     /// <summary>Your password must contain a numeric character, which is required by the password policy.</summary>
-    public virtual string PasswordRequiresDigitRequirement => ExtendedIdentityErrorResources.PasswordRequiresDigitRequirement;
+    public virtual string PasswordRequiresDigitRequirement() => ExtendedIdentityErrorResources.PasswordRequiresDigitRequirement;
     /// <summary>Your password must contain a lower case letter, which is required by the password policy.</summary>
-    public virtual string PasswordRequiresLowerRequirement => ExtendedIdentityErrorResources.PasswordRequiresLowerRequirement;
+    public virtual string PasswordRequiresLowerRequirement() => ExtendedIdentityErrorResources.PasswordRequiresLowerRequirement;
     /// <summary>Your password must contain an upper case letter, which is required by the password policy.</summary>
-    public virtual string PasswordRequiresUpperRequirement => ExtendedIdentityErrorResources.PasswordRequiresUpperRequirement;
+    public virtual string PasswordRequiresUpperRequirement() => ExtendedIdentityErrorResources.PasswordRequiresUpperRequirement;
     /// <summary>Your password is very easy to guess, please choose a more complex one.</summary>
-    public virtual string PasswordIsCommonRequirement => string.Format(IdentityResources.Culture, ExtendedIdentityErrorResources.PasswordIsCommonRequirement);
+    public virtual string PasswordIsCommonRequirement() => string.Format(IdentityResources.Culture, ExtendedIdentityErrorResources.PasswordIsCommonRequirement);
     /// <summary>Your password looks a lot like your username which can lead to your account been hacked.</summary>
-    public virtual string PasswordIdenticalToUserNameRequirement => string.Format(IdentityResources.Culture, ExtendedIdentityErrorResources.PasswordIdenticalToUserNameRequirement);
+    public virtual string PasswordIdenticalToUserNameRequirement() => string.Format(IdentityResources.Culture, ExtendedIdentityErrorResources.PasswordIdenticalToUserNameRequirement);
     /// <summary>It is a good practice not to re-use your past password.</summary>
-    public virtual string PasswordRecentlyUsedRequirement => string.Format(IdentityResources.Culture, ExtendedIdentityErrorResources.PasswordRecentlyUsedRequirement);
+    public virtual string PasswordRecentlyUsedRequirement() => string.Format(IdentityResources.Culture, ExtendedIdentityErrorResources.PasswordRecentlyUsedRequirement);
     /// <summary>Your password cannot contain non-Latin characters, which is required by the password policy.</summary>
-    public virtual string PasswordHasNonLatinCharsRequirement => string.Format(IdentityResources.Culture, ExtendedIdentityErrorResources.PasswordHasNonLatinCharsRequirement);
+    public virtual string PasswordHasNonLatinCharsRequirement() => string.Format(IdentityResources.Culture, ExtendedIdentityErrorResources.PasswordHasNonLatinCharsRequirement);
     /// <summary>Not allowed characters.</summary>
-    public virtual string PasswordContainsNotAllowedCharsRequirement => string.Format(IdentityResources.Culture, ExtendedIdentityErrorResources.PasswordContainsNotAllowedCharsRequirement);
+    public virtual string PasswordContainsNotAllowedCharsRequirement() => string.Format(IdentityResources.Culture, ExtendedIdentityErrorResources.PasswordContainsNotAllowedCharsRequirement);
+}
+
+/// <summary>
+/// Provides extension methods for <see cref="IdentityErrorDescriber"/> to expose all functionality of <see cref="ExtendedIdentityErrorDescriber"/> directly from the base class.
+/// </summary>
+/// <remarks>This class extends the functionality of <see cref="IdentityErrorDescriber"/> with the knowledge that the default ErrorDiscriber is already overriden to be the <see cref="ExtendedIdentityErrorDescriber"/> or a subclass of that.</remarks>
+public static class ExtendedIdentityErrorDescriberExtensions
+{
+    /// <summary>Returns an <see cref="IdentityError"/> indicating that the password has been used recently.</summary>
+    /// <returns>An <see cref="IdentityError"/> with a code and description indicating that the password has been used recently.</returns>
+    public static IdentityError PasswordRecentlyUsed(this IdentityErrorDescriber errorDescriber) => ((ExtendedIdentityErrorDescriber)errorDescriber).PasswordRecentlyUsed();
+
+    /// <summary>Creates an <see cref="IdentityError"/> indicating that the provided password is too common.</summary>
+    /// <returns>An <see cref="IdentityError"/> with a code and description indicating that the password is considered too
+    /// common.</returns>
+    public static IdentityError PasswordIsCommon(this IdentityErrorDescriber errorDescriber) => ((ExtendedIdentityErrorDescriber)errorDescriber).PasswordIsCommon();
+
+    /// <summary>Returns an <see cref="IdentityError"/> indicating that the password is identical to the username.</summary>
+    /// <remarks>This error is typically used to enforce password policies that require passwords to differ
+    /// from the username for security reasons.</remarks>
+    /// <returns>An <see cref="IdentityError"/> with a code and description indicating that the password cannot be the same as
+    /// the username.</returns>
+    public static IdentityError PasswordIdenticalToUserName(this IdentityErrorDescriber errorDescriber) => ((ExtendedIdentityErrorDescriber)errorDescriber).PasswordIdenticalToUserName();
+
+    /// <summary>Returns an <see cref="IdentityError"/> indicating that the password contains non-Latin characters.</summary>
+    /// <returns>An <see cref="IdentityError"/> with a code and description indicating that the password includes non-Latin
+    /// characters.</returns>
+    public static IdentityError PasswordHasNonLatinChars(this IdentityErrorDescriber errorDescriber) => ((ExtendedIdentityErrorDescriber)errorDescriber).PasswordHasNonLatinChars();
+
+    /// <summary>Creates an <see cref="IdentityError"/> indicating that the password contains characters that are not allowed.</summary>
+    /// <returns>An <see cref="IdentityError"/> with a code and description specifying that the password contains disallowed
+    /// characters.</returns>
+    public static IdentityError PasswordContainsNotAllowedChars(this IdentityErrorDescriber errorDescriber) => ((ExtendedIdentityErrorDescriber)errorDescriber).PasswordContainsNotAllowedChars();
+
+    /// <summary>Your password's specified length does not meet the minimum length requirements.</summary>
+    public static string PasswordTooShortRequirement(this IdentityErrorDescriber errorDescriber, int length) => ((ExtendedIdentityErrorDescriber)errorDescriber).PasswordTooShortRequirement(length);
+    /// <summary>Your password must meet the minimum number of unique chars required.</summary>
+    public static string PasswordRequiresUniqueCharsRequirement(this IdentityErrorDescriber errorDescriber, int uniqueChars) => ((ExtendedIdentityErrorDescriber)errorDescriber).PasswordRequiresUniqueCharsRequirement(uniqueChars);
+    /// <summary>Your password must contain a non-alphanumeric character, which is required by the password policy.</summary>
+    public static string PasswordRequiresNonAlphanumericRequirement(this IdentityErrorDescriber errorDescriber) => ((ExtendedIdentityErrorDescriber)errorDescriber).PasswordRequiresNonAlphanumericRequirement();
+    /// <summary>Your password must contain a numeric character, which is required by the password policy.</summary>
+    public static string PasswordRequiresDigitRequirement(this IdentityErrorDescriber errorDescriber) => ((ExtendedIdentityErrorDescriber)errorDescriber).PasswordRequiresDigitRequirement();
+    /// <summary>Your password must contain a lower case letter, which is required by the password policy.</summary>
+    public static string PasswordRequiresLowerRequirement(this IdentityErrorDescriber errorDescriber) => ((ExtendedIdentityErrorDescriber)errorDescriber).PasswordRequiresLowerRequirement();
+    /// <summary>Your password must contain an upper case letter, which is required by the password policy.</summary>
+    public static string PasswordRequiresUpperRequirement(this IdentityErrorDescriber errorDescriber) => ((ExtendedIdentityErrorDescriber)errorDescriber).PasswordRequiresUpperRequirement();
+    /// <summary>Your password is very easy to guess, please choose a more complex one.</summary>
+    public static string PasswordIsCommonRequirement(this IdentityErrorDescriber errorDescriber) => ((ExtendedIdentityErrorDescriber)errorDescriber).PasswordIsCommonRequirement();
+    /// <summary>Your password looks a lot like your username which can lead to your account been hacked.</summary>
+    public static string PasswordIdenticalToUserNameRequirement(this IdentityErrorDescriber errorDescriber) => ((ExtendedIdentityErrorDescriber)errorDescriber).PasswordIdenticalToUserNameRequirement();
+    /// <summary>It is a good practice not to re-use your past password.</summary>
+    public static string PasswordRecentlyUsedRequirement(this IdentityErrorDescriber errorDescriber) => ((ExtendedIdentityErrorDescriber)errorDescriber).PasswordRecentlyUsedRequirement();
+    /// <summary>Your password cannot contain non-Latin characters, which is required by the password policy.</summary>
+    public static string PasswordHasNonLatinCharsRequirement(this IdentityErrorDescriber errorDescriber) => ((ExtendedIdentityErrorDescriber)errorDescriber).PasswordHasNonLatinCharsRequirement();
+    /// <summary>Not allowed characters.</summary>
+    public static string PasswordContainsNotAllowedCharsRequirement(this IdentityErrorDescriber errorDescriber) => ((ExtendedIdentityErrorDescriber)errorDescriber).PasswordContainsNotAllowedCharsRequirement();
 }

--- a/src/Indice.Features.Identity.Core/PasswordValidation/AllowedCharactersPasswordValidator.cs
+++ b/src/Indice.Features.Identity.Core/PasswordValidation/AllowedCharactersPasswordValidator.cs
@@ -9,17 +9,13 @@ public class AllowedCharactersPasswordValidator<TUser> : IPasswordValidator<TUse
 {
     /// <summary>Creates a new instance of <see cref="AllowedCharactersPasswordValidator{TUser}"/>.</summary>
     /// <param name="configuration">Represents a set of key/value application configuration properties.</param>
-    /// <param name="errorDescriber">Provides the various messages used throughout Indice packages.</param>
-    public AllowedCharactersPasswordValidator(IConfiguration configuration, ExtendedIdentityErrorDescriber errorDescriber) {
+    public AllowedCharactersPasswordValidator(IConfiguration configuration) {
         AllowedCharacters = configuration.GetSection($"{nameof(IdentityOptions)}:{nameof(IdentityOptions.Password)}").GetValue<string>(nameof(AllowedCharacters)) ??
                             configuration.GetSection(nameof(PasswordOptions)).GetValue<string>(nameof(AllowedCharacters));
-        ErrorDescriber = errorDescriber ?? throw new ArgumentNullException(nameof(errorDescriber));
     }
 
     /// <summary>The allowed characters of a password.</summary>
     public string? AllowedCharacters { get; }
-    /// <summary>Provides the various messages used throughout Indice packages.</summary>
-    public ExtendedIdentityErrorDescriber ErrorDescriber { get; }
 
     /// <inheritdoc />
     public Task<IdentityResult> ValidateAsync(UserManager<TUser> manager, TUser user, string? password) {
@@ -30,7 +26,7 @@ public class AllowedCharactersPasswordValidator<TUser> : IPasswordValidator<TUse
         }
         var isValid = !string.IsNullOrWhiteSpace(password) && password.All(x => AllowedCharacters.Contains(x));
         if (!isValid) {
-            result = IdentityResult.Failed(ErrorDescriber.PasswordContainsNotAllowedChars());
+            result = IdentityResult.Failed((manager?.ErrorDescriber ?? new ExtendedIdentityErrorDescriber()).PasswordContainsNotAllowedChars());
         }
         return Task.FromResult(result);
     }
@@ -40,5 +36,5 @@ public class AllowedCharactersPasswordValidator<TUser> : IPasswordValidator<TUse
 public class AllowedCharactersPasswordValidator : AllowedCharactersPasswordValidator<User>
 {
     /// <inheritdoc/>
-    public AllowedCharactersPasswordValidator(IConfiguration configuration, ExtendedIdentityErrorDescriber errorDescriber) : base(configuration, errorDescriber) { }
+    public AllowedCharactersPasswordValidator(IConfiguration configuration) : base(configuration) { }
 }

--- a/src/Indice.Features.Identity.Core/PasswordValidation/LatinLettersOnlyPasswordValidator.cs
+++ b/src/Indice.Features.Identity.Core/PasswordValidation/LatinLettersOnlyPasswordValidator.cs
@@ -9,20 +9,16 @@ namespace Indice.Features.Identity.Core.PasswordValidation;
 public class UnicodeCharactersPasswordValidator : UnicodeCharactersPasswordValidator<User>
 {
     /// <inheritdoc/>
-    public UnicodeCharactersPasswordValidator(ExtendedIdentityErrorDescriber errorDescriber, IConfiguration configuration) : base(errorDescriber, configuration) { }
+    public UnicodeCharactersPasswordValidator(IConfiguration configuration) : base(configuration) { }
 }
 
 /// <summary>A validator that checks that the letters contained in the password are only Latin English characters.</summary>
 /// <typeparam name="TUser">The type of user instance.</typeparam>
 public class UnicodeCharactersPasswordValidator<TUser> : IPasswordValidator<TUser> where TUser : User
 {
-    private readonly ExtendedIdentityErrorDescriber _errorDescriber;
-
     /// <summary>Creates a new instance of <see cref="UnicodeCharactersPasswordValidator"/>.</summary>
-    /// <param name="errorDescriber">Provides the various messages used throughout Indice packages.</param>
     /// <param name="configuration">Represents a set of key/value application configuration properties.</param>
-    public UnicodeCharactersPasswordValidator(ExtendedIdentityErrorDescriber errorDescriber, IConfiguration configuration) {
-        _errorDescriber = errorDescriber ?? throw new ArgumentNullException(nameof(errorDescriber));
+    public UnicodeCharactersPasswordValidator(IConfiguration configuration) {
         AllowUnicodeCharacters = configuration.GetSection($"{nameof(IdentityOptions)}:{nameof(IdentityOptions.Password)}").GetValue<bool?>(nameof(AllowUnicodeCharacters)) ??
                                  configuration.GetSection(nameof(PasswordOptions)).GetValue<bool?>(nameof(AllowUnicodeCharacters));
     }
@@ -38,7 +34,7 @@ public class UnicodeCharactersPasswordValidator<TUser> : IPasswordValidator<TUse
         }
         var isValid = !string.IsNullOrWhiteSpace(password) && password.All(x => x.IsDigit() || x.IsSpecial() || x.IsLatinLetter());
         if (!isValid) {
-            result = IdentityResult.Failed(_errorDescriber.PasswordHasNonLatinChars());
+            result = IdentityResult.Failed((manager?.ErrorDescriber ?? new ExtendedIdentityErrorDescriber()).PasswordHasNonLatinChars());
         }
         return Task.FromResult(result);
     }

--- a/src/Indice.Features.Identity.Core/PasswordValidation/NonCommonPasswordValidator.cs
+++ b/src/Indice.Features.Identity.Core/PasswordValidation/NonCommonPasswordValidator.cs
@@ -8,7 +8,7 @@ namespace Indice.Features.Identity.Core.PasswordValidation;
 public class NonCommonPasswordValidator : NonCommonPasswordValidator<User>
 {
     /// <inheritdoc/>
-    public NonCommonPasswordValidator(IEnumerable<IPasswordBlacklistProvider> providers, ExtendedIdentityErrorDescriber errorDescriber) : base(providers, errorDescriber) { }
+    public NonCommonPasswordValidator(IEnumerable<IPasswordBlacklistProvider> providers) : base(providers) { }
 }
 
 /// <summary>A validator that checks if the user's password is a very common one and as a result easy to guess.</summary>
@@ -16,21 +16,18 @@ public class NonCommonPasswordValidator : NonCommonPasswordValidator<User>
 public class NonCommonPasswordValidator<TUser> : IPasswordValidator<TUser> where TUser : User
 {
     private readonly IEnumerable<IPasswordBlacklistProvider> _providers;
-    private readonly ExtendedIdentityErrorDescriber _errorDescriber;
 
     /// <summary>Creates a new instance of <see cref="NonCommonPasswordValidator"/>.</summary>
     /// <param name="providers">The list of <see cref="IPasswordBlacklistProvider"/> providers to use.</param>
-    /// <param name="errorDescriber">Provides the various messages used throughout Indice packages.</param>
-    public NonCommonPasswordValidator(IEnumerable<IPasswordBlacklistProvider> providers, ExtendedIdentityErrorDescriber errorDescriber) {
+    public NonCommonPasswordValidator(IEnumerable<IPasswordBlacklistProvider> providers) {
         _providers = providers ?? throw new ArgumentNullException(nameof(providers));
-        _errorDescriber = errorDescriber ?? throw new ArgumentNullException(nameof(errorDescriber));
     }
 
     /// <inheritdoc/>
     public async Task<IdentityResult> ValidateAsync(UserManager<TUser> manager, TUser user, string? password) {
         var result = IdentityResult.Success;
         if (string.IsNullOrWhiteSpace(password) || await IsBlacklistedAsync(password)) {
-            result = IdentityResult.Failed(_errorDescriber.PasswordIsCommon());
+            result = IdentityResult.Failed((manager?.ErrorDescriber ?? new ExtendedIdentityErrorDescriber()).PasswordIsCommon());
         }
         return result;
     }

--- a/src/Indice.Features.Identity.Core/PasswordValidation/PreviousPasswordAwareValidator.cs
+++ b/src/Indice.Features.Identity.Core/PasswordValidation/PreviousPasswordAwareValidator.cs
@@ -13,8 +13,7 @@ public class PreviousPasswordAwareValidator<TContext> : PreviousPasswordAwareVal
     /// <summary>Class constructor.</summary>
     /// <param name="dbContext">The DbContext to use for the Identity framework.</param>
     /// <param name="configuration">Represents a set of key/value application configuration properties.</param>
-    /// <param name="errorDescriber">Provides the various messages used throughout Indice packages.</param>
-    public PreviousPasswordAwareValidator(TContext dbContext, IConfiguration configuration, ExtendedIdentityErrorDescriber errorDescriber) : base(dbContext, configuration, errorDescriber) { }
+    public PreviousPasswordAwareValidator(TContext dbContext, IConfiguration configuration) : base(dbContext, configuration) { }
 }
 
 /// <summary>An <see cref="IPasswordValidator{TUser}" /> that checks a number of previous passwords for equality.</summary>
@@ -23,8 +22,7 @@ public class PreviousPasswordAwareValidator : PreviousPasswordAwareValidator<Use
     /// <summary>Class constructor.</summary>
     /// <param name="dbContext">The DbContext to use for the Identity framework.</param>
     /// <param name="configuration">Represents a set of key/value application configuration properties.</param>
-    /// <param name="errorDescriber">Provides the various messages used throughout Indice packages.</param>
-    public PreviousPasswordAwareValidator(IdentityDbContext<User, Role> dbContext, IConfiguration configuration, ExtendedIdentityErrorDescriber errorDescriber) : base(dbContext, configuration, errorDescriber) { }
+    public PreviousPasswordAwareValidator(IdentityDbContext<User, Role> dbContext, IConfiguration configuration) : base(dbContext, configuration) { }
 }
 
 /// <summary>An <see cref="IPasswordValidator{TUser}" /> that checks a number of previous passwords for equality.</summary>
@@ -35,8 +33,7 @@ public class PreviousPasswordAwareValidator<TUser, TRole> : PreviousPasswordAwar
     /// <summary>Class constructor.</summary>
     /// <param name="dbContext">The DbContext to use for the Identity framework.</param>
     /// <param name="configuration">Represents a set of key/value application configuration properties.</param>
-    /// <param name="errorDescriber">Provides the various messages used throughout Indice packages.</param>
-    public PreviousPasswordAwareValidator(IdentityDbContext<TUser, TRole> dbContext, IConfiguration configuration, ExtendedIdentityErrorDescriber errorDescriber) : base(dbContext, configuration, errorDescriber) { }
+    public PreviousPasswordAwareValidator(IdentityDbContext<TUser, TRole> dbContext, IConfiguration configuration) : base(dbContext, configuration) { }
 }
 
 /// <summary>An <see cref="IPasswordValidator{TUser}" /> that checks a number of previous passwords for equality.</summary>
@@ -52,10 +49,8 @@ public class PreviousPasswordAwareValidator<TContext, TUser, TRole> : IPasswordV
     /// <summary>Class constructor.</summary>
     /// <param name="dbContext">The DbContext to use for the Identity framework.</param>
     /// <param name="configuration">Represents a set of key/value application configuration properties.</param>
-    /// <param name="errorDescriber">Provides the various messages used throughout Indice packages.</param>
-    public PreviousPasswordAwareValidator(TContext dbContext, IConfiguration configuration, ExtendedIdentityErrorDescriber errorDescriber) {
+    public PreviousPasswordAwareValidator(TContext dbContext, IConfiguration configuration) {
         DbContext = dbContext;
-        ErrorDescriber = errorDescriber ?? throw new ArgumentNullException(nameof(errorDescriber));
         MaximumPasswordAge = configuration.GetSection($"{nameof(IdentityOptions)}:{nameof(IdentityOptions.Password)}").GetValue<TimeSpan?>(nameof(MaximumPasswordAge)) ??
                              configuration.GetSection(nameof(PasswordOptions)).GetValue<TimeSpan?>(nameof(MaximumPasswordAge));
         PasswordHistoryLimit = configuration.GetSection($"{nameof(IdentityOptions)}:{nameof(IdentityOptions.Password)}").GetValue<int?>(nameof(PasswordHistoryLimit)) ??
@@ -73,8 +68,6 @@ public class PreviousPasswordAwareValidator<TContext, TUser, TRole> : IPasswordV
     public TimeSpan? MinimumPasswordAge { get; }
     /// <summary>A timespan written in dd:hh:mm:ss or (null is never).</summary>
     public TimeSpan? MaximumPasswordAge { get; }
-    /// <summary>Provides the various messages used throughout Indice packages.</summary>
-    public ExtendedIdentityErrorDescriber ErrorDescriber { get; }
 
     /// <summary>Validates a password as an asynchronous operation.</summary>
     /// <param name="manager">Provides the APIs for managing user in a persistence store.</param>
@@ -102,7 +95,7 @@ public class PreviousPasswordAwareValidator<TContext, TUser, TRole> : IPasswordV
                                             .Distinct()
                                             .Any(hash => manager.PasswordHasher.VerifyHashedPassword(user, hash!, password) == PasswordVerificationResult.Success);
             if (isUsedBefore) {
-                result = IdentityResult.Failed(ErrorDescriber.PasswordRecentlyUsed());
+                result = IdentityResult.Failed((manager?.ErrorDescriber ?? new ExtendedIdentityErrorDescriber()).PasswordRecentlyUsed());
             }
         }
         return result;

--- a/src/Indice.Features.Identity.Core/PasswordValidation/UserNameAsPasswordValidator.cs
+++ b/src/Indice.Features.Identity.Core/PasswordValidation/UserNameAsPasswordValidator.cs
@@ -8,20 +8,17 @@ namespace Indice.Features.Identity.Core.PasswordValidation;
 public class UserNameAsPasswordValidator : UserNameAsPasswordValidator<User>
 {
     /// <inheritdoc/>
-    public UserNameAsPasswordValidator(IConfiguration configuration, ExtendedIdentityErrorDescriber errorDescriber) : base(configuration, errorDescriber) { }
+    public UserNameAsPasswordValidator(IConfiguration configuration) : base(configuration) { }
 }
 
 /// <summary>A validator that checks if the username is identical to the password for a given number of characters.</summary>
 /// <typeparam name="TUser">The type of user instance.</typeparam>
 public class UserNameAsPasswordValidator<TUser> : IPasswordValidator<TUser> where TUser : User
 {
-    private readonly ExtendedIdentityErrorDescriber _errorDescriber;
-
+    
     /// <summary>Creates a new instance of <see cref="UserNameAsPasswordValidator"/>.</summary>
     /// <param name="configuration">Represents a set of key/value application configuration properties.</param>
-    /// <param name="errorDescriber">Provides the various messages used throughout Indice packages.</param>
-    public UserNameAsPasswordValidator(IConfiguration configuration, ExtendedIdentityErrorDescriber errorDescriber) {
-        _errorDescriber = errorDescriber;
+    public UserNameAsPasswordValidator(IConfiguration configuration) {
         MaxAllowedUserNameSubset = configuration.GetSection($"{nameof(IdentityOptions)}:{nameof(IdentityOptions.Password)}").GetValue<int?>(nameof(MaxAllowedUserNameSubset)) ??
                                    configuration.GetSection(nameof(PasswordOptions)).GetValue<int?>(nameof(MaxAllowedUserNameSubset));
     }
@@ -44,7 +41,7 @@ public class UserNameAsPasswordValidator<TUser> : IPasswordValidator<TUser> wher
         }
         // If username is exactly the same with the password, then this is an error independently of the MaxAllowedUsernameSubset property.
         if (user.UserName!.Equals(password!, StringComparison.InvariantCultureIgnoreCase)) {
-            result = IdentityResult.Failed(_errorDescriber.PasswordIdenticalToUserName());
+            result = IdentityResult.Failed((manager?.ErrorDescriber ?? new ExtendedIdentityErrorDescriber()).PasswordIdenticalToUserName());
             return Task.FromResult(result);
         }
         if (MaxAllowedUserNameSubset > password.Length) {
@@ -57,7 +54,7 @@ public class UserNameAsPasswordValidator<TUser> : IPasswordValidator<TUser> wher
             characterIndex++;
         }
         if (userNameSubstrings.Any(userNameSubstring => password.Contains(userNameSubstring, StringComparison.OrdinalIgnoreCase))) {
-            result = IdentityResult.Failed(_errorDescriber.PasswordIdenticalToUserName());
+            result = IdentityResult.Failed((manager?.ErrorDescriber ?? new ExtendedIdentityErrorDescriber()).PasswordIdenticalToUserName());
         }
         return Task.FromResult(result);
     }

--- a/src/Indice.Features.Identity.Server/Manager/MyAccountHandlers.cs
+++ b/src/Indice.Features.Identity.Server/Manager/MyAccountHandlers.cs
@@ -765,16 +765,16 @@ internal static partial class MyAccountHandlers
         }
         if (passwordOptions.RequireNonAlphanumeric) {
             result.Add(nameof(IdentityErrorDescriber.PasswordRequiresNonAlphanumeric),
-                (userManager.ErrorDescriber.PasswordRequiresNonAlphanumeric().Description, Hint: errorDescriber.PasswordRequiresNonAlphanumericRequirement));
+                (userManager.ErrorDescriber.PasswordRequiresNonAlphanumeric().Description, Hint: errorDescriber.PasswordRequiresNonAlphanumericRequirement()));
         }
         if (passwordOptions.RequireDigit) {
-            result.Add(nameof(IdentityErrorDescriber.PasswordRequiresDigit), (userManager.ErrorDescriber.PasswordRequiresDigit().Description, Hint: errorDescriber.PasswordRequiresDigitRequirement));
+            result.Add(nameof(IdentityErrorDescriber.PasswordRequiresDigit), (userManager.ErrorDescriber.PasswordRequiresDigit().Description, Hint: errorDescriber.PasswordRequiresDigitRequirement()));
         }
         if (passwordOptions.RequireLowercase) {
-            result.Add(nameof(IdentityErrorDescriber.PasswordRequiresLower), (userManager.ErrorDescriber.PasswordRequiresLower().Description, Hint: errorDescriber.PasswordRequiresLowerRequirement));
+            result.Add(nameof(IdentityErrorDescriber.PasswordRequiresLower), (userManager.ErrorDescriber.PasswordRequiresLower().Description, Hint: errorDescriber.PasswordRequiresLowerRequirement()));
         }
         if (passwordOptions.RequireUppercase) {
-            result.Add(nameof(IdentityErrorDescriber.PasswordRequiresUpper), (userManager.ErrorDescriber.PasswordRequiresUpper().Description, Hint: errorDescriber.PasswordRequiresUpperRequirement));
+            result.Add(nameof(IdentityErrorDescriber.PasswordRequiresUpper), (userManager.ErrorDescriber.PasswordRequiresUpper().Description, Hint: errorDescriber.PasswordRequiresUpperRequirement()));
         }
         var validators = userManager.PasswordValidators;
         foreach (var validator in validators) {
@@ -782,26 +782,26 @@ internal static partial class MyAccountHandlers
             validatorType = validatorType.IsGenericType ? validatorType.GetGenericTypeDefinition() : validatorType;
             var isNonCommonPasswordValidator = validatorType == typeof(NonCommonPasswordValidator) || validatorType == typeof(NonCommonPasswordValidator<>);
             if (isNonCommonPasswordValidator) {
-                result.Add(nameof(ExtendedIdentityErrorDescriber.PasswordIsCommon), (errorDescriber.PasswordIsCommon().Description, Hint: errorDescriber.PasswordIsCommonRequirement));
+                result.Add(nameof(ExtendedIdentityErrorDescriber.PasswordIsCommon), (errorDescriber.PasswordIsCommon().Description, Hint: errorDescriber.PasswordIsCommonRequirement()));
             }
             var isUserNameAsPasswordValidator = validatorType == typeof(UserNameAsPasswordValidator) || validatorType == typeof(UserNameAsPasswordValidator<>);
             if (isUserNameAsPasswordValidator && userNameAvailable) {
-                result.Add(nameof(ExtendedIdentityErrorDescriber.PasswordIdenticalToUserName), (errorDescriber.PasswordIdenticalToUserName().Description, Hint: errorDescriber.PasswordIdenticalToUserNameRequirement));
+                result.Add(nameof(ExtendedIdentityErrorDescriber.PasswordIdenticalToUserName), (errorDescriber.PasswordIdenticalToUserName().Description, Hint: errorDescriber.PasswordIdenticalToUserNameRequirement()));
             }
             var isPreviousPasswordAwareValidator = validatorType == typeof(PreviousPasswordAwareValidator)
                 || validatorType == typeof(PreviousPasswordAwareValidator<>)
                 || validatorType == typeof(PreviousPasswordAwareValidator<,>)
                 || validatorType == typeof(PreviousPasswordAwareValidator<,,>);
             if (isPreviousPasswordAwareValidator && userAvailable) {
-                result.Add(nameof(ExtendedIdentityErrorDescriber.PasswordRecentlyUsed), (errorDescriber.PasswordRecentlyUsed().Description, Hint: errorDescriber.PasswordRecentlyUsedRequirement));
+                result.Add(nameof(ExtendedIdentityErrorDescriber.PasswordRecentlyUsed), (errorDescriber.PasswordRecentlyUsed().Description, Hint: errorDescriber.PasswordRecentlyUsedRequirement()));
             }
             var isUnicodeCharactersPasswordValidator = validatorType == typeof(UnicodeCharactersPasswordValidator) || validatorType == typeof(UnicodeCharactersPasswordValidator<>);
             if (isUnicodeCharactersPasswordValidator) {
-                result.Add(nameof(ExtendedIdentityErrorDescriber.PasswordHasNonLatinChars), (errorDescriber.PasswordHasNonLatinChars().Description, Hint: errorDescriber.PasswordHasNonLatinCharsRequirement));
+                result.Add(nameof(ExtendedIdentityErrorDescriber.PasswordHasNonLatinChars), (errorDescriber.PasswordHasNonLatinChars().Description, Hint: errorDescriber.PasswordHasNonLatinCharsRequirement()));
             }
             var isNotAllowedCharactersPasswordValidator = validatorType == typeof(AllowedCharactersPasswordValidator) || validatorType == typeof(AllowedCharactersPasswordValidator<>);
             if (isNotAllowedCharactersPasswordValidator) {
-                result.Add(nameof(ExtendedIdentityErrorDescriber.PasswordContainsNotAllowedChars), (errorDescriber.PasswordContainsNotAllowedChars().Description, Hint: errorDescriber.PasswordContainsNotAllowedCharsRequirement));
+                result.Add(nameof(ExtendedIdentityErrorDescriber.PasswordContainsNotAllowedChars), (errorDescriber.PasswordContainsNotAllowedChars().Description, Hint: errorDescriber.PasswordContainsNotAllowedCharsRequirement()));
             }
         }
         return result;

--- a/test/Indice.Features.Identity.Tests/AllowedCharactersPasswordValidatorTests.cs
+++ b/test/Indice.Features.Identity.Tests/AllowedCharactersPasswordValidatorTests.cs
@@ -1,5 +1,6 @@
 ﻿using Indice.Features.Identity.Core;
 using Indice.Features.Identity.Core.Data.Models;
+using Indice.Features.Identity.Core.Data.Stores;
 using Indice.Features.Identity.Core.PasswordValidation;
 using Microsoft.Extensions.Configuration;
 using Xunit;
@@ -24,7 +25,7 @@ public class AllowedCharactersPasswordValidatorTests
     [InlineData("123 Abc")]
     [InlineData("1234Abc(")]
     public async Task CheckInvalidPasswords(string password) {
-        var validator = new AllowedCharactersPasswordValidator(_configuration, new ExtendedIdentityErrorDescriber());
+        var validator = new AllowedCharactersPasswordValidator(_configuration);
         var identityResult = await validator.ValidateAsync(null, new User(), password);
         Assert.False(identityResult.Succeeded);
     }
@@ -34,7 +35,7 @@ public class AllowedCharactersPasswordValidatorTests
     [InlineData("123Abc!$")]
     [InlineData("123")]
     public async Task CheckValidPasswords(string password) {
-        var validator = new AllowedCharactersPasswordValidator(_configuration, new ExtendedIdentityErrorDescriber());
+        var validator = new AllowedCharactersPasswordValidator(_configuration);
         var identityResult = await validator.ValidateAsync(null, new User(), password);
         Assert.True(identityResult.Succeeded);
     }

--- a/test/Indice.Features.Identity.Tests/UnicodeCharactersPasswordValidatorTests.cs
+++ b/test/Indice.Features.Identity.Tests/UnicodeCharactersPasswordValidatorTests.cs
@@ -22,7 +22,7 @@ public class UnicodeCharactersPasswordValidatorTests
     [InlineData("K1$Λ")]
     [InlineData("K1$ e")]
     public async Task CheckInvalidPasswords(string password) {
-        var validator = new UnicodeCharactersPasswordValidator<User>(new ExtendedIdentityErrorDescriber(), _configuration);
+        var validator = new UnicodeCharactersPasswordValidator<User>(_configuration);
         var identityResult = await validator.ValidateAsync(null, new User(), password);
         Assert.False(identityResult.Succeeded);
     }
@@ -30,7 +30,7 @@ public class UnicodeCharactersPasswordValidatorTests
     [Theory]
     [InlineData(@"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789~!@#$%^&*()_+-={}[]:"";',./<>?")]
     public async Task CheckValidPasswords(string password) {
-        var validator = new UnicodeCharactersPasswordValidator<User>(new ExtendedIdentityErrorDescriber(), _configuration);
+        var validator = new UnicodeCharactersPasswordValidator<User>(_configuration);
         var identityResult = await validator.ValidateAsync(null, new User(), password);
         Assert.True(identityResult.Succeeded);
     }

--- a/test/Indice.Features.Identity.Tests/UserNameAsPasswordValidatorTests.cs
+++ b/test/Indice.Features.Identity.Tests/UserNameAsPasswordValidatorTests.cs
@@ -23,7 +23,7 @@ public class UserNameAsPasswordValidatorTests
         var configurationBuilder = new ConfigurationBuilder().AddInMemoryCollection(new List<KeyValuePair<string, string>> {
             new KeyValuePair<string, string>($"{nameof(PasswordOptions)}:{nameof(UserNameAsPasswordValidator<User>.MaxAllowedUserNameSubset)}", "3")
         });
-        var validator = new UserNameAsPasswordValidator<User>(configurationBuilder.Build(), new ExtendedIdentityErrorDescriber());
+        var validator = new UserNameAsPasswordValidator<User>(configurationBuilder.Build());
         var identityResult = await validator.ValidateAsync(null, new User { UserName = UserName }, password);
         Assert.False(identityResult.Succeeded);
     }
@@ -44,7 +44,7 @@ public class UserNameAsPasswordValidatorTests
         var configurationBuilder = new ConfigurationBuilder().AddInMemoryCollection(new List<KeyValuePair<string, string>> {
             new KeyValuePair<string, string>($"{nameof(PasswordOptions)}:{nameof(UserNameAsPasswordValidator<User>.MaxAllowedUserNameSubset)}", "3")
         });
-        var validator = new UserNameAsPasswordValidator<User>(configurationBuilder.Build(), new ExtendedIdentityErrorDescriber());
+        var validator = new UserNameAsPasswordValidator<User>(configurationBuilder.Build());
         var identityResult = await validator.ValidateAsync(null, new User { UserName = UserName }, password);
         Assert.True(identityResult.Succeeded);
     }


### PR DESCRIPTION
- Changed `ExtendedIdentityErrorDescriber` properties to methods for better flexibility and consistency.
- Introduced `ExtendedIdentityErrorDescriberExtensions` for easier access to error messages.
- Updated password validator constructors to remove dependency on `ExtendedIdentityErrorDescriber`, simplifying their design.
- Implemented fallback logic in validators to create a new `ExtendedIdentityErrorDescriber` instance when needed.
- Adjusted related test classes to align with the new constructor signatures, ensuring proper testing without explicit error describer instances.
- Overall improvements enhance maintainability and usability of the password validation framework.