### PR TITLE
[cases] Elsa package upgrade to 2.15.1 net 9 compatible

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -10,7 +10,7 @@
       <VersionPrefixCore>$(VersionPrefixBase).0</VersionPrefixCore>
       <VersionPrefixIdentity>$(VersionPrefixBase).1</VersionPrefixIdentity>
       <VersionPrefixIdentityUI>$(VersionPrefixBase).1</VersionPrefixIdentityUI>
-      <VersionPrefixCases>$(VersionPrefixBase).0</VersionPrefixCases>
+      <VersionPrefixCases>$(VersionPrefixBase).1</VersionPrefixCases>
       <VersionPrefixMessages>$(VersionPrefixBase).1</VersionPrefixMessages>
       <VersionPrefixMultitenancy>$(VersionPrefixBase).0</VersionPrefixMultitenancy>
       <VersionPrefixRisk>$(VersionPrefixBase).0</VersionPrefixRisk>

--- a/src/Indice.Features.Cases.Server/Endpoints/AdminAccessRulesApi.cs
+++ b/src/Indice.Features.Cases.Server/Endpoints/AdminAccessRulesApi.cs
@@ -27,7 +27,7 @@ internal static class AdminAccessRulesApi
         var group = routes.MapGroup($"{options.PathPrefix.Value!.Trim('/')}/manage");
         group.WithGroupName(options.GroupName);
 
