### PR TITLE
Update IPushNotificationService to return SendReceipt #697

### DIFF
--- a/src/Indice.Common/Services/IPushNotificationService.cs
+++ b/src/Indice.Common/Services/IPushNotificationService.cs
@@ -23,7 +23,7 @@ public interface IPushNotificationService
     /// <param name="tags">Tags are used to route notifications to the correct set of device handles.</param>
     /// <param name="data">Data passed to mobile client, not visible to notification toast.</param>
     /// <param name="classification">The notification's type.</param>
-    Task SendAsync(string title, string? body, IList<PushNotificationTag>? tags, string? data = null, string? classification = null);
+    Task<SendReceipt> SendAsync(string title, string? body, IList<PushNotificationTag>? tags, string? data = null, string? classification = null);
 }
 
 /// <summary>Extensions for <see cref="IPushNotificationService"/>.</summary>

--- a/src/Indice.Common/Services/PushNotificationServiceNoop.cs
+++ b/src/Indice.Common/Services/PushNotificationServiceNoop.cs
@@ -9,7 +9,7 @@ public class PushNotificationServiceNoop : IPushNotificationService
     public Task Register(string deviceId, string? pnsHandle, DevicePlatform devicePlatform, IList<PushNotificationTag> tags) => Task.CompletedTask;
 
     ///<inheritdoc/>
-    public Task SendAsync(string title, string? body, IList<PushNotificationTag>? tags, string? data = null, string? classification = null) => Task.CompletedTask;
+    public Task<SendReceipt> SendAsync(string title, string? body, IList<PushNotificationTag>? tags, string? data = null, string? classification = null) => Task.FromResult(new SendReceipt(string.Empty, DateTimeOffset.UtcNow));
 
     ///<inheritdoc/>
     public Task UnRegister(string deviceId) => Task.CompletedTask;

--- a/src/Indice.Services/PushNotificationServiceAzure.cs
+++ b/src/Indice.Services/PushNotificationServiceAzure.cs
@@ -84,7 +84,7 @@ public class PushNotificationServiceAzure : IPushNotificationService
     }
 
     /// <inheritdoc/>
-    public async Task SendAsync(string title, string? body, IList<PushNotificationTag>? tags, string? data = null, string? classification = null) {
+    public async Task<SendReceipt> SendAsync(string title, string? body, IList<PushNotificationTag>? tags, string? data = null, string? classification = null) {
         if (string.IsNullOrEmpty(title)) {
             throw new ArgumentNullException(nameof(title));
         }
@@ -100,18 +100,21 @@ public class PushNotificationServiceAzure : IPushNotificationService
         if (!string.IsNullOrEmpty(classification)) {
             properties.Add("classification", classification);
         }
+        NotificationOutcome outcome;
         if (tags?.Any() == true) {
             var tagsCollection = tags.Select(
                 tag => tag.Kind == PushNotificationTagKind.User || tag.Kind == PushNotificationTagKind.Unspecified
                     ? tag.ToString()
                     : "$InstallationId:{" + tag.Value + "}" // https://learn.microsoft.com/en-us/azure/notification-hubs/notification-hubs-push-notification-registration-management#installations
             );
-            await NotificationHub.SendTemplateNotificationAsync(properties, tagsCollection);
+            outcome = await NotificationHub.SendTemplateNotificationAsync(properties, tagsCollection);
             _logger.LogInformation("A push notification was dispatched to Azure Notification Hubs with properties '{Properties}' to the following tags: {Tags}.", string.Join(" - ", properties), string.Join(", ", tags));
         } else {
-            await NotificationHub.SendTemplateNotificationAsync(properties);
+            outcome = await NotificationHub.SendTemplateNotificationAsync(properties);
             _logger.LogInformation("A push notification was dispatched to Azure Notification Hubs with properties {Properties}.", string.Join(" - ", properties));
         }
+        // The notification id is only available for the azure standard tier so we use the tracking id as a fallback.
+        return new SendReceipt(outcome.NotificationId ?? outcome.TrackingId, DateTimeOffset.UtcNow);
     }
 }
 

--- a/src/Indice.Services/PushNotificationServiceAzure.cs
+++ b/src/Indice.Services/PushNotificationServiceAzure.cs
@@ -100,7 +100,7 @@ public class PushNotificationServiceAzure : IPushNotificationService
         if (!string.IsNullOrEmpty(classification)) {
             properties.Add("classification", classification);
         }
-        NotificationOutcome outcome = null!;
+        NotificationOutcome outcome;
         if (tags?.Any() == true) {
             var tagsCollection = tags.Select(
                 tag => tag.Kind == PushNotificationTagKind.User || tag.Kind == PushNotificationTagKind.Unspecified

--- a/src/Indice.Services/PushNotificationServiceAzure.cs
+++ b/src/Indice.Services/PushNotificationServiceAzure.cs
@@ -100,7 +100,7 @@ public class PushNotificationServiceAzure : IPushNotificationService
         if (!string.IsNullOrEmpty(classification)) {
             properties.Add("classification", classification);
         }
-        NotificationOutcome outcome;
+        NotificationOutcome outcome = null!;
         if (tags?.Any() == true) {
             var tagsCollection = tags.Select(
                 tag => tag.Kind == PushNotificationTagKind.User || tag.Kind == PushNotificationTagKind.Unspecified


### PR DESCRIPTION
Refactor the SendAsync method in IPushNotificationService to return a Task<​SendReceipt> instead of a Task.

The PushNotificationServiceNoop now returns a SendReceipt with an empty notification ID and the current UTC time. The PushNotificationServiceAzure has been enhanced to handle notification outcomes, returning a SendReceipt with the notification ID or tracking ID.

cc: @travlos 