### PR TITLE
[messaging] Update version, image preview, and campaign metrics

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -10,7 +10,7 @@
       <VersionPrefixIdentity>$(VersionPrefixBase).0</VersionPrefixIdentity>
       <VersionPrefixIdentityUI>$(VersionPrefixBase).0</VersionPrefixIdentityUI>
       <VersionPrefixCases>$(VersionPrefixBase).0</VersionPrefixCases>
-      <VersionPrefixMessages>$(VersionPrefixBase).1</VersionPrefixMessages>
+      <VersionPrefixMessages>$(VersionPrefixBase).2</VersionPrefixMessages>
       <VersionPrefixMultitenancy>$(VersionPrefixBase).0</VersionPrefixMultitenancy>
       <VersionPrefixRisk>$(VersionPrefixBase).0</VersionPrefixRisk>
       <VersionPrefixMedia>$(VersionPrefixBase).1</VersionPrefixMedia>

--- a/src/Indice.Features.Messages.App/src/app/features/media-library/document-edit/document-edit.component.html
+++ b/src/Indice.Features.Messages.App/src/app/features/media-library/document-edit/document-edit.component.html
@@ -128,7 +128,7 @@
         <section aria-labelledby="information-title" *ngIf="file?.isImage" class="mt-4">
 
           <div class="grid w-full place-items-center rounded-lg p-6 bg-white">
-            <img class="object-contain object-center rounded-lg shadow-xl shadow-blue-gray-900/50 max-h-[300px]"
+            <img class="object-contain object-center rounded-lg shadow-xl shadow-blue-gray-900/50 media-image-preview"
                  [src]="file?.permaLink"
                  [alt]="file?.description || file?.name"
                  (load)="originalWidth = $event.target.naturalWidth; originalHeight = $event.target.naturalHeight"/>

--- a/src/Indice.Features.Messages.App/src/styles.scss
+++ b/src/Indice.Features.Messages.App/src/styles.scss
@@ -226,3 +226,8 @@ textarea.code-editor:focus {
 .dot-Warning {
   @apply bg-yellow-400;
 }
+
+.media-image-preview {
+  max-height: 300px;
+  margin: auto;
+}

--- a/src/Indice.Features.Messages.AspNetCore/Endpoints/CampaignsHandlers.cs
+++ b/src/Indice.Features.Messages.AspNetCore/Endpoints/CampaignsHandlers.cs
@@ -124,7 +124,7 @@ internal static class CampaignsHandlers
         }
         var metrics = new CampaignDetailsMetrics {
             Recipient = statistics,
-            Channels = (await campaignService.GetChannelMetrics()).Select(x => new ChannelMetrics {
+            Channels = (await campaignService.GetChannelMetrics(campaignId)).Select(x => new ChannelMetrics {
                 Kind = Enum.Parse<MessageChannelKind>(x.Key),
                 Total = x.Value
             }).ToList(),


### PR DESCRIPTION
- Incremented `Messages` version prefix in Directory.Build.props.
- Added `media-image-preview` class to style image previews.
- Introduced `.media-image-preview` CSS class in styles.scss.
- Updated `GetChannelMetrics` to accept `campaignId` for specificity.