### PR TITLE
Update Indice.Features.GeoIP version references

### DIFF
--- a/src/Indice.Features.Identity.Core/Indice.Features.Identity.Core.csproj
+++ b/src/Indice.Features.Identity.Core/Indice.Features.Identity.Core.csproj
@@ -9,8 +9,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Indice.AspNetCore" Version="$(VersionPrefixCore)-*" />
-    <PackageReference Include="Indice.Features.GeoIP" Version="$(VersionGeoIP)" />
     <PackageReference Include="Indice.Extensions.Configuration.Database" Version="$(VersionPrefixCore)-*" />
+    <PackageReference Include="Indice.Features.GeoIP" Version="$(VersionPrefixGeoIP)-*" />
     <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="4.2.1" />
     <PackageReference Include="UAParser" Version="3.1.47" />
     <PackageReference Include="System.ServiceModel.Syndication" Version="9.0.7" />
@@ -30,8 +30,8 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Indice.AspNetCore\Indice.AspNetCore.csproj" />
-    <ProjectReference Include="..\Indice.Features.GeoIP\Indice.Features.GeoIP.csproj" />
     <ProjectReference Include="..\Indice.Extensions.Configuration.Database\Indice.Extensions.Configuration.Database.csproj" />
+    <ProjectReference Include="..\Indice.Features.GeoIP\Indice.Features.GeoIP.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="ExtendedIdentityErrorResources.Designer.cs">


### PR DESCRIPTION
Modified the `PackageReference` for `Indice.Features.GeoIP` to use `$(VersionPrefixGeoIP)-*` instead of `$(VersionGeoIP)`. Confirmed that the `ProjectReference` for `Indice.Features.GeoIP` remains included in the project file.