-        var allowedScopes = new[] { options.RequiredScope }.Where(x => x != null).Cast<string>().ToArray();
+        var allowedScopes = new[] { options.RequiredScope }.FilterOutNulls().ToArray();
         group.RequireAuthorization(pb => pb
                 .RequireAuthenticatedUser()
                 .AddAuthenticationSchemes("Bearer")

--- a/src/Indice.Features.Cases.Server/Endpoints/AdminAttachmentsApi.cs
+++ b/src/Indice.Features.Cases.Server/Endpoints/AdminAttachmentsApi.cs
@@ -24,7 +24,7 @@ internal static class AdminAttachmentsApi
 
         group.WithGroupName(options.GroupName);
 
-        var allowedScopes = new[] { options.RequiredScope }.Where(x => x != null).Cast<string>().ToArray();
+        var allowedScopes = new[] { options.RequiredScope }.FilterOutNulls().ToArray();
         group.RequireAuthorization(policy => policy
             .RequireAuthenticatedUser()
             .AddAuthenticationSchemes("Bearer")

--- a/src/Indice.Features.Cases.Server/Endpoints/AdminCaseTypesApi.cs
+++ b/src/Indice.Features.Cases.Server/Endpoints/AdminCaseTypesApi.cs
@@ -24,7 +24,7 @@ internal static class AdminCaseTypesApi
         group.WithTags("AdminCaseTypes");
         group.WithGroupName(options.GroupName);
 
-        var allowedScopes = new[] { options.RequiredScope }.Where(x => x != null).Cast<string>().ToArray();
+        var allowedScopes = new[] { options.RequiredScope }.FilterOutNulls().ToArray();
 
         group.RequireAuthorization(pb => pb
             .RequireAuthenticatedUser()

--- a/src/Indice.Features.Cases.Server/Endpoints/AdminCasesApi.cs
+++ b/src/Indice.Features.Cases.Server/Endpoints/AdminCasesApi.cs
@@ -24,7 +24,7 @@ internal static class AdminCasesApi
         group.WithTags("AdminCases");
         group.WithGroupName(options.GroupName);
 
-        var allowedScopes = new[] { options.RequiredScope }.Where(x => x != null).Cast<string>().ToArray();
+        var allowedScopes = new[] { options.RequiredScope }.FilterOutNulls().ToArray();
         group.RequireAuthorization(policy => policy
             .RequireAuthenticatedUser()
             .AddAuthenticationSchemes("Bearer")
@@ -80,7 +80,7 @@ internal static class AdminCasesApi
         group.MapPatch("{caseId}/metadata", AdminCasesHandlers.PatchCaseMetadata)
             .WithName(nameof(AdminCasesHandlers.PatchCaseMetadata))
             .WithSummary("Patches the metadata of a case.")
-            .RequireAuthorization(policy => policy.RequireCasesRecordAccess(CasesAccessLevel.Manage)); 
+            .RequireAuthorization(policy => policy.RequireCasesRecordAccess(CasesAccessLevel.Manage));
 
         group.MapPost("{caseId}/comment", AdminCasesHandlers.AdminAddComment)
             .WithName(nameof(AdminCasesHandlers.AdminAddComment))

--- a/src/Indice.Features.Cases.Server/Endpoints/AdminCheckpointTypesApi.cs
+++ b/src/Indice.Features.Cases.Server/Endpoints/AdminCheckpointTypesApi.cs
@@ -23,7 +23,7 @@ internal static class AdminCheckpointTypesApi
         group.WithTags("AdminCheckpointTypes");
         group.WithGroupName(options.GroupName);
 
-        var allowedScopes = new[] { options.RequiredScope }.Where(x => x != null).Cast<string>().ToArray();
+        var allowedScopes = new[] { options.RequiredScope }.FilterOutNulls().ToArray();
 
         group.RequireAuthorization(pb => pb
             .RequireAuthenticatedUser()

--- a/src/Indice.Features.Cases.Server/Endpoints/AdminContactsApi.cs
+++ b/src/Indice.Features.Cases.Server/Endpoints/AdminContactsApi.cs
@@ -22,7 +22,7 @@ internal static class AdminContactsApi
         group.WithTags("AdminIntegration");
         group.WithGroupName(options.GroupName);
 
-        var allowedScopes = new[] { options.RequiredScope }.Where(x => x != null).Cast<string>().ToArray();
+        var allowedScopes = new[] { options.RequiredScope }.FilterOutNulls().ToArray();
         group.RequireAuthorization(pb => pb
             .RequireAuthenticatedUser()
             .AddAuthenticationSchemes("Bearer")

--- a/src/Indice.Features.Cases.Server/Endpoints/AdminNotificationsApi.cs
+++ b/src/Indice.Features.Cases.Server/Endpoints/AdminNotificationsApi.cs
@@ -24,7 +24,7 @@ internal static class AdminNotificationsApi
         group.WithTags("AdminNotifications");
         group.WithGroupName(options.GroupName);
 
-        var allowedScopes = new[] { options.RequiredScope }.Where(x => x != null).Cast<string>().ToArray();
+        var allowedScopes = new[] { options.RequiredScope }.FilterOutNulls().ToArray();
         group.RequireAuthorization(pb => pb
             .RequireAuthenticatedUser()
             .AddAuthenticationSchemes("Bearer")

--- a/src/Indice.Features.Cases.Server/Endpoints/AdminQueriesApi.cs
+++ b/src/Indice.Features.Cases.Server/Endpoints/AdminQueriesApi.cs
@@ -24,7 +24,7 @@ internal static class AdminQueriesApi
         group.WithTags("AdminQueries");
         group.WithGroupName(options.GroupName);
 
-        var allowedScopes = new[] { options.RequiredScope }.Where(x => x != null).Cast<string>().ToArray();
+        var allowedScopes = new[] { options.RequiredScope }.FilterOutNulls().ToArray();
 
         group.RequireAuthorization(policy => policy
             .RequireAuthenticatedUser()

--- a/src/Indice.Features.Cases.Server/Endpoints/AdminReportsApi.cs
+++ b/src/Indice.Features.Cases.Server/Endpoints/AdminReportsApi.cs
@@ -22,7 +22,7 @@ internal static class AdminReportsApi
         group.WithTags("AdminReports");
         group.WithGroupName(options.GroupName);
 
-        var allowedScopes = new[] { options.RequiredScope }.Where(x => x != null).Cast<string>().ToArray();
+        var allowedScopes = new[] { options.RequiredScope }.FilterOutNulls().ToArray();
 
         group.RequireAuthorization(policy => policy
             .RequireAuthenticatedUser()

--- a/src/Indice.Features.Cases.Server/Endpoints/AdminWorkflowInvokerApi.cs
+++ b/src/Indice.Features.Cases.Server/Endpoints/AdminWorkflowInvokerApi.cs
@@ -20,7 +20,7 @@ internal static class AdminWorkflowInvokerApi
         group.WithTags("AdminWorkflowInvoker");
         group.WithGroupName(options.GroupName);
 
-        var allowedScopes = new[] { options.RequiredScope }.Where(x => x != null).Cast<string>().ToArray();
+        var allowedScopes = new[] { options.RequiredScope }.FilterOutNulls().ToArray();
 
         group.RequireAuthorization(policy => policy
             .RequireAuthenticatedUser()

--- a/src/Indice.Features.Cases.Server/Endpoints/IntegrationApi.cs
+++ b/src/Indice.Features.Cases.Server/Endpoints/IntegrationApi.cs
@@ -18,7 +18,7 @@ internal static class IntegrationApi
         group.WithGroupName("cases-workflow");
         group.WithTags("Cases workflow");
         
-        var allowedScopes = new[] { options.RequiredScope }.Where(x => x != null).Cast<string>().ToArray();
+        var allowedScopes = new[] { options.RequiredScope }.FilterOutNulls().ToArray();
         group.RequireAuthorization(policy => policy
                 .RequireAuthenticatedUser()
                 .RequireAssertion(ctx=> ctx.User.IsSystemClient() || ctx.User.IsAdmin())

--- a/src/Indice.Features.Cases.Server/Endpoints/LookupApi.cs
+++ b/src/Indice.Features.Cases.Server/Endpoints/LookupApi.cs
@@ -22,7 +22,7 @@ internal static class LookupApi
         group.WithTags("Lookup");
         group.WithGroupName(options.GroupName);
 
-        var allowedScopes = new[] { options.RequiredScope }.Where(x => x != null).Cast<string>().ToArray();
+        var allowedScopes = new[] { options.RequiredScope }.FilterOutNulls().ToArray();
 
         group.RequireAuthorization(policy => policy
             .RequireAuthenticatedUser()

--- a/src/Indice.Features.Cases.Server/Endpoints/MyCaseTypesApi.cs
+++ b/src/Indice.Features.Cases.Server/Endpoints/MyCaseTypesApi.cs
@@ -24,7 +24,7 @@ internal static class MyCaseTypesApi
         group.WithTags("MyCases");
         group.WithGroupName("my");
 
-        var allowedScopes = new[] { options.RequiredScope }.Where(x => x != null).Cast<string>().ToArray();
+        var allowedScopes = new[] { options.RequiredScope }.FilterOutNulls().ToArray();
 
         // Add security requirements, all incoming requests to this API *must* be authenticated with a valid user.
         group.RequireAuthorization(policy => policy

--- a/src/Indice.Features.Cases.Server/Endpoints/MyCasesApi.cs
+++ b/src/Indice.Features.Cases.Server/Endpoints/MyCasesApi.cs
@@ -26,7 +26,7 @@ internal static class MyCasesApi
         group.WithTags("MyCases");
         group.WithGroupName("my");
 
-        var allowedScopes = new[] { options.RequiredScope }.Where(x => x != null).Cast<string>().ToArray();
+        var allowedScopes = new[] { options.RequiredScope }.FilterOutNulls().ToArray();
 
         // Add security requirements, all incoming requests to this API *must* be authenticated with a valid user.
         group.RequireAuthorization(policy => policy

--- a/src/Indice.Features.Cases.Workflows/Indice.Features.Cases.Workflows.csproj
+++ b/src/Indice.Features.Cases.Workflows/Indice.Features.Cases.Workflows.csproj
@@ -7,19 +7,18 @@
 
   <ItemGroup>
     <PackageReference Include="Duende.AccessTokenManagement" Version="3.2.0" />
-    <PackageReference Include="Elsa" Version="2.13.0" />
-    <PackageReference Include="Elsa.Activities.Email" Version="2.13.0" />
-    <PackageReference Include="Elsa.Activities.Http" Version="2.13.0" />
-    <PackageReference Include="Elsa.Activities.Temporal.Quartz" Version="2.13.0" />
-    <PackageReference Include="Elsa.Activities.UserTask" Version="2.13.0" />
-    <PackageReference Include="Elsa.Designer.Components.Web" Version="2.13.0" />
-    <PackageReference Include="Elsa.Persistence.EntityFramework.SqlServer" Version="2.13.0" />
-    <PackageReference Include="Elsa.Retention" Version="2.13.0" />
-    <PackageReference Include="Elsa.Server.Api" Version="2.13.0" />
+    <PackageReference Include="Elsa" Version="2.15.1" />
+    <PackageReference Include="Elsa.Activities.Email" Version="2.15.1" />
+    <PackageReference Include="Elsa.Activities.Http" Version="2.15.1" />
+    <PackageReference Include="Elsa.Activities.Temporal.Quartz" Version="2.15.1" />
+    <PackageReference Include="Elsa.Activities.UserTask" Version="2.15.1" />
+    <PackageReference Include="Elsa.Designer.Components.Web" Version="2.15.1" />
+    <PackageReference Include="Elsa.Persistence.EntityFramework.SqlServer" Version="2.15.1" />
+    <PackageReference Include="Elsa.Retention" Version="2.15.1" />
+    <PackageReference Include="Elsa.Server.Api" Version="2.15.1" />
     <PackageReference Include="JsonSchema.Net" Version="7.3.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.16" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.16" />
-    <PackageReference Include="MediatR" Version="12.2.0" />
     <PackageReference Include="Indice.Common" Version="$(VersionPrefixCore)-*" />
     <PackageReference Include="Indice.Services" Version="$(VersionPrefixCore)-*" />
     <PackageReference Include="IdentityModel" Version="7.0.0" />

--- a/src/Indice.Features.Identity.Server/Devices/DevicesApi.cs
+++ b/src/Indice.Features.Identity.Server/Devices/DevicesApi.cs
@@ -22,7 +22,7 @@ public static class DevicesApi
         group.WithTags("Devices");
         group.WithGroupName("identity");
         // Add security requirements, all incoming requests to this API *must* be authenticated with a valid user.
-        var allowedScopes = new[] { options.ApiScope }.Where(x => x != null).Cast<string>().ToArray();
+        var allowedScopes = new[] { options.ApiScope }.FilterOutNulls().ToArray();
         group.RequireAuthorization(policy => policy
             .RequireAuthenticatedUser()
             .AddAuthenticationSchemes(IdentityEndpoints.AuthenticationScheme)

--- a/src/Indice.Features.Identity.Server/Devices/PushNotificationsApi.cs
+++ b/src/Indice.Features.Identity.Server/Devices/PushNotificationsApi.cs
@@ -20,7 +20,7 @@ public static class PushNotificationsApi
         group.WithGroupName("identity");
         // Add security requirements, all incoming requests to this API *must*
         // be authenticated with a valid user.
-        var allowedScopes = new[] { options.ApiScope }.Where(x => x != null).Cast<string>().ToArray();
+        var allowedScopes = new[] { options.ApiScope }.FilterOutNulls().ToArray();
         group.RequireAuthorization(policy => policy
             .RequireAuthenticatedUser()
             .AddAuthenticationSchemes(IdentityEndpoints.AuthenticationScheme)

--- a/src/Indice.Features.Identity.Server/Manager/ClaimTypesApi.cs
+++ b/src/Indice.Features.Identity.Server/Manager/ClaimTypesApi.cs
@@ -23,7 +23,7 @@ public static class ClaimTypesApi
         group.WithTags("ClaimTypes");
         group.WithGroupName("identity");
         // Add security requirements, all incoming requests to this API *must* be authenticated with a valid user.
-        var allowedScopes = new[] { options.ApiScope, IdentityEndpoints.SubScopes.Users }.Where(x => x != null).Cast<string>().ToArray();
+        var allowedScopes = new[] { options.ApiScope, IdentityEndpoints.SubScopes.Users }.FilterOutNulls().ToArray();
         group.RequireAuthorization(policy => policy
              .RequireAuthenticatedUser()
              .AddAuthenticationSchemes(IdentityEndpoints.AuthenticationScheme)

--- a/src/Indice.Features.Identity.Server/Manager/ClientsApi.cs
+++ b/src/Indice.Features.Identity.Server/Manager/ClientsApi.cs
@@ -24,7 +24,7 @@ public static class ClientsApi
         group.WithTags("Clients");
         group.WithGroupName("identity");
         // Add security requirements, all incoming requests to this API *must* be authenticated with a valid user.
-        var allowedScopes = new[] { options.ApiScope, IdentityEndpoints.SubScopes.Clients }.Where(x => x != null).Cast<string>().ToArray();
+        var allowedScopes = new[] { options.ApiScope, IdentityEndpoints.SubScopes.Clients }.FilterOutNulls().ToArray();
         group.RequireAuthorization(policy => policy
             .RequireAuthenticatedUser()
             .AddAuthenticationSchemes(IdentityEndpoints.AuthenticationScheme)

--- a/src/Indice.Features.Identity.Server/Manager/DashboardApi.cs
+++ b/src/Indice.Features.Identity.Server/Manager/DashboardApi.cs
@@ -24,7 +24,7 @@ public static class DashboardApi
         group.WithTags("Dashboard");
         group.WithGroupName("identity");
         // Add security requirements, all incoming requests to this API *must* be authenticated with a valid user.
-        var allowedScopes = new[] { options.ApiScope, IdentityEndpoints.SubScopes.Users, IdentityEndpoints.SubScopes.Clients }.Where(x => x != null).Cast<string>().ToArray();
+        var allowedScopes = new[] { options.ApiScope, IdentityEndpoints.SubScopes.Users, IdentityEndpoints.SubScopes.Clients }.FilterOutNulls().ToArray();
         group.RequireAuthorization(policy => policy
             .RequireAuthenticatedUser()
             .AddAuthenticationSchemes(IdentityEndpoints.AuthenticationScheme)

--- a/src/Indice.Features.Identity.Server/Manager/LookupsApi.cs
+++ b/src/Indice.Features.Identity.Server/Manager/LookupsApi.cs
@@ -17,7 +17,7 @@ public static class LookupsApi
         group.WithTags("Lookups");
         group.WithGroupName("identity");
         // Add security requirements, all incoming requests to this API *must* be authenticated with a valid user.
-        var allowedScopes = new[] { options.ApiScope }.Where(x => x != null).Cast<string>().ToArray();
+        var allowedScopes = new[] { options.ApiScope }.FilterOutNulls().ToArray();
         group.RequireAuthorization(policy => policy
             .RequireAuthenticatedUser()
             .AddAuthenticationSchemes(IdentityEndpoints.AuthenticationScheme)

--- a/src/Indice.Features.Identity.Server/Manager/ResourcesApi.cs
+++ b/src/Indice.Features.Identity.Server/Manager/ResourcesApi.cs
@@ -22,7 +22,7 @@ public static class ResourcesApi
         group.WithTags("Resources");
         group.WithGroupName("identity");
         // Add security requirements, all incoming requests to this API *must* be authenticated with a valid user.
-        var allowedScopes = new[] { options.ApiScope, IdentityEndpoints.SubScopes.Clients }.Where(x => x != null).Cast<string>().ToArray();
+        var allowedScopes = new[] { options.ApiScope, IdentityEndpoints.SubScopes.Clients }.FilterOutNulls().ToArray();
         group.RequireAuthorization(pb => pb.RequireAuthenticatedUser()
                                            .AddAuthenticationSchemes(IdentityEndpoints.AuthenticationScheme));
 

--- a/src/Indice.Features.Identity.Server/Manager/RolesApi.cs
+++ b/src/Indice.Features.Identity.Server/Manager/RolesApi.cs
@@ -27,7 +27,7 @@ public static class RolesApi
         group.WithTags("Roles");
         group.WithGroupName("identity");
         // Add security requirements, all incoming requests to this API *must* be authenticated with a valid user.
-        var allowedScopes = new[] { options.ApiScope, IdentityEndpoints.SubScopes.Users }.Where(x => x != null).Cast<string>().ToArray();
+        var allowedScopes = new[] { options.ApiScope, IdentityEndpoints.SubScopes.Users }.FilterOutNulls().ToArray();
         group.RequireAuthorization(policy => policy
              .RequireAuthenticatedUser()
              .AddAuthenticationSchemes(IdentityEndpoints.AuthenticationScheme)

--- a/src/Indice.Features.Identity.Server/Manager/UsersApi.cs
+++ b/src/Indice.Features.Identity.Server/Manager/UsersApi.cs
@@ -21,7 +21,7 @@ public static class UsersApi
         group.WithTags("Users");
         group.WithGroupName("identity");
         // Add security requirements, all incoming requests to this API *must* be authenticated with a valid user.
-        var allowedScopes = new[] { options.ApiScope, IdentityEndpoints.SubScopes.Users }.Where(x => x != null).Cast<string>().ToArray();
+        var allowedScopes = new[] { options.ApiScope, IdentityEndpoints.SubScopes.Users }.FilterOutNulls().ToArray();
         group.RequireAuthorization(policy => policy
              .RequireAuthenticatedUser()
              .AddAuthenticationSchemes(IdentityEndpoints.AuthenticationScheme)

--- a/src/Indice.Features.Identity.Server/Totp/TotpApi.cs
+++ b/src/Indice.Features.Identity.Server/Totp/TotpApi.cs
@@ -28,7 +28,7 @@ public static class TotpApi
                            .ProducesProblem(StatusCodes.Status500InternalServerError)
                            .RequireRateLimiting(IdentityEndpoints.RateLimiter.Policies.Totp);
 
-        var allowedScopes = new[] { options.ApiScope, IdentityEndpoints.SubScopes.Totp }.Where(x => x != null).Cast<string>().ToArray();
+        var allowedScopes = new[] { options.ApiScope, IdentityEndpoints.SubScopes.Totp }.FilterOutNulls().ToArray();
         group.WithOpenApi().AddOpenApiSecurityRequirement("oauth2", allowedScopes);
 
         // POST: /api/totp


### PR DESCRIPTION
Upgraded the `Elsa` package from version `2.13.0` to `2.15.1`, which may include new features or bug fixes.

Also Updated the definition of `allowedScopes` across multiple API classes to use the new `FilterOutNulls()` method for improved readability.