### PR TITLE
Fix channel check logic

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -19,7 +19,7 @@
       <VersionPrefixAspNet>$(VersionPrefixBase).0</VersionPrefixAspNet>
       <VersionPrefix>$(VersionPrefixBase).0</VersionPrefix>
       
-      <!--<VersionSuffix>rc04</VersionSuffix>-->
+      <!--<VersionSuffix>rc04</VersionSuffix> -->
       <Authors>Constantinos Leftheris</Authors>
       <GenerateDocumentationFile>true</GenerateDocumentationFile>
       <LangVersion>Latest</LangVersion>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,7 +4,7 @@
       <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
       <!--<TargetFramework></TargetFramework>-->
       <VersionPrefixMajor>8</VersionPrefixMajor>
-      <VersionPrefixBase>$(VersionPrefixMajor).12</VersionPrefixBase>
+      <VersionPrefixBase>$(VersionPrefixMajor).13</VersionPrefixBase>
       
       <VersionPrefixCore>$(VersionPrefixBase).0</VersionPrefixCore>
       <VersionPrefixIdentity>$(VersionPrefixBase).0</VersionPrefixIdentity>

--- a/src/Indice.Features.Messages.Core/Handlers/ResolveMessageHandler.cs
+++ b/src/Indice.Features.Messages.Core/Handlers/ResolveMessageHandler.cs
@@ -151,7 +151,7 @@ public class ResolveMessageHandler : ICampaignJobHandler<ResolveMessageEvent>
         });
         var eventDispatcher = EventDispatcherFactory.Create(KeyedServiceNames.EventDispatcherServiceKey);
         var contactChannels = contact.GetAvailableChannels(campaign.MessageChannelKind, campaign.IgnoreUserPreferences);
-        if (contactChannels.HasFlag(MessageChannelKind.None)) {
+        if (contactChannels == MessageChannelKind.None) {
             return;
         }
 


### PR DESCRIPTION
- Updated `VersionPrefixBase` in `Directory.Build.props` from `$(VersionPrefixMajor).12` to `$(VersionPrefixMajor).13`.
- Changed condition in `ResolveMessageHandler.cs` to check for `contactChannels` using direct equality with `MessageChannelKind.None` for better clarity and correctness.