### PR TITLE
Update codeql-action/upload-sarif to v3.29.11

### DIFF
--- a/.github/workflows/composites/codeql-csharp/action.yml
+++ b/.github/workflows/composites/codeql-csharp/action.yml
@@ -31,13 +31,13 @@ runs:
         source-url: https://api.nuget.org/v3/index.json
   
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@3.29.0
+      uses: github/codeql-action/init@3c3833e0f8c1c83d449a7478aa59c036a9165498 # v3.29.11
       with:
         languages: csharp
         build-mode: none
         config-file: ./.github/workflows/codeql/codeql-config.yml
       
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@3.29.0
+      uses: github/codeql-action/analyze@3c3833e0f8c1c83d449a7478aa59c036a9165498 # v3.29.11
       with:
         category: "/language:csharp"

--- a/.github/workflows/composites/codeql-js/action.yml
+++ b/.github/workflows/composites/codeql-js/action.yml
@@ -30,13 +30,13 @@ runs:
         node-version: 20
   
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@3.29.0
+      uses: github/codeql-action/init@3c3833e0f8c1c83d449a7478aa59c036a9165498 # v3.29.11
       with:
         languages: javascript-typescript
         build-mode: none
         config-file: ./.github/workflows/codeql/codeql-config.yml
       
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@3.29.0
+      uses: github/codeql-action/analyze@3c3833e0f8c1c83d449a7478aa59c036a9165498 # v3.29.11
       with:
         category: "/language:javascript-typescript"

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -73,6 +73,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@3.29.0
+        uses: github/codeql-action/upload-sarif@3c3833e0f8c1c83d449a7478aa59c036a9165498 # v3.29.11
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Replaced the upload step for GitHub's code scanning dashboard from version 3.29.0 to version 3.29.11, using a specific commit hash. The configuration for the `sarif_file` input parameter remains unchanged.