### PR TITLE
Add certificate forwarding support in web application

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,11 +4,11 @@
       <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
       <!--<TargetFramework></TargetFramework>-->
       <VersionPrefixMajor>8</VersionPrefixMajor>
-      <VersionPrefixBase>$(VersionPrefixMajor).2</VersionPrefixBase>
+      <VersionPrefixBase>$(VersionPrefixMajor).3</VersionPrefixBase>
       
       <VersionPrefixCore>$(VersionPrefixBase).0</VersionPrefixCore>
-      <VersionPrefixIdentity>$(VersionPrefixBase).1</VersionPrefixIdentity>
-      <VersionPrefixIdentityUI>$(VersionPrefixBase).1</VersionPrefixIdentityUI>
+      <VersionPrefixIdentity>$(VersionPrefixBase).0</VersionPrefixIdentity>
+      <VersionPrefixIdentityUI>$(VersionPrefixBase).0</VersionPrefixIdentityUI>
       <VersionPrefixCases>$(VersionPrefixBase).0</VersionPrefixCases>
       <VersionPrefixMessages>$(VersionPrefixBase).0</VersionPrefixMessages>
       <VersionPrefixMultitenancy>$(VersionPrefixBase).0</VersionPrefixMultitenancy>

--- a/src/Indice.AspNetCore.Builder/IndiceWebApplicationBuilder.cs
+++ b/src/Indice.AspNetCore.Builder/IndiceWebApplicationBuilder.cs
@@ -62,6 +62,9 @@ public class IndiceWebApplicationBuilder : IHostApplicationBuilder
     public WebApplication Build() {
         var app = InnerBuilder.Build();
 
+        if (app.Configuration.UseCertificateForwarding()) {
+            app.UseCertificateForwarding();
+        }
         if (app.Configuration.ProxyEnabled()) {
             app.UseForwardedHeaders();
             app.UseHttpMethodOverride();
@@ -77,6 +80,7 @@ public class IndiceWebApplicationBuilder : IHostApplicationBuilder
         if (app.Configuration.HstsEnabled()) {
             app.UseHsts();
         }
+
         app.UseCors();
         app.UseExceptionHandler();
         app.UseStatusCodePages();

--- a/src/Indice.Services/Configuration/GeneralSettings.cs
+++ b/src/Indice.Services/Configuration/GeneralSettings.cs
@@ -29,6 +29,8 @@ public class GeneralSettings
     public bool UseHttpsRedirection { get; set; }
     /// <summary>A flag that indicates whether to redirect the setting that is definded in <see cref="Host"/>.</summary>
     public bool UseRedirectToHost { get; set; }
+    /// <summary>A flag that indicates whether to use certificate forwarding middleware.</summary>
+    public bool UseCertificateForwarding { get; set; }
     /// <summary>A list of endpoints used throughout the application.</summary>
     public Dictionary<string, string>? Endpoints { get; set; }
     /// <summary>A flag that indicates whether to enable HSTS (HTTP Strict Transport Security).</summary>

--- a/src/Indice.Services/Extensions/IConfigurationExtensions.cs
+++ b/src/Indice.Services/Extensions/IConfigurationExtensions.cs
@@ -18,6 +18,14 @@ public static class IConfigurationExtensions
     /// <remarks>Checks for the <strong>General:UseHttpsRedirection</strong> option in appsettings.json file. When true you can register HttpsPolicyBuilderExtensions.UseHttpsRedirection(IApplicationBuilder) middleware.</remarks>
     public static bool UseHttpsRedirection(this IConfiguration configuration) => configuration.GetSection(GeneralSettings.Name).GetValue<bool>(nameof(GeneralSettings.UseHttpsRedirection));
 
+    /// <summary>
+    /// Determines whether client certificate forwarding is enabled based on the configuration settings. 
+    /// </summary>
+    /// <remarks>This allows client certificates to be loaded behind a reverse proxy, such as Nginx or Apache, which is useful in scenarios where the application is hosted behind a load balancer or reverse proxy that handles SSL termination.</remarks>
+    /// <param name="configuration">The configuration instance to retrieve the setting from.</param>
+    /// <returns><see langword="true"/> if certificate forwarding is enabled; otherwise, <see langword="false"/>.</returns>
+    public static bool UseCertificateForwarding(this IConfiguration configuration) => configuration.GetSection(GeneralSettings.Name).GetValue<bool>(nameof(GeneralSettings.UseCertificateForwarding));
+
     /// <summary>A flag that indicates whether to redirect the setting that is defined in <see cref="GeneralSettings.Host"/>.</summary>
     /// <param name="configuration">Represents a set of key/value application configuration properties.</param>
     /// <returns>True if specified flag is set to true, otherwise false.</returns>


### PR DESCRIPTION
Updated `IndiceWebApplicationBuilder` to include middleware for certificate forwarding based on configuration settings. Added `UseCertificateForwarding` property to `GeneralSettings` to control this feature. Introduced a new extension method in `IConfigurationExtensions` to retrieve the forwarding setting from the configuration, complete with XML documentation.