### PR TITLE
[messaging]  Stop adding Communication Options for new contacts

### DIFF
--- a/src/Indice.Features.Messages.App/src/app/app.links.ts
+++ b/src/Indice.Features.Messages.App/src/app/app.links.ts
@@ -9,13 +9,13 @@ export class AppLinks implements IAppLinks {
   public profileActions: Observable<NavLink[]> = of([]);
 
   private _mainLInks = [
-    new NavLink('Αρχική', 'dashboard', false, false, Icons.Dashboard),
-    new NavLink('Καμπάνιες', '/campaigns', false, false, Icons.Messages),
-    new NavLink('Τύποι Μηνυμάτων', '/message-types', false, false, Icons.Details),
-    new NavLink('Λίστες Διανομής', '/distribution-lists', false, false, Icons.TilesView),
-    new NavLink('Επαφές', '/contacts', false, false, 'ms-Icon ms-Icon--ContactCard'),
-    new NavLink('Πρότυπα', '/templates', false, false, Icons.SendEmail),
-    new NavLink('Αρχεία', '/media', false, false, 'ms-Icon ms-Icon--Folder'),
+    new NavLink('Αρχική', 'dashboard', false, false, 'ms-Icon ms-Icon--BIDashboard'),
+    new NavLink('Καμπάνιες', '/campaigns', false, false, 'ms-Icon ms-Icon--Communications'),
+    new NavLink('Τύποι Μηνυμάτων', '/message-types', false, false, 'ms-Icon ms-Icon--SingleBookmark'),
+    new NavLink('Λίστες Διανομής', '/distribution-lists', false, false, 'ms-Icon ms-Icon--ContactList'),
+    new NavLink('Επαφές', '/contacts', false, false, 'ms-Icon ms-Icon--Contact'),
+    new NavLink('Πρότυπα', '/templates', false, false, 'ms-Icon ms-Icon--CampaignTemplate'),
+    new NavLink('Αρχεία', '/media', false, false, 'ms-Icon ms-Icon--PhotoVideoMedia'),
     new NavLink('Ρυθμίσεις', '/settings', false, false, 'ms-Icon ms-Icon--Settings')
   ];
   public main: Observable<NavLink[]> = of(settings.enableMediaLibrary ? this._mainLInks : this._mainLInks.filter((l) => l.path !== '/media'));

--- a/src/Indice.Features.Messages.Core/Services/ContactService.cs
+++ b/src/Indice.Features.Messages.Core/Services/ContactService.cs
@@ -437,13 +437,7 @@ public class ContactService : IContactService
                 ConsentCommercial = preference.ConsentCommercial,
                 ConsentCommercialDate = preference.ConsentCommercialDate,
                 DefaultChannels = preference.DefaultChannels != null ? ContactChannelOption.ToContactChannelKind(preference.DefaultChannels) : null,
-                UpdatedAt = DateTimeOffset.UtcNow,
-                CommunicationOptions = messageTypes.Select(x =>
-                    new DbContactCommunicationOption() {
-                        MessageTypeId = x.Id,
-                        Channels = ContactChannelOption.ToContactChannelKind(ContactChannelOption.FromKindFlags(ContactChannelKind.Any)),
-                        UpdatedAt = DateTimeOffset.UtcNow
-                    }).ToList()
+                UpdatedAt = DateTimeOffset.UtcNow
             };
 
             await DbContext.ContactPreferences.AddAsync(recipientPreferences);


### PR DESCRIPTION
Simplified `ContactService` by removing the
`CommunicationOptions` property from `recipientPreferences`. This change streamlines the object creation process and removes unused functionality.

Updated `AppLinks` to use string-based icon class names instead of `Icons` constants for better UI consistency. Retained existing functionality for the `main` observable.
