### PR TITLE
[Identity] Propagate page event down the DI

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,7 +8,7 @@
       
       <VersionPrefixCore>$(VersionPrefixBase).0</VersionPrefixCore>
       <VersionPrefixIdentity>$(VersionPrefixBase).0</VersionPrefixIdentity>
-      <VersionPrefixIdentityUI>$(VersionPrefixBase).0</VersionPrefixIdentityUI>
+      <VersionPrefixIdentityUI>$(VersionPrefixBase).1</VersionPrefixIdentityUI>
       <VersionPrefixCases>$(VersionPrefixBase).0</VersionPrefixCases>
       <VersionPrefixMessages>$(VersionPrefixBase).0</VersionPrefixMessages>
       <VersionPrefixMultitenancy>$(VersionPrefixBase).0</VersionPrefixMultitenancy>

--- a/src/Indice.Features.Identity.UI/IdentityBuilderUIExtensions.cs
+++ b/src/Indice.Features.Identity.UI/IdentityBuilderUIExtensions.cs
@@ -50,6 +50,7 @@ public static class IdentityBuilderUIExtensions
             options.RememberMeLoginDuration = configuredOptions.RememberMeLoginDuration;
             options.ShowLogoutPrompt = configuredOptions.ShowLogoutPrompt;
             options.TermsUrl = configuredOptions.TermsUrl;
+            options.Events = configuredOptions.Events;
             options.EnablePhoneNumberCallingCodes = configuredOptions.EnablePhoneNumberCallingCodes;
             foreach (var url in configuredOptions.ValidReturnUrls) {
                 options.ValidReturnUrls.Add(url);


### PR DESCRIPTION
Added support for custom event handling in `IdentityBuilderUIExtensions` by setting the `options.Events` property to `configuredOptions.Events`.
Updated `VersionPrefixIdentityUI` to reflect a new versioning scheme. 