### PR TITLE
[identity] Fix CodeQL suggestions

### DIFF
--- a/src/Indice.Features.Identity.UI/IdentityLabels.Designer.cs
+++ b/src/Indice.Features.Identity.UI/IdentityLabels.Designer.cs
@@ -153,9 +153,9 @@ namespace Indice.Features.Identity.UI {
         /// <summary>
         ///   Looks up a localized string similar to New password.
         /// </summary>
-        public static string AddPassword_Newpassword {
+        public static string AddPassword_Newpassword_FieldLabel {
             get {
-                return ResourceManager.GetString("AddPassword_Newpassword", resourceCulture);
+                return ResourceManager.GetString("AddPassword_Newpassword_FieldLabel", resourceCulture);
             }
         }
         
@@ -315,18 +315,18 @@ namespace Indice.Features.Identity.UI {
         /// <summary>
         ///   Looks up a localized string similar to New password.
         /// </summary>
-        public static string ChangePassword_NewPassword {
+        public static string ChangePassword_Newpassword_FieldLabel {
             get {
-                return ResourceManager.GetString("ChangePassword_NewPassword", resourceCulture);
+                return ResourceManager.GetString("ChangePassword_Newpassword_FieldLabel", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Old password.
         /// </summary>
-        public static string ChangePassword_OldPassword {
+        public static string ChangePassword_OldPassword_FieldLabel {
             get {
-                return ResourceManager.GetString("ChangePassword_OldPassword", resourceCulture);
+                return ResourceManager.GetString("ChangePassword_OldPassword_FieldLabel", resourceCulture);
             }
         }
         
@@ -882,9 +882,9 @@ namespace Indice.Features.Identity.UI {
         /// <summary>
         ///   Looks up a localized string similar to Reset password.
         /// </summary>
-        public static string Email_Reset_Password {
+        public static string Email_Reset_Password_FieldLabel {
             get {
-                return ResourceManager.GetString("Email_Reset_Password", resourceCulture);
+                return ResourceManager.GetString("Email_Reset_Password_FieldLabel", resourceCulture);
             }
         }
         
@@ -1224,9 +1224,9 @@ namespace Indice.Features.Identity.UI {
         /// <summary>
         ///   Looks up a localized string similar to Please fill in your new password.
         /// </summary>
-        public static string ForgotPasswordConfirmation_FillNewPassword {
+        public static string ForgotPasswordConfirmation_FillNewPassword_FieldLabel {
             get {
-                return ResourceManager.GetString("ForgotPasswordConfirmation_FillNewPassword", resourceCulture);
+                return ResourceManager.GetString("ForgotPasswordConfirmation_FillNewPassword_FieldLabel", resourceCulture);
             }
         }
         
@@ -1242,9 +1242,9 @@ namespace Indice.Features.Identity.UI {
         /// <summary>
         ///   Looks up a localized string similar to New Password.
         /// </summary>
-        public static string ForgotPasswordConfirmation_NewPassword {
+        public static string ForgotPasswordConfirmation_Newpassword_FieldLabel {
             get {
-                return ResourceManager.GetString("ForgotPasswordConfirmation_NewPassword", resourceCulture);
+                return ResourceManager.GetString("ForgotPasswordConfirmation_Newpassword_FieldLabel", resourceCulture);
             }
         }
         
@@ -1521,9 +1521,9 @@ namespace Indice.Features.Identity.UI {
         /// <summary>
         ///   Looks up a localized string similar to Forgot password?.
         /// </summary>
-        public static string Login_ForgotPassword {
+        public static string Login_ForgotPassword_FieldLabel {
             get {
-                return ResourceManager.GetString("Login_ForgotPassword", resourceCulture);
+                return ResourceManager.GetString("Login_ForgotPassword_FieldLabel", resourceCulture);
             }
         }
         
@@ -1593,9 +1593,9 @@ namespace Indice.Features.Identity.UI {
         /// <summary>
         ///   Looks up a localized string similar to Password.
         /// </summary>
-        public static string Login_Password {
+        public static string Login_Password_FieldLabel {
             get {
-                return ResourceManager.GetString("Login_Password", resourceCulture);
+                return ResourceManager.GetString("Login_Password_FieldLabel", resourceCulture);
             }
         }
         
@@ -1998,9 +1998,9 @@ namespace Indice.Features.Identity.UI {
         /// <summary>
         ///   Looks up a localized string similar to New password.
         /// </summary>
-        public static string PasswordExpired_NewPassword {
+        public static string PasswordExpired_Newpassword_FieldLabel {
             get {
-                return ResourceManager.GetString("PasswordExpired_NewPassword", resourceCulture);
+                return ResourceManager.GetString("PasswordExpired_Newpassword_FieldLabel", resourceCulture);
             }
         }
         
@@ -2610,18 +2610,18 @@ namespace Indice.Features.Identity.UI {
         /// <summary>
         ///   Looks up a localized string similar to Choose an email and a password of your choice. You can periodically change your password or whenever you wish to..
         /// </summary>
-        public static string Register_ChooseEmailAndPassword {
+        public static string Register_ChooseEmailAndPassword_FieldLabel {
             get {
-                return ResourceManager.GetString("Register_ChooseEmailAndPassword", resourceCulture);
+                return ResourceManager.GetString("Register_ChooseEmailAndPassword_FieldLabel", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Choose a username and a password of your choice. You can periodically change your password or whenever you wish to..
         /// </summary>
-        public static string Register_ChooseUsernameAndPassword {
+        public static string Register_ChooseUsernameAndPassword_FieldLabel {
             get {
-                return ResourceManager.GetString("Register_ChooseUsernameAndPassword", resourceCulture);
+                return ResourceManager.GetString("Register_ChooseUsernameAndPassword_FieldLabel", resourceCulture);
             }
         }
         
@@ -2745,9 +2745,9 @@ namespace Indice.Features.Identity.UI {
         /// <summary>
         ///   Looks up a localized string similar to Password.
         /// </summary>
-        public static string Register_Password {
+        public static string Register_Password_FieldLabel {
             get {
-                return ResourceManager.GetString("Register_Password", resourceCulture);
+                return ResourceManager.GetString("Register_Password_FieldLabel", resourceCulture);
             }
         }
         

--- a/src/Indice.Features.Identity.UI/IdentityLabels.el.resx
+++ b/src/Indice.Features.Identity.UI/IdentityLabels.el.resx
@@ -153,7 +153,7 @@
   <data name="AddPassword_PageHeader" xml:space="preserve">
     <value>Προσθήκη Κωδικού</value>
   </data>
-  <data name="AddPassword_Newpassword" xml:space="preserve">
+  <data name="AddPassword_Newpassword_FieldLabel" xml:space="preserve">
     <value>Νέος κωδικός</value>
   </data>
   <data name="AddPassword_PasswordConfirmation" xml:space="preserve">
@@ -201,10 +201,10 @@
   <data name="ChangePassword_PageHeader" xml:space="preserve">
     <value>Αλλαγή Κωδικού</value>
   </data>
-  <data name="ChangePassword_NewPassword" xml:space="preserve">
+  <data name="ChangePassword_Newpassword_FieldLabel" xml:space="preserve">
     <value>Νέος κωδικός</value>
   </data>
-  <data name="ChangePassword_OldPassword" xml:space="preserve">
+  <data name="ChangePassword_OldPassword_FieldLabel" xml:space="preserve">
     <value>Παλιός κωδικός </value>
   </data>
   <data name="ChangePassword_PasswordSuccessfullyChanged" xml:space="preserve">
@@ -378,7 +378,7 @@
   <data name="Email_Body_Organization" xml:space="preserve">
     <value>{0}</value>
   </data>
-  <data name="Email_Reset_Password" xml:space="preserve">
+  <data name="Email_Reset_Password_FieldLabel" xml:space="preserve">
     <value>Επαναφορά κωδικού</value>
   </data>
   <data name="Email_ResetPassword_RequestInfo" xml:space="preserve">
@@ -486,7 +486,7 @@
   <data name="ForgotPasswordConfirmation_PageHeader" xml:space="preserve">
     <value>Επιβεβαίωση Υπενθύμισης Κωδικού</value>
   </data>
-  <data name="ForgotPasswordConfirmation_NewPassword" xml:space="preserve">
+  <data name="ForgotPasswordConfirmation_Newpassword_FieldLabel" xml:space="preserve">
     <value>Νέος Κωδικός</value>
   </data>
   <data name="ForgotPasswordConfirmation_PasswordChanged" xml:space="preserve">
@@ -495,7 +495,7 @@
   <data name="ForgotPasswordConfirmation_LoginLink" xml:space="preserve">
     <value>Παρακαλώ &lt;a href="{0}"&gt;συνδεθείτε&lt;/a&gt; χρησιμοποιόντας το νέο σας συνθηματικό.</value>
   </data>
-  <data name="ForgotPasswordConfirmation_FillNewPassword" xml:space="preserve">
+  <data name="ForgotPasswordConfirmation_FillNewPassword_FieldLabel" xml:space="preserve">
     <value>Παρακαλώ εισάγετε τον νέο σας κωδικό</value>
   </data>
   <data name="ForgotPasswordConfirmation_Send" xml:space="preserve">
@@ -582,7 +582,7 @@
   <data name="Login_NoAccount" xml:space="preserve">
     <value>Δεν έχετε δημιουργήσει λογαριασμό;</value>
   </data>
-  <data name="Login_ForgotPassword" xml:space="preserve">
+  <data name="Login_ForgotPassword_FieldLabel" xml:space="preserve">
     <value>Ξέχασες το κωδικό;</value>
   </data>
   <data name="Login_InvalidLoginRequest" xml:space="preserve">
@@ -600,7 +600,7 @@
   <data name="Login_OR" xml:space="preserve">
     <value>Ή</value>
   </data>
-  <data name="Login_Password" xml:space="preserve">
+  <data name="Login_Password_FieldLabel" xml:space="preserve">
     <value>Κωδικός</value>
   </data>
   <data name="Login_RememberMe" xml:space="preserve">
@@ -735,7 +735,7 @@
   <data name="PasswordExpired_PageHeader" xml:space="preserve">
     <value>Αλλαγή κωδικού πρόσβασης</value>
   </data>
-  <data name="PasswordExpired_NewPassword" xml:space="preserve">
+  <data name="PasswordExpired_Newpassword_FieldLabel" xml:space="preserve">
     <value>Νέος κωδικός</value>
   </data>
   <data name="PasswordExpired_Next" xml:space="preserve">
@@ -864,7 +864,7 @@
   <data name="Register_CallingCode" xml:space="preserve">
     <value>Κωδικός Τηλεφώνου</value>
   </data>
-  <data name="Register_ChooseEmailAndPassword" xml:space="preserve">
+  <data name="Register_ChooseEmailAndPassword_FieldLabel" xml:space="preserve">
     <value>Επιλέξτε ένα email και έναν κωδικό πρόσβασης της προτίμησής σας. Έχετε τη δυνατότητα να αλλάξετε τον κωδικό σας σε περιοδικά διαστήματα ή όποτε το επιθυμείτε.</value>
   </data>
   <data name="Register_FirstName" xml:space="preserve">
@@ -891,7 +891,7 @@
   <data name="Register_OR" xml:space="preserve">
     <value>Ή</value>
   </data>
-  <data name="Register_Password" xml:space="preserve">
+  <data name="Register_Password_FieldLabel" xml:space="preserve">
     <value>Κωδικός πρόσβασης</value>
   </data>
   <data name="Register_PhoneNumber" xml:space="preserve">
@@ -936,7 +936,7 @@
   <data name="VerifyPhone_OTP_is_valid_till" xml:space="preserve">
     <value>Το OTP ισχύει έως:</value>
   </data>
-  <data name="Register_ChooseUsernameAndPassword" xml:space="preserve">
+  <data name="Register_ChooseUsernameAndPassword_FieldLabel" xml:space="preserve">
     <value>Επιλέξτε ένα όνομα χρήστη και έναν κωδικό πρόσβασης της προτίμησής σας. Έχετε τη δυνατότητα να αλλάξετε τον κωδικό σας σε περιοδικά διαστήματα ή όποτε το επιθυμείτε.</value>
   </data>
   <data name="Register_ConsentToContactUsage" xml:space="preserve">

--- a/src/Indice.Features.Identity.UI/IdentityLabels.es.resx
+++ b/src/Indice.Features.Identity.UI/IdentityLabels.es.resx
@@ -153,7 +153,7 @@
   <data name="AddPassword_PageHeader" xml:space="preserve">
     <value>Agregar contraseña</value>
   </data>
-  <data name="AddPassword_Newpassword" xml:space="preserve">
+  <data name="AddPassword_Newpassword_FieldLabel" xml:space="preserve">
     <value>Nueva contraseña</value>
   </data>
   <data name="AddPassword_PasswordConfirmation" xml:space="preserve">
@@ -201,10 +201,10 @@
   <data name="ChangePassword_PageHeader" xml:space="preserve">
     <value>Cambiar contraseña</value>
   </data>
-  <data name="ChangePassword_NewPassword" xml:space="preserve">
+  <data name="ChangePassword_NewPassword_FieldLabel" xml:space="preserve">
     <value>Nueva contraseña</value>
   </data>
-  <data name="ChangePassword_OldPassword" xml:space="preserve">
+  <data name="ChangePassword_OldPassword_FieldLabel" xml:space="preserve">
     <value>Contraseña anterior</value>
   </data>
   <data name="ChangePassword_PasswordSuccessfullyChanged" xml:space="preserve">
@@ -378,7 +378,7 @@
   <data name="Email_Body_Organization" xml:space="preserve">
     <value>{0}</value>
   </data>
-  <data name="Email_Reset_Password" xml:space="preserve">
+  <data name="Email_Reset_Password_FieldLabel" xml:space="preserve">
     <value>Restablecer contraseña</value>
   </data>
   <data name="Email_ResetPassword_RequestInfo" xml:space="preserve">
@@ -486,7 +486,7 @@
   <data name="ForgotPasswordConfirmation_PageHeader" xml:space="preserve">
     <value>Confirmación de restablecimiento de contraseña</value>
   </data>
-  <data name="ForgotPasswordConfirmation_NewPassword" xml:space="preserve">
+  <data name="ForgotPasswordConfirmation_Newpassword_FieldLabel" xml:space="preserve">
     <value>Nueva contraseña</value>
   </data>
   <data name="ForgotPasswordConfirmation_PasswordChanged" xml:space="preserve">
@@ -495,7 +495,7 @@
   <data name="ForgotPasswordConfirmation_LoginLink" xml:space="preserve">
     <value>Por favor, &lt;a href="{0}"&gt;inicie sesión&lt;/a&gt; con su nueva contraseña.</value>
   </data>
-  <data name="ForgotPasswordConfirmation_FillNewPassword" xml:space="preserve">
+  <data name="ForgotPasswordConfirmation_FillNewPassword_FieldLabel" xml:space="preserve">
     <value>Por favor, ingrese su nueva contraseña</value>
   </data>
   <data name="ForgotPasswordConfirmation_Send" xml:space="preserve">
@@ -582,7 +582,7 @@
   <data name="Login_NoAccount" xml:space="preserve">
     <value>¿No tienes una cuenta?</value>
   </data>
-  <data name="Login_ForgotPassword" xml:space="preserve">
+  <data name="Login_ForgotPassword_FieldLabel" xml:space="preserve">
     <value>¿Olvidaste tu contraseña?</value>
   </data>
   <data name="Login_InvalidLoginRequest" xml:space="preserve">
@@ -600,7 +600,7 @@
   <data name="Login_OR" xml:space="preserve">
     <value>O</value>
   </data>
-  <data name="Login_Password" xml:space="preserve">
+  <data name="Login_Password_FieldLabel" xml:space="preserve">
     <value>Contraseña</value>
   </data>
   <data name="Login_RememberMe" xml:space="preserve">
@@ -735,7 +735,7 @@
   <data name="PasswordExpired_PageHeader" xml:space="preserve">
     <value>Cambiar contraseña</value>
   </data>
-  <data name="PasswordExpired_NewPassword" xml:space="preserve">
+  <data name="PasswordExpired_Newpassword_FieldLabel" xml:space="preserve">
     <value>Nueva contraseña</value>
   </data>
   <data name="PasswordExpired_Next" xml:space="preserve">
@@ -864,7 +864,7 @@
   <data name="Register_CallingCode" xml:space="preserve">
     <value>Código telefónico</value>
   </data>
-  <data name="Register_ChooseEmailAndPassword" xml:space="preserve">
+  <data name="Register_ChooseEmailAndPassword_FieldLabel" xml:space="preserve">
     <value>Elija un correo electrónico y una contraseña de su elección. Puede cambiar su contraseña periódicamente o cuando lo desee.</value>
   </data>
   <data name="Register_FirstName" xml:space="preserve">
@@ -891,7 +891,7 @@
   <data name="Register_OR" xml:space="preserve">
     <value>O</value>
   </data>
-  <data name="Register_Password" xml:space="preserve">
+  <data name="Register_Password_FieldLabel" xml:space="preserve">
     <value>Contraseña</value>
   </data>
   <data name="Register_PhoneNumber" xml:space="preserve">
@@ -936,7 +936,7 @@
   <data name="VerifyPhone_OTP_is_valid_till" xml:space="preserve">
     <value>OTP válido hasta:</value>
   </data>
-  <data name="Register_ChooseUsernameAndPassword" xml:space="preserve">
+  <data name="Register_ChooseUsernameAndPassword_FieldLabel" xml:space="preserve">
     <value>Elija un nombre de usuario y una contraseña de su elección. Puede cambiar su contraseña periódicamente o cuando lo desee.</value>
   </data>
   <data name="Register_ConsentToContactUsage" xml:space="preserve">

--- a/src/Indice.Features.Identity.UI/IdentityLabels.it.resx
+++ b/src/Indice.Features.Identity.UI/IdentityLabels.it.resx
@@ -153,7 +153,7 @@
   <data name="AddPassword_PageHeader" xml:space="preserve">
     <value>Aggiungi password</value>
   </data>
-  <data name="AddPassword_Newpassword" xml:space="preserve">
+  <data name="AddPassword_Newpassword_FieldLabel" xml:space="preserve">
     <value>Nuova password</value>
   </data>
   <data name="AddPassword_PasswordConfirmation" xml:space="preserve">
@@ -201,10 +201,10 @@
   <data name="ChangePassword_PageHeader" xml:space="preserve">
     <value>Modifica password</value>
   </data>
-  <data name="ChangePassword_NewPassword" xml:space="preserve">
+  <data name="ChangePassword_Newpassword_FieldLabel" xml:space="preserve">
     <value>Nuova password</value>
   </data>
-  <data name="ChangePassword_OldPassword" xml:space="preserve">
+  <data name="ChangePassword_OldPassword_FieldLabel" xml:space="preserve">
     <value>Vecchia password</value>
   </data>
   <data name="ChangePassword_PasswordSuccessfullyChanged" xml:space="preserve">
@@ -378,7 +378,7 @@
   <data name="Email_Body_Organization" xml:space="preserve">
     <value>{0}</value>
   </data>
-  <data name="Email_Reset_Password" xml:space="preserve">
+  <data name="Email_Reset_Password_FieldLabel" xml:space="preserve">
     <value>Reimposta password</value>
   </data>
   <data name="Email_ResetPassword_RequestInfo" xml:space="preserve">
@@ -486,7 +486,7 @@
   <data name="ForgotPasswordConfirmation_PageHeader" xml:space="preserve">
     <value>Password dimenticata</value>
   </data>
-  <data name="ForgotPasswordConfirmation_NewPassword" xml:space="preserve">
+  <data name="ForgotPasswordConfirmation_Newpassword_FieldLabel" xml:space="preserve">
     <value>Nuova password</value>
   </data>
   <data name="ForgotPasswordConfirmation_PasswordChanged" xml:space="preserve">
@@ -495,7 +495,7 @@
   <data name="ForgotPasswordConfirmation_LoginLink" xml:space="preserve">
     <value>Effettuare &lt;a href="{0}"&gt;l’accesso&lt;/a&gt; utilizzando la nuova password</value>
   </data>
-  <data name="ForgotPasswordConfirmation_FillNewPassword" xml:space="preserve">
+  <data name="ForgotPasswordConfirmation_FillNewPassword_FieldLabel" xml:space="preserve">
     <value>Inserire una nuova password</value>
   </data>
   <data name="ForgotPasswordConfirmation_Send" xml:space="preserve">
@@ -582,7 +582,7 @@
   <data name="Login_NoAccount" xml:space="preserve">
     <value>Non hai un account?</value>
   </data>
-  <data name="Login_ForgotPassword" xml:space="preserve">
+  <data name="Login_ForgotPassword_FieldLabel" xml:space="preserve">
     <value>Password dimenticata?</value>
   </data>
   <data name="Login_InvalidLoginRequest" xml:space="preserve">
@@ -600,7 +600,7 @@
   <data name="Login_OR" xml:space="preserve">
     <value>OR</value>
   </data>
-  <data name="Login_Password" xml:space="preserve">
+  <data name="Login_Password_FieldLabel" xml:space="preserve">
     <value>Password</value>
   </data>
   <data name="Login_RememberMe" xml:space="preserve">
@@ -735,7 +735,7 @@
   <data name="PasswordExpired_PageHeader" xml:space="preserve">
     <value>Modifica password</value>
   </data>
-  <data name="PasswordExpired_NewPassword" xml:space="preserve">
+  <data name="PasswordExpired_Newpassword_FieldLabel" xml:space="preserve">
     <value>Nuova password</value>
   </data>
   <data name="PasswordExpired_Next" xml:space="preserve">
@@ -864,7 +864,7 @@
   <data name="Register_CallingCode" xml:space="preserve">
     <value>Codice di chiamata</value>
   </data>
-  <data name="Register_ChooseEmailAndPassword" xml:space="preserve">
+  <data name="Register_ChooseEmailAndPassword_FieldLabel" xml:space="preserve">
     <value>Scegli un'email e una password a tua scelta. Puoi modificare la password periodicamente o ogni volta che lo desideri.</value>
   </data>
   <data name="Register_FirstName" xml:space="preserve">
@@ -891,7 +891,7 @@
   <data name="Register_OR" xml:space="preserve">
     <value>OR</value>
   </data>
-  <data name="Register_Password" xml:space="preserve">
+  <data name="Register_Password_FieldLabel" xml:space="preserve">
     <value>Password</value>
   </data>
   <data name="Register_PhoneNumber" xml:space="preserve">
@@ -936,7 +936,7 @@
   <data name="VerifyPhone_OTP_is_valid_till" xml:space="preserve">
     <value>OTP valido fino a:</value>
   </data>
-  <data name="Register_ChooseUsernameAndPassword" xml:space="preserve">
+  <data name="Register_ChooseUsernameAndPassword_FieldLabel" xml:space="preserve">
     <value>Scegli un nome utente e una password a tua scelta. Puoi modificare la password periodicamente o ogni volta che lo desideri.</value>
   </data>
   <data name="Register_ConsentToContactUsage" xml:space="preserve">

--- a/src/Indice.Features.Identity.UI/IdentityLabels.ja.resx
+++ b/src/Indice.Features.Identity.UI/IdentityLabels.ja.resx
@@ -153,7 +153,7 @@
   <data name="AddPassword_PageHeader" xml:space="preserve">
     <value>パスワード追加</value>
   </data>
-  <data name="AddPassword_Newpassword" xml:space="preserve">
+  <data name="AddPassword_Newpassword_FieldLabel" xml:space="preserve">
     <value>新しいパスワード</value>
   </data>
   <data name="AddPassword_PasswordConfirmation" xml:space="preserve">
@@ -201,10 +201,10 @@
   <data name="ChangePassword_PageHeader" xml:space="preserve">
     <value>パスワード変更</value>
   </data>
-  <data name="ChangePassword_NewPassword" xml:space="preserve">
+  <data name="ChangePassword_Newpassword_FieldLabel" xml:space="preserve">
     <value>新しいパスワード</value>
   </data>
-  <data name="ChangePassword_OldPassword" xml:space="preserve">
+  <data name="ChangePassword_OldPassword_FieldLabel" xml:space="preserve">
     <value>以前のパスワード</value>
   </data>
   <data name="ChangePassword_PasswordSuccessfullyChanged" xml:space="preserve">
@@ -378,7 +378,7 @@
   <data name="Email_Body_Organization" xml:space="preserve">
     <value>{0}</value>
   </data>
-  <data name="Email_Reset_Password" xml:space="preserve">
+  <data name="Email_Reset_Password_FieldLabel" xml:space="preserve">
     <value>パスワードをリセット</value>
   </data>
   <data name="Email_ResetPassword_RequestInfo" xml:space="preserve">
@@ -486,7 +486,7 @@
   <data name="ForgotPasswordConfirmation_PageHeader" xml:space="preserve">
     <value>パスワードリセットの確認</value>
   </data>
-  <data name="ForgotPasswordConfirmation_NewPassword" xml:space="preserve">
+  <data name="ForgotPasswordConfirmation_Newpassword_FieldLabel" xml:space="preserve">
     <value>新しいパスワード</value>
   </data>
   <data name="ForgotPasswordConfirmation_PasswordChanged" xml:space="preserve">
@@ -495,7 +495,7 @@
   <data name="ForgotPasswordConfirmation_LoginLink" xml:space="preserve">
     <value>新しいパスワードで&lt;a href="{0}"&gt;ログイン&lt;/a&gt;してください</value>
   </data>
-  <data name="ForgotPasswordConfirmation_FillNewPassword" xml:space="preserve">
+  <data name="ForgotPasswordConfirmation_FillNewPassword_FieldLabel" xml:space="preserve">
     <value>新しいパスワードを入力してください</value>
   </data>
   <data name="ForgotPasswordConfirmation_Send" xml:space="preserve">
@@ -582,7 +582,7 @@
   <data name="Login_NoAccount" xml:space="preserve">
     <value>アカウントをお持ちでないですか？</value>
   </data>
-  <data name="Login_ForgotPassword" xml:space="preserve">
+  <data name="Login_ForgotPassword_FieldLabel" xml:space="preserve">
     <value>パスワードをお忘れですか？</value>
   </data>
   <data name="Login_InvalidLoginRequest" xml:space="preserve">
@@ -600,7 +600,7 @@
   <data name="Login_OR" xml:space="preserve">
     <value>または</value>
   </data>
-  <data name="Login_Password" xml:space="preserve">
+  <data name="Login_Password_FieldLabel" xml:space="preserve">
     <value>パスワード</value>
   </data>
   <data name="Login_RememberMe" xml:space="preserve">
@@ -735,7 +735,7 @@
   <data name="PasswordExpired_PageHeader" xml:space="preserve">
     <value>パスワードを変更</value>
   </data>
-  <data name="PasswordExpired_NewPassword" xml:space="preserve">
+  <data name="PasswordExpired_Newpassword_FieldLabel" xml:space="preserve">
     <value>新しいパスワード</value>
   </data>
   <data name="PasswordExpired_Next" xml:space="preserve">
@@ -864,7 +864,7 @@
   <data name="Register_CallingCode" xml:space="preserve">
     <value>国番号</value>
   </data>
-  <data name="Register_ChooseEmailAndPassword" xml:space="preserve">
+  <data name="Register_ChooseEmailAndPassword_FieldLabel" xml:space="preserve">
     <value>ご希望のメールアドレスとパスワードを選択してください。パスワードは定期的または任意のタイミングで変更できます。</value>
   </data>
   <data name="Register_FirstName" xml:space="preserve">
@@ -891,7 +891,7 @@
   <data name="Register_OR" xml:space="preserve">
     <value>または</value>
   </data>
-  <data name="Register_Password" xml:space="preserve">
+  <data name="Register_Password_FieldLabel" xml:space="preserve">
     <value>パスワード</value>
   </data>
   <data name="Register_PhoneNumber" xml:space="preserve">
@@ -936,7 +936,7 @@
   <data name="VerifyPhone_OTP_is_valid_till" xml:space="preserve">
     <value>OTPの有効期限:</value>
   </data>
-  <data name="Register_ChooseUsernameAndPassword" xml:space="preserve">
+  <data name="Register_ChooseUsernameAndPassword_FieldLabel" xml:space="preserve">
     <value>ご希望のユーザー名とパスワードを選択してください。パスワードは定期的または任意のタイミングで変更できます。</value>
   </data>
   <data name="Register_ConsentToContactUsage" xml:space="preserve">

--- a/src/Indice.Features.Identity.UI/IdentityLabels.resx
+++ b/src/Indice.Features.Identity.UI/IdentityLabels.resx
@@ -153,7 +153,7 @@
   <data name="AddPassword_PageHeader" xml:space="preserve">
     <value>Add Password</value>
   </data>
-  <data name="AddPassword_Newpassword" xml:space="preserve">
+  <data name="AddPassword_Newpassword_FieldLabel" xml:space="preserve">
     <value>New password</value>
   </data>
   <data name="AddPassword_PasswordConfirmation" xml:space="preserve">
@@ -201,10 +201,10 @@
   <data name="ChangePassword_PageHeader" xml:space="preserve">
     <value>Change Password</value>
   </data>
-  <data name="ChangePassword_NewPassword" xml:space="preserve">
+  <data name="ChangePassword_Newpassword_FieldLabel" xml:space="preserve">
     <value>New password</value>
   </data>
-  <data name="ChangePassword_OldPassword" xml:space="preserve">
+  <data name="ChangePassword_OldPassword_FieldLabel" xml:space="preserve">
     <value>Old password</value>
   </data>
   <data name="ChangePassword_PasswordSuccessfullyChanged" xml:space="preserve">
@@ -378,7 +378,7 @@
   <data name="Email_Body_Organization" xml:space="preserve">
     <value>{0}</value>
   </data>
-  <data name="Email_Reset_Password" xml:space="preserve">
+  <data name="Email_Reset_Password_FieldLabel" xml:space="preserve">
     <value>Reset password</value>
   </data>
   <data name="Email_ResetPassword_RequestInfo" xml:space="preserve">
@@ -486,7 +486,7 @@
   <data name="ForgotPasswordConfirmation_PageHeader" xml:space="preserve">
     <value>Forgot Password Confirmation</value>
   </data>
-  <data name="ForgotPasswordConfirmation_NewPassword" xml:space="preserve">
+  <data name="ForgotPasswordConfirmation_Newpassword_FieldLabel" xml:space="preserve">
     <value>New Password</value>
   </data>
   <data name="ForgotPasswordConfirmation_PasswordChanged" xml:space="preserve">
@@ -495,7 +495,7 @@
   <data name="ForgotPasswordConfirmation_LoginLink" xml:space="preserve">
     <value>Please &lt;a href="{0}"&gt;login&lt;/a&gt; with your new password</value>
   </data>
-  <data name="ForgotPasswordConfirmation_FillNewPassword" xml:space="preserve">
+  <data name="ForgotPasswordConfirmation_FillNewPassword_FieldLabel" xml:space="preserve">
     <value>Please fill in your new password</value>
   </data>
   <data name="ForgotPasswordConfirmation_Send" xml:space="preserve">
@@ -582,7 +582,7 @@
   <data name="Login_NoAccount" xml:space="preserve">
     <value>Don't have an account?</value>
   </data>
-  <data name="Login_ForgotPassword" xml:space="preserve">
+  <data name="Login_ForgotPassword_FieldLabel" xml:space="preserve">
     <value>Forgot password?</value>
   </data>
   <data name="Login_InvalidLoginRequest" xml:space="preserve">
@@ -600,7 +600,7 @@
   <data name="Login_OR" xml:space="preserve">
     <value>OR</value>
   </data>
-  <data name="Login_Password" xml:space="preserve">
+  <data name="Login_Password_FieldLabel" xml:space="preserve">
     <value>Password</value>
   </data>
   <data name="Login_RememberMe" xml:space="preserve">
@@ -735,7 +735,7 @@
   <data name="PasswordExpired_PageHeader" xml:space="preserve">
     <value>Change password</value>
   </data>
-  <data name="PasswordExpired_NewPassword" xml:space="preserve">
+  <data name="PasswordExpired_Newpassword_FieldLabel" xml:space="preserve">
     <value>New password</value>
   </data>
   <data name="PasswordExpired_Next" xml:space="preserve">
@@ -864,7 +864,7 @@
   <data name="Register_CallingCode" xml:space="preserve">
     <value>Calling Code</value>
   </data>
-  <data name="Register_ChooseEmailAndPassword" xml:space="preserve">
+  <data name="Register_ChooseEmailAndPassword_FieldLabel" xml:space="preserve">
     <value>Choose an email and a password of your choice. You can periodically change your password or whenever you wish to.</value>
   </data>
   <data name="Register_FirstName" xml:space="preserve">
@@ -891,7 +891,7 @@
   <data name="Register_OR" xml:space="preserve">
     <value>OR</value>
   </data>
-  <data name="Register_Password" xml:space="preserve">
+  <data name="Register_Password_FieldLabel" xml:space="preserve">
     <value>Password</value>
   </data>
   <data name="Register_PhoneNumber" xml:space="preserve">
@@ -936,7 +936,7 @@
   <data name="VerifyPhone_OTP_is_valid_till" xml:space="preserve">
     <value>OTP is valid till:</value>
   </data>
-  <data name="Register_ChooseUsernameAndPassword" xml:space="preserve">
+  <data name="Register_ChooseUsernameAndPassword_FieldLabel" xml:space="preserve">
     <value>Choose a username and a password of your choice. You can periodically change your password or whenever you wish to.</value>
   </data>
   <data name="Register_ConsentToContactUsage" xml:space="preserve">

--- a/src/Indice.Features.Identity.UI/IdentityUILocalizer.cs
+++ b/src/Indice.Features.Identity.UI/IdentityUILocalizer.cs
@@ -55,7 +55,7 @@ public class IdentityUILocalizer
     public virtual HtmlString AddPassword_PageTitle => new HtmlString(string.Format(CultureInfo.CurrentUICulture, IdentityLabels.AddPassword_PageTitle));
 
     /// <summary>Label for the New Password input field (alternate reference).</summary>
-    public virtual HtmlString AddPassword_NewPassword => new HtmlString(string.Format(CultureInfo.CurrentUICulture, IdentityLabels.AddPassword_Newpassword));
+    public virtual HtmlString AddPassword_Newpassword_FieldLabel => new HtmlString(string.Format(CultureInfo.CurrentUICulture, IdentityLabels.AddPassword_Newpassword_FieldLabel));
 
     /// <summary>Label for the Confirm Password input field.</summary>
     public virtual HtmlString AddPassword_ConfirmPassword => new HtmlString(string.Format(CultureInfo.CurrentUICulture, IdentityLabels.AddPassword_PasswordConfirmation));
@@ -102,9 +102,9 @@ public class IdentityUILocalizer
     
 
     /// <summary>Label for the New Password input field.</summary>
-    public virtual HtmlString ChangePassword_NewPassword => new HtmlString(string.Format(CultureInfo.CurrentUICulture, IdentityLabels.ChangePassword_NewPassword));
+    public virtual HtmlString ChangePassword_Newpassword_FieldLabel => new HtmlString(string.Format(CultureInfo.CurrentUICulture, IdentityLabels.ChangePassword_Newpassword_FieldLabel));
     /// <summary>Label for the Old Password input field.</summary>
-    public virtual HtmlString ChangePassword_OldPassword => new HtmlString(string.Format(CultureInfo.CurrentUICulture, IdentityLabels.ChangePassword_OldPassword));
+    public virtual HtmlString ChangePassword_OldPassword => new HtmlString(string.Format(CultureInfo.CurrentUICulture, IdentityLabels.ChangePassword_OldPassword_FieldLabel));
     /// <summary>Success message displayed when the password has been successfully changed.</summary>
     public virtual HtmlString ChangePassword_PasswordSuccessfullyChanged => new HtmlString(string.Format(CultureInfo.CurrentUICulture, IdentityLabels.ChangePassword_PasswordSuccessfullyChanged));
     /// <summary>Message displayed when the password change process is completed.</summary>
@@ -235,7 +235,7 @@ public class IdentityUILocalizer
     /// <summary>
     /// Label for the Reset password action.
     /// </summary>
-    public virtual HtmlString Email_Reset_Password => new HtmlString(string.Format(CultureInfo.CurrentUICulture, IdentityLabels.Email_Reset_Password));
+    public virtual HtmlString Email_Reset_Password => new HtmlString(string.Format(CultureInfo.CurrentUICulture, IdentityLabels.Email_Reset_Password_FieldLabel));
     /// <summary>
     /// Text informing the user about the password reset request.
     /// </summary>
@@ -365,14 +365,14 @@ public class IdentityUILocalizer
     /// <summary>Gets the title text for the Forgot Password Confirmation page.</summary>
     public virtual HtmlString ForgotPasswordConfirmation_PageTitle => new HtmlString(string.Format(CultureInfo.CurrentUICulture, IdentityLabels.ForgotPasswordConfirmation_PageTitle));
     /// <summary>Gets the instruction text prompting the user to enter a new password.</summary>
-    public virtual HtmlString ForgotPasswordConfirmation_New_Password => new HtmlString(string.Format(CultureInfo.CurrentUICulture, IdentityLabels.ForgotPasswordConfirmation_NewPassword));
+    public virtual HtmlString ForgotPasswordConfirmation_New_Password => new HtmlString(string.Format(CultureInfo.CurrentUICulture, IdentityLabels.ForgotPasswordConfirmation_Newpassword_FieldLabel));
     /// <summary>Gets the message indicating that the password has been successfully changed.</summary>
     public virtual HtmlString ForgotPasswordConfirmation_Password_Changed => new HtmlString(string.Format(CultureInfo.CurrentUICulture, IdentityLabels.ForgotPasswordConfirmation_PasswordChanged));
     /// <summary>Gets the instruction text asking the user to log in using their new password. Includes a link for login.</summary>
     /// <param name="callbackUrl">The URL to the login page.</param>
     public virtual HtmlString ForgotPasswordConfirmation_LoginLink(string callbackUrl) => new HtmlString(string.Format(CultureInfo.CurrentUICulture, IdentityLabels.ForgotPasswordConfirmation_LoginLink, callbackUrl));
     /// <summary>Gets the label prompting the user to fill in their new password.</summary>
-    public virtual HtmlString ForgotPasswordConfirmation_Please_Fill_In_Your_New_Password => new HtmlString(string.Format(CultureInfo.CurrentUICulture, IdentityLabels.ForgotPasswordConfirmation_FillNewPassword));
+    public virtual HtmlString ForgotPasswordConfirmation_Please_Fill_In_Your_New_Password => new HtmlString(string.Format(CultureInfo.CurrentUICulture, IdentityLabels.ForgotPasswordConfirmation_FillNewPassword_FieldLabel));
     /// <summary>Gets the text for the "Send" button on the Forgot Password Confirmation page.</summary>
     public virtual HtmlString ForgotPasswordConfirmation_Send => new HtmlString(string.Format(CultureInfo.CurrentUICulture, IdentityLabels.ForgotPasswordConfirmation_Send));
     #endregion
@@ -446,9 +446,9 @@ public class IdentityUILocalizer
     public virtual HtmlString Login_Dont_Have_An_Account => new HtmlString(string.Format(CultureInfo.CurrentUICulture, IdentityLabels.Login_NoAccount));
 
     /// <summary>
-    ///   Gets the localized string for "Forgot Password" instruction on the Login page.
+    ///   Gets the localized string for "Forgot Password_FieldLabel" instruction on the Login page.
     /// </summary>
-    public virtual HtmlString Login_Forgot_Password => new HtmlString(string.Format(CultureInfo.CurrentUICulture, IdentityLabels.Login_ForgotPassword));
+    public virtual HtmlString Login_Forgot_Password => new HtmlString(string.Format(CultureInfo.CurrentUICulture, IdentityLabels.Login_ForgotPassword_FieldLabel));
 
     /// <summary>
     ///   Gets the localized string for "Invalid login request" instruction on the Login page.
@@ -471,9 +471,9 @@ public class IdentityUILocalizer
     public virtual HtmlString Login_OR => new HtmlString(string.Format(CultureInfo.CurrentUICulture, IdentityLabels.Login_OR));
 
     /// <summary>
-    ///   Gets the localized string for "Password" label.
+    ///   Gets the localized string for "Password_FieldLabel" label.
     /// </summary>
-    public virtual HtmlString Login_Password => new HtmlString(string.Format(CultureInfo.CurrentUICulture, IdentityLabels.Login_Password));
+    public virtual HtmlString Login_Password => new HtmlString(string.Format(CultureInfo.CurrentUICulture, IdentityLabels.Login_Password_FieldLabel));
 
     /// <summary>
     ///   Gets the localized string for "Remember me" option.
@@ -708,14 +708,14 @@ public class IdentityUILocalizer
     #region PasswordExpired
 
     /// <summary>
-    ///   Gets the localized string for "Change password".
+    ///   Gets the localized string for "Change Password_FieldLabel".
     /// </summary>
     public virtual HtmlString PasswordExpired_PageTitle => new HtmlString(string.Format(CultureInfo.CurrentUICulture, IdentityLabels.PasswordExpired_PageTitle));
 
     /// <summary>
-    ///   Gets the localized string for "New password".
+    ///   Gets the localized string for "New Password_FieldLabel".
     /// </summary>
-    public virtual HtmlString PasswordExpired_New_Password => new HtmlString(string.Format(CultureInfo.CurrentUICulture, IdentityLabels.PasswordExpired_NewPassword));
+    public virtual HtmlString PasswordExpired_New_Password => new HtmlString(string.Format(CultureInfo.CurrentUICulture, IdentityLabels.PasswordExpired_Newpassword_FieldLabel));
 
     /// <summary>
     ///   Gets the localized string for "Next".
@@ -955,12 +955,12 @@ public class IdentityUILocalizer
     /// <summary>
     ///   Gets the localized string for "Choose a username and a password of your choice. You can periodically change your password or whenever you wish to.".
     /// </summary>
-    public virtual HtmlString Register_Choose_A_Username_And_A_Password => new HtmlString(string.Format(CultureInfo.CurrentUICulture, IdentityLabels.Register_ChooseUsernameAndPassword));
+    public virtual HtmlString Register_Choose_A_Username_And_A_Password => new HtmlString(string.Format(CultureInfo.CurrentUICulture, IdentityLabels.Register_ChooseUsernameAndPassword_FieldLabel));
 
     /// <summary>
     ///   Gets the localized string for "Choose an email and a password of your choice. You can periodically change your password or whenever you wish to.".
     /// </summary>
-    public virtual HtmlString Register_Choose_An_Email_And_A_Password => new HtmlString(string.Format(CultureInfo.CurrentUICulture, IdentityLabels.Register_ChooseEmailAndPassword));
+    public virtual HtmlString Register_Choose_An_Email_And_A_Password => new HtmlString(string.Format(CultureInfo.CurrentUICulture, IdentityLabels.Register_ChooseEmailAndPassword_FieldLabel));
 
     /// <summary>
     ///   Gets the localized string for "First name".
@@ -1003,9 +1003,9 @@ public class IdentityUILocalizer
     public virtual HtmlString Register_OR => new HtmlString(string.Format(CultureInfo.CurrentUICulture, IdentityLabels.Register_OR));
 
     /// <summary>
-    ///   Gets the localized string for "Password".
+    ///   Gets the localized string for "Password_FieldLabel".
     /// </summary>
-    public virtual HtmlString Register_Password => new HtmlString(string.Format(CultureInfo.CurrentUICulture, IdentityLabels.Register_Password));
+    public virtual HtmlString Register_Password => new HtmlString(string.Format(CultureInfo.CurrentUICulture, IdentityLabels.Register_Password_FieldLabel));
 
     /// <summary>
     ///   Gets the localized string for "Phone number".

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/AddEmail.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/AddEmail.cshtml
@@ -6,7 +6,7 @@
 
 
 @{
-	var title = ViewData["Title"] = Localizer.AddEmail_PageTitle;
+	ViewData["Title"] = Localizer.AddEmail_PageTitle;
     var tempData = TempData.Peek<ExtendedValidationTempDataModel>(BaseAddEmailModel.TempDataKey);
 }
 

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/AddPassword.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/AddPassword.cshtml
@@ -6,7 +6,7 @@
 @inject IdentityUILocalizer Localizer
 
 @{
-    var title = ViewData["Title"] = Localizer.AddPassword_PageTitle;
+    ViewData["Title"] = Localizer.AddPassword_PageTitle;
 }
 
 <section class="sign-in m-auto">
@@ -20,8 +20,8 @@
     }
     <form indice-if="!Model.PasswordSuccessfullyAdded" data-sbind="event: { change: formChanged }" data-token="@Base64Id.Parse(User.FindSubjectId()!)" data-userName="@(User.Identity?.Name ?? string.Empty)" novalidate method="post">
         <div class="mb-3">
-            <label asp-for="Input.NewPassword" class="form-label">@Localizer.AddPassword_NewPassword</label>
-            <input class="form-control" type="password" placeholder="@Localizer.AddPassword_NewPassword" asp-for="Input.NewPassword" data-sbind="event: { keyup: passwordChanged }" autocomplete="off" />
+            <label asp-for="Input.NewPassword" class="form-label">@Localizer.AddPassword_Newpassword_FieldLabel</label>
+            <input class="form-control" type="password" placeholder="@Localizer.AddPassword_Newpassword_FieldLabel" asp-for="Input.NewPassword" data-sbind="event: { keyup: passwordChanged }" autocomplete="off" />
             <span asp-validation-for="Input.NewPassword" class="text-danger"></span>
         </div>
         <div class="mb-3">

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/AddPhone.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/AddPhone.cshtml
@@ -10,7 +10,7 @@
 @inject IdentityUILocalizer Localizer
 
 @{
-    var title = ViewData["Title"] = Localizer.AddPhone_PageTitle;
+    ViewData["Title"] = Localizer.AddPhone_PageTitle;
     var alert = TempData.Peek<AlertModel>(BaseAddPhoneModel.TempDataKey);
 }
 

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Associate.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Associate.cshtml
@@ -5,7 +5,7 @@
 @inject IdentityUILocalizer Localizer
 
 @{
-    var title = ViewData["Title"] = Localizer.Register_Associate_your_Account(Model.View.Provider);
+    ViewData["Title"] = Localizer.Register_Associate_your_Account(Model.View.Provider);
 }
 
 <section class="sign-up m-auto">

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/ChangePassword.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/ChangePassword.cshtml
@@ -5,7 +5,7 @@
 @inject IdentityUILocalizer Localizer
 
 @{
-    var title = ViewData["Title"] = Localizer.ChangePassword_PageTitle;
+    ViewData["Title"] = Localizer.ChangePassword_PageTitle;
 }
 
 <section class="sign-in m-auto">
@@ -24,8 +24,8 @@
             <span asp-validation-for="Input.OldPassword" class="text-danger"></span>
         </div>
         <div class="mb-3">
-            <label asp-for="Input.NewPassword" class="form-label">@Localizer.ChangePassword_NewPassword</label>
-            <input class="form-control" type="password" placeholder="@Localizer.ChangePassword_NewPassword" asp-for="Input.NewPassword" data-sbind="event: { keyup: passwordChanged }" autocomplete="new-password" />
+            <label asp-for="Input.NewPassword" class="form-label">@Localizer.ChangePassword_Newpassword_FieldLabel</label>
+            <input class="form-control" type="password" placeholder="@Localizer.ChangePassword_Newpassword_FieldLabel" asp-for="Input.NewPassword" data-sbind="event: { keyup: passwordChanged }" autocomplete="new-password" />
             <span asp-validation-for="Input.NewPassword" class="text-danger"></span>
         </div>
         <div class="mb-3">

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/ForgotPassword.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/ForgotPassword.cshtml
@@ -7,7 +7,7 @@
 
 
 @{
-    var title = ViewData["Title"] = Localizer.ForgotPassword_PageTitle;
+    ViewData["Title"] = Localizer.ForgotPassword_PageTitle;
 }
 
 <section class="sign-in m-auto">

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/ForgotPasswordConfirmation.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/ForgotPasswordConfirmation.cshtml
@@ -5,7 +5,7 @@
 @inject IdentityUILocalizer Localizer
 
 @{
-    var title = ViewData["Title"] = Localizer.ForgotPasswordConfirmation_PageTitle;
+    ViewData["Title"] = Localizer.ForgotPasswordConfirmation_PageTitle;
 }
 
 <section class="sign-in p-5 m-auto">

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Grants.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Grants.cshtml
@@ -5,7 +5,7 @@
 
 
 @{
-    var title = ViewData["Title"] = Localizer.Grants_PageTitle;
+    ViewData["Title"] = Localizer.Grants_PageTitle;
 }
 
 <section class="page-grants m-auto">

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/LoggedOut.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/LoggedOut.cshtml
@@ -5,7 +5,7 @@
 
 
 @{
-    var title = ViewData["Title"] = Localizer.LoggedOut_PageTitle;
+    ViewData["Title"] = Localizer.LoggedOut_PageTitle;
 }
 
 <section class="identity-panel wide logged-out @(Model.AutomaticRedirectAfterSignOut ? "d-none": "")">

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Login.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Login.cshtml
@@ -6,7 +6,7 @@
 @inject IdentityUILocalizer Localizer
 
 @{
-    var title = ViewData["Title"] = Localizer.Login_PageTitle;
+    ViewData["Title"] = Localizer.Login_PageTitle;
 }
 
 <section class="sign-in m-auto">

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Logout.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Logout.cshtml
@@ -4,7 +4,7 @@
 @inject IdentityUILocalizer Localizer
 
 @{
-    var title = ViewData["Title"] = Localizer.Logout_PageTitle;
+    ViewData["Title"] = Localizer.Logout_PageTitle;
 }
 
 <section class="identity-panel wide logout-page">

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Mfa.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Mfa.cshtml
@@ -8,7 +8,7 @@
 @inject IConfiguration Configuration
 
 @{
-    var title = ViewData["Title"] = Localizer.Mfa_PageTitle;
+    ViewData["Title"] = Localizer.Mfa_PageTitle;
 }
 @functions {
     public string GetIconFromAuthenticationMethod(AuthenticationMethod method)

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/PasswordExpired.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/PasswordExpired.cshtml
@@ -5,7 +5,7 @@
 @inject IdentityUILocalizer Localizer
 
 @{
-    var title = ViewData["Title"] = Localizer.PasswordExpired_PageTitle;
+    ViewData["Title"] = Localizer.PasswordExpired_PageTitle;
     var tempData = TempData.Peek<ExtendedValidationTempDataModel>(BasePasswordExpiredModel.TempDataKey);
 }
 

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Profile.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Profile.cshtml
@@ -9,7 +9,7 @@
 @model BaseProfileModel
 
 @{
-    var title = ViewData["Title"] = Localizer.Profile_PageTitle;
+    ViewData["Title"] = Localizer.Profile_PageTitle;
     var alert = TempData.Get<AlertModel>("Alert");
 }
 

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Register.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Register.cshtml
@@ -8,7 +8,7 @@
 @inject IdentityUILocalizer Localizer
 
 @{
-    var title = ViewData["Title"] = Localizer.Register_PageTitle;
+    ViewData["Title"] = Localizer.Register_PageTitle;
 }
 
 <section class="sign-up m-auto">

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/VerifyPhone.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/VerifyPhone.cshtml
@@ -6,7 +6,7 @@
 @inject IdentityUILocalizer Localizer
 
 @{
-    var title = ViewData["Title"] = Localizer.VerifyPhone_PageTitle;
+    ViewData["Title"] = Localizer.VerifyPhone_PageTitle;
     var tempData = TempData.Peek<ExtendedValidationTempDataModel>(BaseVerifyPhoneModel.TempDataKey);
     var displayNext = !string.IsNullOrEmpty(tempData?.NextStepUrl) && tempData?.Alert?.AlertType == AlertType.Success;
 }

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/AddPassword.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/AddPassword.cshtml
@@ -5,7 +5,7 @@
 @inject IdentityUILocalizer Localizer
 
 @{
-    var title = ViewData["Title"] = Localizer.AddPassword_PageTitle;
+    ViewData["Title"] = Localizer.AddPassword_PageTitle;
 }
 
 <div class="content-wrapper">
@@ -20,8 +20,8 @@
         }
         <form indice-if="!Model.PasswordSuccessfullyAdded" data-sbind="event: { change: formChanged }" data-token="@Base64Id.Parse(User.FindSubjectId()!)" data-userName="@(User.Identity?.Name ?? string.Empty)" novalidate method="post">
             <div class="form-group">
-                <label asp-for="Input.NewPassword" class="">@Localizer.AddPassword_NewPassword</label>
-                <input class="form-control" type="password" placeholder="@Localizer.AddPassword_NewPassword" asp-for="Input.NewPassword" data-sbind="event: { keyup: passwordChanged }" autocomplete="off" />
+                <label asp-for="Input.NewPassword" class="">@Localizer.AddPassword_Newpassword_FieldLabel</label>
+                <input class="form-control" type="password" placeholder="@Localizer.AddPassword_Newpassword_FieldLabel" asp-for="Input.NewPassword" data-sbind="event: { keyup: passwordChanged }" autocomplete="off" />
                 <span asp-validation-for="Input.NewPassword" class="text-danger"></span>
             </div>
             <div class="form-group">

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/AddPhone.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/AddPhone.cshtml
@@ -8,7 +8,7 @@
 @inject IdentityUILocalizer Localizer
 
 @{
-    var title = ViewData["Title"] = Localizer.AddPhone_PageTitle;
+    ViewData["Title"] = Localizer.AddPhone_PageTitle;
     var alert = TempData.Peek<AlertModel>(BaseAddPhoneModel.TempDataKey);
 }
 

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/Associate.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/Associate.cshtml
@@ -5,7 +5,7 @@
 @inject IdentityUILocalizer Localizer
 
 @{
-    var title = ViewData["Title"] = Localizer.Register_Associate_your_Account(Model.View.Provider);
+    ViewData["Title"] = Localizer.Register_Associate_your_Account(Model.View.Provider);
 }
 
 <section class="sign-up m-auto">

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/ChangePassword.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/ChangePassword.cshtml
@@ -6,7 +6,7 @@
 
 @{
     Layout = "_IdentityProfileLayout";
-    var title = ViewData["Title"] = Localizer.ChangePassword_PageTitle;
+    ViewData["Title"] = Localizer.ChangePassword_PageTitle;
 }
 
 <div class="tab-panel"
@@ -29,8 +29,8 @@
                 <span asp-validation-for="Input.OldPassword" class="text-danger"></span>
             </div>
             <div class="input-group-w-full">
-                <input class="peer" type="password" placeholder="@Localizer.ChangePassword_NewPassword" asp-for="Input.NewPassword" data-sbind="event: { keyup: passwordChanged }" autocomplete="new-password" />
-                <label asp-for="Input.NewPassword" class="peer-focus:-translate-y-[6px] peer-focus:visible absolute">@Localizer.ChangePassword_NewPassword</label>
+                <input class="peer" type="password" placeholder="@Localizer.ChangePassword_Newpassword_FieldLabel" asp-for="Input.NewPassword" data-sbind="event: { keyup: passwordChanged }" autocomplete="new-password" />
+                <label asp-for="Input.NewPassword" class="peer-focus:-translate-y-[6px] peer-focus:visible absolute">@Localizer.ChangePassword_Newpassword_FieldLabel</label>
                 <span asp-validation-for="Input.NewPassword" class="text-danger"></span>
             </div>
         </div>

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/ConfirmEmail.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/ConfirmEmail.cshtml
@@ -5,7 +5,7 @@
 @inject IdentityUILocalizer Localizer
 
 @{
-    var title = ViewData["Title"] = Localizer.ConfirmEmail_PageTitle;
+    ViewData["Title"] = Localizer.ConfirmEmail_PageTitle;
 }
 
 <div class="content-wrapper">

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/ConfirmEmailChange.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/ConfirmEmailChange.cshtml
@@ -6,7 +6,7 @@
 
 
 @{
-    var title = ViewData["Title"] = Localizer.ConfirmEmailChange_PageTitle;
+    ViewData["Title"] = Localizer.ConfirmEmailChange_PageTitle;
 }
 
 <div class="content-wrapper">

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/ForgotPassword.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/ForgotPassword.cshtml
@@ -6,7 +6,7 @@
 @inject ExtendedUserManager<User> userManager
 
 @{
-    var title = ViewData["Title"] = Localizer.ForgotPassword_PageTitle;
+    ViewData["Title"] = Localizer.ForgotPassword_PageTitle;
 }
 
 <div class="content-wrapper">

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/ForgotPasswordConfirmation.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/ForgotPasswordConfirmation.cshtml
@@ -6,7 +6,7 @@
 
 
 @{
-    var title = ViewData["Title"] = Localizer.ForgotPasswordConfirmation_PageTitle;
+    ViewData["Title"] = Localizer.ForgotPasswordConfirmation_PageTitle;
 }
 
 <div class="content-wrapper">

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/LoggedOut.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/LoggedOut.cshtml
@@ -5,7 +5,7 @@
 
 
 @{
-    var title = ViewData["Title"] = Localizer.LoggedOut_PageTitle;
+    ViewData["Title"] = Localizer.LoggedOut_PageTitle;
     ViewData["signed-out"] = true;
 }
 

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/Login.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/Login.cshtml
@@ -7,7 +7,7 @@
 
 
 @{
-    var title = ViewData["Title"] = Localizer.Login_PageTitle;
+    ViewData["Title"] = Localizer.Login_PageTitle;
 }
 
 <div class="content-wrapper">

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/Logout.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/Logout.cshtml
@@ -5,7 +5,7 @@
 @inject IdentityUILocalizer Localizer
 
 @{
-    var title = ViewData["Title"] = Localizer.Logout_PageTitle;
+    ViewData["Title"] = Localizer.Logout_PageTitle;
 }
 
 <div class="content-wrapper">

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/Mfa.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/Mfa.cshtml
@@ -10,7 +10,7 @@
 
 
 @{
-    var title = ViewData["Title"] = Localizer.Mfa_PageTitle;
+    ViewData["Title"] = Localizer.Mfa_PageTitle;
 }
 @functions {
     public string GetIconFromAuthenticationMethod(AuthenticationMethod method)

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/MfaOnboarding.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/MfaOnboarding.cshtml
@@ -6,7 +6,7 @@
 @inject IdentityUILocalizer Localizer
 
 @{
-    var title = ViewData["Title"] = @Localizer.MfaOnBoarding_PageTitle;
+    ViewData["Title"] = @Localizer.MfaOnBoarding_PageTitle;
     var lang = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
     var langSuffix = (lang == "el") ? ".el" : string.Empty;
 }

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/PasswordExpired.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/PasswordExpired.cshtml
@@ -5,7 +5,7 @@
 @inject IdentityUILocalizer Localizer
 
 @{
-    var title = ViewData["Title"] = Localizer.PasswordExpired_PageTitle;
+    ViewData["Title"] = Localizer.PasswordExpired_PageTitle;
     var tempData = TempData.Peek<ExtendedValidationTempDataModel>(BasePasswordExpiredModel.TempDataKey);
     var alert = tempData?.Alert;
 }

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/Profile.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/Profile.cshtml
@@ -10,7 +10,7 @@
 
 @{
     Layout = "_IdentityProfileLayout";
-    var title = ViewData["Title"] = Localizer.Profile_PageTitle;
+    ViewData["Title"] = Localizer.Profile_PageTitle;
     var alert = TempData.Get<AlertModel>("Alert");
 }
 

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/Register.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/Register.cshtml
@@ -10,7 +10,7 @@
 @inject IdentityUILocalizer Localizer
 
 @{
-    var title = ViewData["Title"] = Localizer.Register_PageTitle;
+    ViewData["Title"] = Localizer.Register_PageTitle;
 }
 
 <div class="content-wrapper">

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/VerifyPhone.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/VerifyPhone.cshtml
@@ -5,7 +5,7 @@
 @inject IdentityUILocalizer Localizer
 
 @{
-    var title = ViewData["Title"] = Localizer.VerifyPhone_PageTitle;
+    ViewData["Title"] = Localizer.VerifyPhone_PageTitle;
     var tempData = TempData.Peek<ExtendedValidationTempDataModel>(BaseVerifyPhoneModel.TempDataKey);
     var alert = tempData?.Alert;
     var displayNext = !string.IsNullOrEmpty(tempData?.NextStepUrl) && tempData?.Alert?.AlertType == AlertType.Success;

--- a/src/Indice.Features.Identity.UI/Validators/ChangePasswordInputModelValidator.cs
+++ b/src/Indice.Features.Identity.UI/Validators/ChangePasswordInputModelValidator.cs
@@ -1,7 +1,6 @@
 ﻿using FluentValidation;
 using Indice.Features.Identity.Core;
 using Indice.Features.Identity.UI.Models;
-using Microsoft.Extensions.Localization;
 
 namespace Indice.Features.Identity.UI.Validators;
 

--- a/src/Indice.Features.Messages.Core/Services/ContactService.cs
+++ b/src/Indice.Features.Messages.Core/Services/ContactService.cs
@@ -428,9 +428,6 @@ public class ContactService : IContactService
                                              .ThenInclude(up => up.MessageType)
                                              .SingleOrDefaultAsync(x => x.RecipientId == recipientId);
         if (recipientPreferences == null) {
-            var messageTypes = await DbContext.MessageTypes
-                                     .AsNoTracking()
-                                     .ToListAsync();
             recipientPreferences = new DbContactPreference() {
                 RecipientId = recipientId,
                 Locale = preference.Locale,

--- a/src/Indice.Services/SmsServiceApifon.cs
+++ b/src/Indice.Services/SmsServiceApifon.cs
@@ -48,7 +48,7 @@ public class SmsServiceApifon : ISmsService
     public async Task<SendReceipt> SendAsync(string destination, string subject, string? body, SmsSender? sender = null) {
         HttpResponseMessage httpResponse;
         ApifonResponse response;
-        var recipients = (destination ?? string.Empty).Split(new string[] { "," }, StringSplitOptions.RemoveEmptyEntries);
+        var recipients = (destination ?? string.Empty).Split(',', StringSplitOptions.RemoveEmptyEntries);
         if (recipients == null) {
             throw new ArgumentNullException(nameof(destination));
         }
@@ -77,8 +77,8 @@ public class SmsServiceApifon : ISmsService
         request.Headers.Add("X-ApifonWS-Date", payload.RequestDate.ToString("r"));
         request.Headers.Authorization = new AuthenticationHeaderValue("ApifonWS", $"{Settings.Token}:{signature}");
         try {
-            Logger.LogInformation("The full request sent to Apifon: {RequestMessage}", JsonSerializer.Serialize(request, GetJsonSerializerOptions()));
-            Logger.LogInformation("The following payload was sent to Apifon: {RequestPayload}", payload.ToJson());
+            Logger.LogDebug("The full request sent to Apifon: {RequestMessage}", JsonSerializer.Serialize(request, GetJsonSerializerOptions()));
+            Logger.LogDebug("The following payload was sent to Apifon: {RequestPayload}", payload.ToJson());
             httpResponse = await HttpClient.SendAsync(request);
         } catch (Exception ex) {
             Logger.LogError(ex, "SMS Delivery took too long");
@@ -86,12 +86,12 @@ public class SmsServiceApifon : ISmsService
         }
         var responseString = await httpResponse.Content.ReadAsStringAsync();
         if (!httpResponse.IsSuccessStatusCode) {
-            Logger.LogInformation("SMS Delivery failed. {StatusCode} : {ResponseString}", httpResponse.StatusCode, responseString);
+            Logger.LogWarning("SMS Delivery failed. {StatusCode} : {ResponseString}", httpResponse.StatusCode, responseString);
             throw new SmsServiceException($"SMS Delivery failed. {httpResponse.StatusCode} : {responseString}");
         }
         response = JsonSerializer.Deserialize<ApifonResponse>(responseString, GetJsonSerializerOptions())!;
         if (response.HasError) {
-            Logger.LogInformation("SMS Delivery failed. {ResponseStatus}. ResponseId: {ResponseId}", response.Status?.Description, response.Id);
+            Logger.LogWarning("SMS Delivery failed. {ResponseStatus}. ResponseId: {ResponseId}", response.Status?.Description, response.Id);
             throw new SmsServiceException($"SMS Delivery failed. {response.Status?.Description} responseId {response.Id}");
         } else {
             Logger.LogInformation("SMS message successfully sent: {Result}", response.Results!.FirstOrDefault().Key);
@@ -99,7 +99,7 @@ public class SmsServiceApifon : ISmsService
         var messageId = response.Id;
         var messageIds = response.Results?.Values.SelectMany(x => x?.Select(y => y.Id)!)?.ToList();
         if (messageIds?.Count > 0) {
-            messageId = string.Join(",", messageIds);
+            messageId = string.Join(',', messageIds);
         }
         return new SendReceipt(messageId, DateTimeOffset.UtcNow);
     }
@@ -110,7 +110,7 @@ public class SmsServiceApifon : ISmsService
     public bool Supports(string deliveryChannel) => "SMS".Equals(deliveryChannel, StringComparison.OrdinalIgnoreCase);
 
     /// <summary>Get default JSON serializer options: CamelCase, ignore null values.</summary>
-    protected static JsonSerializerOptions GetJsonSerializerOptions() => new JsonSerializerOptions {
+    protected static JsonSerializerOptions GetJsonSerializerOptions() => new () {
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase
     };
@@ -188,13 +188,12 @@ internal class ApifonRequest
 
     internal static Dictionary<string, ApifonListParameter> ExtractParametersAndReplaceUrlsFromMessage(ref string message) {
         int instance = 0;
-        List<string> extractedLinks = new List<string>();
-        Regex regex = new Regex(@"https?://[^\s""<>]*[^\s""<>.,!?)]", RegexOptions.Compiled);
+        var extractedLinks = new List<string>();
+        var regex = new Regex(@"https?://[^\s""<>]*[^\s""<>.,!?)]", RegexOptions.Compiled);
         message = regex.Replace(message, match => {
             extractedLinks.Add(match.Value);
             return $"{{apifon_lp_{instance++}}}";
         });
-        Console.WriteLine(message);
         var parameters = new Dictionary<string, ApifonListParameter>();
         instance = 0;
         foreach (var link in extractedLinks) {

--- a/src/Indice.Services/SmsServiceApifonIM.cs
+++ b/src/Indice.Services/SmsServiceApifonIM.cs
@@ -44,7 +44,7 @@ public class SmsServiceApifonIM : ISmsService
     public async Task<SendReceipt> SendAsync(string destination, string subject, string? body, SmsSender? sender = null) {
         HttpResponseMessage httpResponse;
         ApifonResponse response;
-        var recipients = (destination ?? string.Empty).Split(new string[] { "," }, StringSplitOptions.RemoveEmptyEntries);
+        var recipients = (destination ?? string.Empty).Split(',', StringSplitOptions.RemoveEmptyEntries);
         if (recipients == null) {
             throw new ArgumentNullException(nameof(destination));
         }
@@ -73,8 +73,8 @@ public class SmsServiceApifonIM : ISmsService
         request.Headers.Add("X-ApifonWS-Date", payload.RequestDate.ToString("r"));
         request.Headers.Authorization = new AuthenticationHeaderValue("ApifonWS", $"{Options.Token}:{signature}");
         try {
-            Logger.LogInformation("The full request sent to Apifon: {RequestMessage}", JsonSerializer.Serialize(request, GetJsonSerializerOptions()));
-            Logger.LogInformation("The following payload was sent to Apifon: {RequestPayload}", payload.ToJson());
+            Logger.LogDebug("The full request sent to Apifon: {RequestMessage}", JsonSerializer.Serialize(request, GetJsonSerializerOptions()));
+            Logger.LogDebug("The following payload was sent to Apifon: {RequestPayload}", payload.ToJson());
             httpResponse = await HttpClient.SendAsync(request);
         } catch (Exception ex) {
             Logger.LogError(ex, "Viber/SMS Delivery took too long");
@@ -82,12 +82,12 @@ public class SmsServiceApifonIM : ISmsService
         }
         var responseString = await httpResponse.Content.ReadAsStringAsync();
         if (!httpResponse.IsSuccessStatusCode) {
-            Logger.LogInformation("Viber/SMS Delivery failed. {StatusCode} : {ResponseString}", httpResponse.StatusCode, responseString);
+            Logger.LogWarning("Viber/SMS Delivery failed. {StatusCode} : {ResponseString}", httpResponse.StatusCode, responseString);
             throw new SmsServiceException($"Viber/SMS Delivery failed. {httpResponse.StatusCode} : {responseString}");
         }
         response = JsonSerializer.Deserialize<ApifonResponse>(responseString, GetJsonSerializerOptions())!;
         if (response.HasError) {
-            Logger.LogInformation("Viber/SMS Delivery failed. {ResponseStatus}. ResponseId: {ResponseId}", response.Status?.Description, response.Id);
+            Logger.LogWarning("Viber/SMS Delivery failed. {ResponseStatus}. ResponseId: {ResponseId}", response.Status?.Description, response.Id);
             throw new SmsServiceException($"Viber/SMS Delivery failed. {response.Status?.Description} responseId {response.Id}");
         } else {
             Logger.LogInformation("Viber/SMS message successfully sent: {Result}", response.Results!.FirstOrDefault().Key);
@@ -105,7 +105,8 @@ public class SmsServiceApifonIM : ISmsService
     /// <summary>Checks the implementation if supports the given <paramref name="deliveryChannel"/>.</summary>
     /// <param name="deliveryChannel">A string representing the delivery channel. i.e 'SMS'</param>
     /// <returns></returns>
-    public bool Supports(string deliveryChannel) => "Viber".Equals(deliveryChannel, StringComparison.OrdinalIgnoreCase);
+    public bool Supports(string deliveryChannel) => "Viber".Equals(deliveryChannel, StringComparison.OrdinalIgnoreCase) ||
+                                                    ("SMS".Equals(deliveryChannel, StringComparison.OrdinalIgnoreCase) && Options.ViberFallbackEnabled);
 
     /// <summary>Get default JSON serializer options: CamelCase, ignore null values.</summary>
     protected static JsonSerializerOptions GetJsonSerializerOptions() => new JsonSerializerOptions {

--- a/src/Indice.Services/SmsServiceYubotoOmniViber.cs
+++ b/src/Indice.Services/SmsServiceYubotoOmniViber.cs
@@ -24,7 +24,7 @@ public class SmsServiceYubotoOmniViber : SmsServiceYubotoOmniBase, ISmsService
         var phoneNumbers = GetRecipientsFromDestination(destination);
         var requestBody = SendRequest.CreateViber(phoneNumbers, (sender?.Id ?? Settings.Sender ?? Settings.SenderName)!, body!, Settings.ViberFallbackEnabled, Settings.Validity);
         var jsonData = JsonSerializer.Serialize(requestBody, GetJsonSerializerOptions());
-        Logger.LogInformation("The following payload was sent to Yuboto: {0}", jsonData);
+        Logger.LogDebug("The following payload was sent to Yuboto: {requestBody}", jsonData);
         var data = new StringContent(jsonData, Encoding.UTF8, "application/json");
         var httpResponseMessage = await HttpClient.PostAsync("Send", data);
         if (!httpResponseMessage.IsSuccessStatusCode) {
@@ -36,12 +36,11 @@ public class SmsServiceYubotoOmniViber : SmsServiceYubotoOmniBase, ISmsService
             throw new SmsServiceException(errorMessage);
         }
         var responseContent = await httpResponseMessage.Content.ReadAsStringAsync();
-        Logger.LogInformation("The following response was received from Yuboto: {0}", responseContent);
+        Logger.LogDebug("The following response was received from Yuboto: {responseContent}", responseContent);
         var response = JsonSerializer.Deserialize<SendResponse>(responseContent);
         if (!response!.IsSuccess) {
-            var errorMessage = $"SMS Delivery failed: {response.ErrorCode} - {response.ErrorMessage}";
-            Logger.LogError(errorMessage);
-            throw new SmsServiceException(errorMessage);
+            Logger.LogError("SMS Delivery failed: {responseErrorCode} - {responseErrorMessage}", response.ErrorCode, response.ErrorMessage);
+            throw new SmsServiceException($"SMS Delivery failed: {response.ErrorCode} - {response.ErrorMessage}");
         }
         Logger.LogInformation("SMS message successfully sent.");
         if (response.Messages?.Count > 0) {
@@ -51,5 +50,6 @@ public class SmsServiceYubotoOmniViber : SmsServiceYubotoOmniBase, ISmsService
     }
 
     /// <inheritdoc />
-    public bool Supports(string deliveryChannel) => "Viber".Equals(deliveryChannel, StringComparison.OrdinalIgnoreCase);
+    public bool Supports(string deliveryChannel) => "Viber".Equals(deliveryChannel, StringComparison.OrdinalIgnoreCase) ||
+                                                    ("SMS".Equals(deliveryChannel, StringComparison.OrdinalIgnoreCase) && Settings.ViberFallbackEnabled);
 }

--- a/test/Indice.Services.Tests/SmsTests.cs
+++ b/test/Indice.Services.Tests/SmsTests.cs
@@ -100,6 +100,37 @@ public class SmsTests
         Assert.Null(error);
     }
 
+    [Fact]
+    public async Task ApifonIM_Should_Support_SMS_Only_When_ViberFallback_IsEnabled_Test() {
+        var inMemorySettings = new Dictionary<string, string?> {
+            ["Sms:ApiKey"] = "test",
+            ["Sms:Token"] = "test",
+            ["Sms:Sender"] = "INDICE",
+            ["Sms:SenderName"] = "INDICE",
+            ["Sms:TestMode"] = true.ToString(),
+            ["Sms:EnableUrlShortener"] = true.ToString(),
+            ["Sms:ViberFallbackEnabled"] = true.ToString()
+        };
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(inMemorySettings)
+            .Build();
+        var collection = new ServiceCollection()
+            .AddSingleton(configuration)
+            .AddOptions()
+            .Configure<SmsServiceApifonSettings>(configuration.GetSection(SmsServiceApifonSettings.Name))
+            .AddSmsServiceApifonIM(configuration);
+
+        var serviceProvider = collection.BuildServiceProvider();
+        
+        var serviceFactory = serviceProvider.GetRequiredService<ISmsServiceFactory>();
+        var smsService = serviceFactory.Create("SMS");
+        var viberService = serviceFactory.Create("Viber");
+            
+        Assert.NotNull(smsService);
+        Assert.IsType<SmsServiceApifonIM>(smsService);
+        Assert.IsType<SmsServiceApifonIM>(viberService);
+    }
+
     [Theory(Skip = "Sensitive Data")]
     [InlineData("", "Hello from INDICE", "", "", "Indice")]
     public async Task TestVonageSms(string phoneNumber, string body, string apiKey, string signatureSecret, string sender) {

--- a/test/Indice.Services.Tests/SmsTests.cs
+++ b/test/Indice.Services.Tests/SmsTests.cs
@@ -101,7 +101,7 @@ public class SmsTests
     }
 
     [Fact]
-    public async Task ApifonIM_Should_Support_SMS_Only_When_ViberFallback_IsEnabled_Test() {
+    public void ApifonIM_Should_Support_SMS_Only_When_ViberFallback_IsEnabled_Test() {
         var inMemorySettings = new Dictionary<string, string?> {
             ["Sms:ApiKey"] = "test",
             ["Sms:Token"] = "test",


### PR DESCRIPTION
Renamed resource keys in `IdentityLabels` to include the `_FieldLabel` suffix for consistency and clarity. Updated corresponding references in `IdentityLabels.Designer.cs`, `.resx` files (including localized versions), and `IdentityUILocalizer.cs`.

Simplified `ViewData["Title"]` assignments in `.cshtml` files by removing redundant `var title` variables. Updated field label references in `.cshtml` files to use the new `_FieldLabel` suffixed keys.

Removed an unused `using` directive in `ChangePasswordInputModelValidator.cs`. Cleaned up redundant code in `ContactService.cs` related to fetching `MessageTypes`.

These changes improve code readability, maintainability, and localization consistency.