### PR TITLE
[Actions] Prevent concurrent workflow runs per Pull Request/Branch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,10 @@ on:
   push:
     branches: [ develop ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run-build:
     name: .NET Build


### PR DESCRIPTION
Ensure only one workflow run per Pull Request or Branch is active at a time, automatically cancelling any previous runs for faster execution.