### PR TITLE
[cases] fix for sqlparameterexpception

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,7 +9,7 @@
       <VersionPrefixCore>$(VersionPrefixBase).0</VersionPrefixCore>
       <VersionPrefixIdentity>$(VersionPrefixBase).0</VersionPrefixIdentity>
       <VersionPrefixIdentityUI>$(VersionPrefixBase).1</VersionPrefixIdentityUI>
-      <VersionPrefixCases>$(VersionPrefixBase).0</VersionPrefixCases>
+      <VersionPrefixCases>$(VersionPrefixBase).1</VersionPrefixCases>
       <VersionPrefixMessages>$(VersionPrefixBase).3</VersionPrefixMessages>
       <VersionPrefixMultitenancy>$(VersionPrefixBase).0</VersionPrefixMultitenancy>
       <VersionPrefixRisk>$(VersionPrefixBase).0</VersionPrefixRisk>

--- a/src/Indice.Features.Cases.Core/Data/Models/DbCaseAccessRule.cs
+++ b/src/Indice.Features.Cases.Core/Data/Models/DbCaseAccessRule.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
 
 namespace Indice.Features.Cases.Core.Data.Models;
 
@@ -26,7 +27,7 @@ public class DbCaseAccessRule
     public static Expression<Func<DbCaseAccessRule, bool>> AccessMatchPredicate(string? userId, List<string> userRoles, string? groupId) {
         return x =>
             (userId != null && x.MemberUserId == userId) ||
-            (userRoles.Any() && userRoles.Contains(x.MemberRole!)) ||
+            (EF.Constant(userRoles).Contains(x.MemberRole!)) ||
             (groupId != null && x.MemberGroupId == groupId);
     }
     public static Expression<Func<DbCaseAccessRule, bool>> RuleMatchPredicate(Guid caseId, Guid caseTypeId, Guid checkpointTypeId) {

--- a/src/Indice.Features.Cases.Core/Data/Models/DbCaseAccessRule.cs
+++ b/src/Indice.Features.Cases.Core/Data/Models/DbCaseAccessRule.cs
@@ -26,9 +26,9 @@ public class DbCaseAccessRule
 
     public static Expression<Func<DbCaseAccessRule, bool>> AccessMatchPredicate(string? userId, List<string> userRoles, string? groupId) {
         return x =>
-            (userId != null && x.MemberUserId == userId) ||
-            (EF.Constant(userRoles).Contains(x.MemberRole!)) ||
-            (groupId != null && x.MemberGroupId == groupId);
+            userRoles.Count > 0 ?
+                (userId != null && x.MemberUserId == userId) || (groupId != null && x.MemberGroupId == groupId) || EF.Constant(userRoles).Contains(x.MemberRole!) :
+                (userId != null && x.MemberUserId == userId) || (groupId != null && x.MemberGroupId == groupId);
     }
     public static Expression<Func<DbCaseAccessRule, bool>> RuleMatchPredicate(Guid caseId, Guid caseTypeId, Guid checkpointTypeId) {
         return x =>


### PR DESCRIPTION
The list of roles was added by EF Core as an sqlparameter without type, the next time that the parameter was added this resulted to an Exception. We have used EF.Constant on  users roles so tha ef core will see it as an Constant and not as a parameter.

Changes: 
- Switch `AccessMatchPredicate` to use EF's constant handling for user roles.
- Increment `VersionPrefixCases` in `Directory.Build.props`.