### PR TITLE
[cases] Enhanced checkpoint type validation for send message when updating only data

### DIFF
--- a/src/Indice.Features.Cases.Core/Services/AdminCaseService.cs
+++ b/src/Indice.Features.Cases.Core/Services/AdminCaseService.cs
@@ -1,12 +1,8 @@
 ﻿using System.Globalization;
 using System.Linq.Expressions;
-using System.Security.Claims;
-using System.Text.Json;
 using System.Text.Json.Nodes;
-using System.Text.RegularExpressions;
 using Indice.Events;
 using Indice.Features.Cases.Core.Data;
-using Indice.Features.Cases.Core.Data.Models;
 using Indice.Features.Cases.Core.Events;
 using Indice.Features.Cases.Core.Exceptions;
 using Indice.Features.Cases.Core.Models;

--- a/src/Indice.Features.Cases.Core/Services/CaseMessageService/BaseCaseMessageService.cs
+++ b/src/Indice.Features.Cases.Core/Services/CaseMessageService/BaseCaseMessageService.cs
@@ -40,7 +40,7 @@ internal abstract class BaseCaseMessageService
         var newCheckpointType = await DbContext.CheckpointTypes
             .AsQueryable()
             .SingleOrDefaultAsync(x => x.Code == message.CheckpointTypeName && x.CaseTypeId == caseType.Id);
-        if (newCheckpointType == null) {
+        if (!string.IsNullOrWhiteSpace(message.CheckpointTypeName) && newCheckpointType == null) {
             throw new BusinessException($"Invalid checkpoint. Not checkpoint was found for the current case with name {message.CheckpointTypeName}.");
         }
 


### PR DESCRIPTION
Removed unnecessary using directives in AdminCaseService.cs. Enhanced checkpoint type validation in BaseCaseMessageService.cs to check for non-empty checkpoint type names before querying the database, ensuring better error handling.