### PR TITLE
[identity] Refactor to use HtmlString for Message and Title properties

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,13 +4,13 @@
       <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
       <!--<TargetFramework></TargetFramework>-->
       <VersionPrefixMajor>8</VersionPrefixMajor>
-      <VersionPrefixBase>$(VersionPrefixMajor).21</VersionPrefixBase>
+      <VersionPrefixBase>$(VersionPrefixMajor).22</VersionPrefixBase>
 
       <VersionPrefixCore>$(VersionPrefixBase).0</VersionPrefixCore>
       <VersionPrefixIdentity>$(VersionPrefixBase).0</VersionPrefixIdentity>
-      <VersionPrefixIdentityUI>$(VersionPrefixBase).1</VersionPrefixIdentityUI>
+      <VersionPrefixIdentityUI>$(VersionPrefixBase).0</VersionPrefixIdentityUI>
       <VersionPrefixCases>$(VersionPrefixBase).0</VersionPrefixCases>
-      <VersionPrefixMessages>$(VersionPrefixBase).1</VersionPrefixMessages>
+      <VersionPrefixMessages>$(VersionPrefixBase).0</VersionPrefixMessages>
       <VersionPrefixMultitenancy>$(VersionPrefixBase).0</VersionPrefixMultitenancy>
       <VersionPrefixRisk>$(VersionPrefixBase).0</VersionPrefixRisk>
       <VersionPrefixMedia>$(VersionPrefixBase).0</VersionPrefixMedia>

--- a/src/Indice.Features.Identity.Core/IdentityResources.el.resx
+++ b/src/Indice.Features.Identity.Core/IdentityResources.el.resx
@@ -220,7 +220,7 @@
     <value>Ειδοποίηση ασφαλείας για {0}</value>
   </data>
   <data name="AddEmailValidationEmailEmpty" xml:space="preserve">
-    <value>Παρακαλώ εισάγετε &lt;br/&gt;τη διεύθυνση email &lt;br/&gt; σας για να την &lt;br/&gt;επιβεβαιώσουμε πριν προχωρήσουμε.</value>
+    <value>Παρακαλώ εισάγετε τη διεύθυνση email σας για να την επιβεβαιώσουμε πριν προχωρήσουμε.</value>
   </data>
   <data name="AddEmailConfirmationEmailSend" xml:space="preserve">
     <value>Ένα email επιβεβαίωσης έχει αποσταλεί στην παρακάτω διεύθυνση.</value>

--- a/src/Indice.Features.Identity.Core/IdentityResources.el.resx
+++ b/src/Indice.Features.Identity.Core/IdentityResources.el.resx
@@ -220,7 +220,7 @@
     <value>Ειδοποίηση ασφαλείας για {0}</value>
   </data>
   <data name="AddEmailValidationEmailEmpty" xml:space="preserve">
-    <value>Παρακαλώ εισάγετε τη διεύθυνση email σας για να την επιβεβαιώσουμε πριν προχωρήσουμε.</value>
+    <value>Παρακαλώ εισάγετε &lt;br/&gt;τη διεύθυνση email &lt;br/&gt; σας για να την &lt;br/&gt;επιβεβαιώσουμε πριν προχωρήσουμε.</value>
   </data>
   <data name="AddEmailConfirmationEmailSend" xml:space="preserve">
     <value>Ένα email επιβεβαίωσης έχει αποσταλεί στην παρακάτω διεύθυνση.</value>

--- a/src/Indice.Features.Identity.Server/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Indice.Features.Identity.Server/Extensions/ServiceCollectionExtensions.cs
@@ -94,6 +94,8 @@ public static class IdentityServerEndpointServiceCollectionExtensions
         services.Configure<CookieTempDataProviderOptions>(options => {
             options.Cookie.Expiration = TimeSpan.FromMinutes(30);
             options.Cookie.Name = ExtendedIdentityConstants.TempDataCookieName;
+            options.Cookie.HttpOnly = true;
+            options.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
         });
         services.TryAddScoped<IdentityMessageDescriber>();
         services.TryAddScoped<CallingCodesProvider>();

--- a/src/Indice.Features.Identity.UI/IdentityLabels.el.resx
+++ b/src/Indice.Features.Identity.UI/IdentityLabels.el.resx
@@ -136,10 +136,10 @@
     <value>Αποθήκευση</value>
   </data>
   <data name="AddEmail_PageTitle" xml:space="preserve">
-    <value>Επιβεβαίωση &lt;strong&gt;email&lt;/strong&gt;</value>
+    <value>Επιβεβαίωση email</value>
   </data>
   <data name="AddEmail_PageHeader" xml:space="preserve">
-    <value>Επιβεβαίωση &lt;strong&gt;email&lt;/strong&gt;</value>
+    <value>Επιβεβαίωση email</value>
   </data>
   <data name="AddPassword_Required" xml:space="preserve">
     <value>απαιτείται</value>
@@ -223,10 +223,10 @@
     <value>Πατήστε</value>
   </data>
   <data name="ConfirmEmail_PageTitle" xml:space="preserve">
-    <value>Επιβεβαίωση &lt;strong&gt;email&lt;/strong&gt;</value>
+    <value>Επιβεβαίωση email</value>
   </data>
   <data name="ConfirmEmail_PageHeader" xml:space="preserve">
-    <value>Επιβεβαίωση &lt;strong&gt;email&lt;/strong&gt;</value>
+    <value>Επιβεβαίωση email</value>
   </data>
   <data name="ConfirmEmail_LinkExpired" xml:space="preserve">
     <value>Ο σύνδεσμος επιβεβαίωσης έχει λήξει</value>

--- a/src/Indice.Features.Identity.UI/IdentityLabels.el.resx
+++ b/src/Indice.Features.Identity.UI/IdentityLabels.el.resx
@@ -136,10 +136,10 @@
     <value>Αποθήκευση</value>
   </data>
   <data name="AddEmail_PageTitle" xml:space="preserve">
-    <value>Επιβεβαίωση email</value>
+    <value>Επιβεβαίωση &lt;strong&gt;email&lt;/strong&gt;</value>
   </data>
   <data name="AddEmail_PageHeader" xml:space="preserve">
-    <value>Επιβεβαίωση email</value>
+    <value>Επιβεβαίωση &lt;strong&gt;email&lt;/strong&gt;</value>
   </data>
   <data name="AddPassword_Required" xml:space="preserve">
     <value>απαιτείται</value>
@@ -223,10 +223,10 @@
     <value>Πατήστε</value>
   </data>
   <data name="ConfirmEmail_PageTitle" xml:space="preserve">
-    <value>Επιβεβαίωση Email</value>
+    <value>Επιβεβαίωση &lt;strong&gt;email&lt;/strong&gt;</value>
   </data>
   <data name="ConfirmEmail_PageHeader" xml:space="preserve">
-    <value>Επιβεβαίωση Email</value>
+    <value>Επιβεβαίωση &lt;strong&gt;email&lt;/strong&gt;</value>
   </data>
   <data name="ConfirmEmail_LinkExpired" xml:space="preserve">
     <value>Ο σύνδεσμος επιβεβαίωσης έχει λήξει</value>

--- a/src/Indice.Features.Identity.UI/Models/AlertModel.cs
+++ b/src/Indice.Features.Identity.UI/Models/AlertModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Web;
+﻿using System.Text.Json.Serialization;
+using System.Web;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 
@@ -8,8 +9,14 @@ namespace Indice.Features.Identity.UI.Models;
 /// <remarks>Usually combined perfectly with <see cref="TempDataDictionary"/> in order to pass the state of success or error between pages.</remarks>
 public class AlertModel
 {
-    /// <summary>The message.</summary>
-    public HtmlString Message { get; set; } = new HtmlString("");
+    /// <summary>The raw message</summary>
+    public string MessageText { get; set; } = string.Empty;
+
+    /// <summary>The Html message.</summary>
+    [JsonIgnore]
+    public HtmlString Message { get => new HtmlString(MessageText); set => MessageText = value.ToString(); }
+    /// <summary>Gets a value indicating whether the message text is null, empty, or consists only of white-space characters.</summary>
+    public bool IsEmpty => string.IsNullOrWhiteSpace(MessageText);
     /// <summary>The alert type.</summary>
     public AlertType AlertType { get; set; }
 
@@ -17,31 +24,29 @@ public class AlertModel
     /// <param name="message">The message.</param>
     public static AlertModel Info(string message) => new() {
         AlertType = AlertType.Info,
-        Message = new HtmlString(message)
+        MessageText = message
     };
 
     /// <summary>Creates an alert with <see cref="AlertType.Warning"/>.</summary>
     /// <param name="message">The message.</param>
     public static AlertModel Warn(string message) => new() {
         AlertType = AlertType.Warning,
-        Message = new HtmlString(message)
+        MessageText = message
     };
 
     /// <summary>Creates an alert with <see cref="AlertType.Danger"/>.</summary>
     /// <param name="message">The message.</param>
     public static AlertModel Error(string message) => new() {
         AlertType = AlertType.Danger,
-        Message = new HtmlString(message)
+        MessageText = message
     };
 
     /// <summary>Creates an alert with <see cref="AlertType.Success"/></summary>
     /// <param name="message">The message.</param>
     public static AlertModel Success(string message) => new() {
         AlertType = AlertType.Success,
-        Message = new HtmlString(message)
+        MessageText = message
     };
-
-
 
     /// <summary>Creates an alert with <see cref="AlertType.Info"/>.</summary>
     /// <param name="message">The message.</param>

--- a/src/Indice.Features.Identity.UI/Models/AlertModel.cs
+++ b/src/Indice.Features.Identity.UI/Models/AlertModel.cs
@@ -24,7 +24,7 @@ public class AlertModel
     /// <param name="message">The message.</param>
     public static AlertModel Warn(string message) => new() { 
         AlertType = AlertType.Warning, 
-        Message = new HtmlString(message )
+        Message = new HtmlString(message)
     };
     
     /// <summary>Creates an alert with <see cref="AlertType.Danger"/>.</summary>

--- a/src/Indice.Features.Identity.UI/Models/AlertModel.cs
+++ b/src/Indice.Features.Identity.UI/Models/AlertModel.cs
@@ -14,7 +14,7 @@ public class AlertModel
 
     /// <summary>The Html message.</summary>
     [JsonIgnore]
-    public HtmlString Message { get => new HtmlString(MessageText); set => MessageText = value.ToString(); }
+    public HtmlString Message { get => new HtmlString(MessageText); set => MessageText = value?.ToString() ?? string.Empty; }
     /// <summary>Gets a value indicating whether the message text is null, empty, or consists only of white-space characters.</summary>
     public bool IsEmpty => string.IsNullOrWhiteSpace(MessageText);
     /// <summary>The alert type.</summary>

--- a/src/Indice.Features.Identity.UI/Models/AlertModel.cs
+++ b/src/Indice.Features.Identity.UI/Models/AlertModel.cs
@@ -9,7 +9,7 @@ namespace Indice.Features.Identity.UI.Models;
 public class AlertModel
 {
     /// <summary>The message.</summary>
-    public string Message { get; set; } = string.Empty;
+    public HtmlString Message { get; set; } = new HtmlString("");
     /// <summary>The alert type.</summary>
     public AlertType AlertType { get; set; }
 
@@ -17,28 +17,28 @@ public class AlertModel
     /// <param name="message">The message.</param>
     public static AlertModel Info(string message) => new() { 
         AlertType = AlertType.Info, 
-        Message = message 
+        Message = new HtmlString(message) 
     };
     
     /// <summary>Creates an alert with <see cref="AlertType.Warning"/>.</summary>
     /// <param name="message">The message.</param>
     public static AlertModel Warn(string message) => new() { 
         AlertType = AlertType.Warning, 
-        Message = message 
+        Message = new HtmlString(message )
     };
     
     /// <summary>Creates an alert with <see cref="AlertType.Danger"/>.</summary>
     /// <param name="message">The message.</param>
     public static AlertModel Error(string message) => new() { 
         AlertType = AlertType.Danger, 
-        Message = message 
+        Message = new HtmlString(message )
     };
     
     /// <summary>Creates an alert with <see cref="AlertType.Success"/></summary>
     /// <param name="message">The message.</param>
     public static AlertModel Success(string message) => new() { 
         AlertType = AlertType.Success, 
-        Message = message 
+        Message = new HtmlString(message )
     };
 
 
@@ -47,27 +47,27 @@ public class AlertModel
     /// <param name="message">The message.</param>
     public static AlertModel Info(HtmlString message) => new() {
         AlertType = AlertType.Info,
-        Message = message.Value!
+        Message = message
     };
 
     /// <summary>Creates an alert with <see cref="AlertType.Warning"/>.</summary>
     /// <param name="message">The message.</param>
     public static AlertModel Warn(HtmlString message) => new() {
         AlertType = AlertType.Warning,
-        Message = message.Value!
+        Message = message
     };
 
     /// <summary>Creates an alert with <see cref="AlertType.Danger"/>.</summary>
     /// <param name="message">The message.</param>
     public static AlertModel Error(HtmlString message) => new() {
         AlertType = AlertType.Danger,
-        Message = message.Value!
+        Message = message
     };
 
     /// <summary>Creates an alert with <see cref="AlertType.Success"/></summary>
     /// <param name="message">The message.</param>
     public static AlertModel Success(HtmlString message) => new() {
         AlertType = AlertType.Success,
-        Message = message.Value!
+        Message = message
     };
 }

--- a/src/Indice.Features.Identity.UI/Models/AlertModel.cs
+++ b/src/Indice.Features.Identity.UI/Models/AlertModel.cs
@@ -15,30 +15,30 @@ public class AlertModel
 
     /// <summary>Creates an alert with <see cref="AlertType.Info"/>.</summary>
     /// <param name="message">The message.</param>
-    public static AlertModel Info(string message) => new() { 
-        AlertType = AlertType.Info, 
-        Message = new HtmlString(message) 
-    };
-    
-    /// <summary>Creates an alert with <see cref="AlertType.Warning"/>.</summary>
-    /// <param name="message">The message.</param>
-    public static AlertModel Warn(string message) => new() { 
-        AlertType = AlertType.Warning, 
+    public static AlertModel Info(string message) => new() {
+        AlertType = AlertType.Info,
         Message = new HtmlString(message)
     };
-    
+
+    /// <summary>Creates an alert with <see cref="AlertType.Warning"/>.</summary>
+    /// <param name="message">The message.</param>
+    public static AlertModel Warn(string message) => new() {
+        AlertType = AlertType.Warning,
+        Message = new HtmlString(message)
+    };
+
     /// <summary>Creates an alert with <see cref="AlertType.Danger"/>.</summary>
     /// <param name="message">The message.</param>
-    public static AlertModel Error(string message) => new() { 
-        AlertType = AlertType.Danger, 
-        Message = new HtmlString(message )
+    public static AlertModel Error(string message) => new() {
+        AlertType = AlertType.Danger,
+        Message = new HtmlString(message)
     };
-    
+
     /// <summary>Creates an alert with <see cref="AlertType.Success"/></summary>
     /// <param name="message">The message.</param>
-    public static AlertModel Success(string message) => new() { 
-        AlertType = AlertType.Success, 
-        Message = new HtmlString(message )
+    public static AlertModel Success(string message) => new() {
+        AlertType = AlertType.Success,
+        Message = new HtmlString(message)
     };
 
 

--- a/src/Indice.Features.Identity.UI/Models/PageHeadingViewModel.cs
+++ b/src/Indice.Features.Identity.UI/Models/PageHeadingViewModel.cs
@@ -13,7 +13,7 @@ public class PageHeadingViewModel
     /// </summary>
     /// <param name="title"></param>
     /// <param name="imageSrc"></param>
-    public PageHeadingViewModel(HtmlString? title, string? imageSrc) {
+    public PageHeadingViewModel(IHtmlContent? title, string? imageSrc) {
         Title = title;
         ImageSrc = imageSrc;
     }
@@ -26,5 +26,5 @@ public class PageHeadingViewModel
     /// <summary>
     /// The page title
     /// </summary>
-    public HtmlString? Title { get; }
+    public IHtmlContent? Title { get; }
 }

--- a/src/Indice.Features.Identity.UI/Models/PageHeadingViewModel.cs
+++ b/src/Indice.Features.Identity.UI/Models/PageHeadingViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Indice.Features.Identity.UI.ViewComponents;
+using Microsoft.AspNetCore.Html;
 
 namespace Indice.Features.Identity.UI.Models;
 /// <summary>
@@ -12,7 +13,7 @@ public class PageHeadingViewModel
     /// </summary>
     /// <param name="title"></param>
     /// <param name="imageSrc"></param>
-    public PageHeadingViewModel(string? title, string? imageSrc) {
+    public PageHeadingViewModel(HtmlString? title, string? imageSrc) {
         Title = title;
         ImageSrc = imageSrc;
     }
@@ -25,5 +26,5 @@ public class PageHeadingViewModel
     /// <summary>
     /// The page title
     /// </summary>
-    public string? Title { get; }
+    public HtmlString? Title { get; }
 }

--- a/src/Indice.Features.Identity.UI/Pages/AddPhone.cs
+++ b/src/Indice.Features.Identity.UI/Pages/AddPhone.cs
@@ -51,10 +51,7 @@ public abstract class BaseAddPhoneModel : BasePageModel
     public virtual async Task<IActionResult> OnGetAsync([FromQuery] string? returnUrl) {
         var user = await UserManager.GetUserAsync(User) ?? throw new InvalidOperationException("User cannot be null.");
 
-        TempData.Put(TempDataKey, new AlertModel {
-            Message = new HtmlString(UserManager.MessageDescriber.AddPhoneValidationPhoneEmpty),
-            AlertType = AlertType.Info
-        });
+        TempData.Put(TempDataKey, AlertModel.Info(UserManager.MessageDescriber.AddPhoneValidationPhoneEmpty));
         _ = PhoneNumber.TryParse(user.PhoneNumber!, out var phone);
         Input.PhoneNumber = phone.Number;
         Input.CallingCode = phone.CallingCode;

--- a/src/Indice.Features.Identity.UI/Pages/AddPhone.cs
+++ b/src/Indice.Features.Identity.UI/Pages/AddPhone.cs
@@ -6,6 +6,7 @@ using Indice.Features.Identity.UI.Filters;
 using Indice.Features.Identity.UI.Models;
 using Indice.Globalization;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 
@@ -49,9 +50,9 @@ public abstract class BaseAddPhoneModel : BasePageModel
     /// <param name="returnUrl">The return URL.</param>
     public virtual async Task<IActionResult> OnGetAsync([FromQuery] string? returnUrl) {
         var user = await UserManager.GetUserAsync(User) ?? throw new InvalidOperationException("User cannot be null.");
-        
+
         TempData.Put(TempDataKey, new AlertModel {
-            Message =  UserManager.MessageDescriber.AddPhoneValidationPhoneEmpty,
+            Message = new HtmlString(UserManager.MessageDescriber.AddPhoneValidationPhoneEmpty),
             AlertType = AlertType.Info
         });
         _ = PhoneNumber.TryParse(user.PhoneNumber!, out var phone);

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/Components/PageHeading/Default.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/Components/PageHeading/Default.cshtml
@@ -14,5 +14,5 @@
     <a class="header-logo" href="/">
         <img class="w-100" src="@Model.ImageSrc" />
     </a>
-    <span indice-if="!string.IsNullOrWhiteSpace(Model.Title?.Value)" class="header-text">@Model.Title</span>
+    <span indice-if="!string.IsNullOrWhiteSpace(Model.Title?.ToString())" class="header-text">@Model.Title</span>
 </h1>

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/Components/PageHeading/Default.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/Components/PageHeading/Default.cshtml
@@ -14,5 +14,5 @@
     <a class="header-logo" href="/">
         <img class="w-100" src="@Model.ImageSrc" />
     </a>
-    <span indice-if="!string.IsNullOrWhiteSpace(Model.Title)" class="header-text">@Model.Title</span>
+    <span indice-if="string.IsNullOrEmpty(Model.Title?.Value)" class="header-text">@Model.Title</span>
 </h1>

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/Components/PageHeading/Default.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/Components/PageHeading/Default.cshtml
@@ -14,5 +14,5 @@
     <a class="header-logo" href="/">
         <img class="w-100" src="@Model.ImageSrc" />
     </a>
-    <span indice-if="string.IsNullOrEmpty(Model.Title?.Value)" class="header-text">@Model.Title</span>
+    <span indice-if="!string.IsNullOrWhiteSpace(Model.Title?.Value)" class="header-text">@Model.Title</span>
 </h1>

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/_Alert.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/_Alert.cshtml
@@ -1,6 +1,6 @@
 ﻿@model AlertModel
 
-@if (!string.IsNullOrEmpty(Model?.Message))
+@if (!string.IsNullOrEmpty(Model?.Message.Value))
 {
     <div class="alert alert-@($"{Model.AlertType}".ToLower())">
         @Model.Message

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/_Alert.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/_Alert.cshtml
@@ -1,6 +1,6 @@
 ﻿@model AlertModel
 
-@if (!string.IsNullOrEmpty(Model?.Message.Value))
+@if (!Model.IsEmpty)
 {
     <div class="alert alert-@($"{Model.AlertType}".ToLower())">
         @Model.Message

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/Components/PageHeading/Default.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/Components/PageHeading/Default.cshtml
@@ -15,7 +15,7 @@
         </div>
     </div>
 </div>
-@if (!string.IsNullOrWhiteSpace(Model.Title))
+@if (!string.IsNullOrWhiteSpace(Model?.Title?.Value))
 {
     <h3>@Settings.Value.ApplicationName</h3>
     <h1>@Model.Title</h1>

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/Components/PageHeading/Default.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/Components/PageHeading/Default.cshtml
@@ -15,7 +15,7 @@
         </div>
     </div>
 </div>
-@if (!string.IsNullOrWhiteSpace(Model?.Title?.Value))
+@if (!string.IsNullOrWhiteSpace(Model.Title?.ToString()))
 {
     <h3>@Settings.Value.ApplicationName</h3>
     <h1>@Model.Title</h1>

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/_Alert.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/_Alert.cshtml
@@ -1,6 +1,6 @@
 ﻿@model AlertModel
 
-@if (!string.IsNullOrEmpty(Model?.Message))
+@if (!string.IsNullOrEmpty(Model?.Message.Value))
 {
     <div class="alert alert-@($"{Model.AlertType}".ToLower())">
         @Model.Message

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/_Alert.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/_Alert.cshtml
@@ -1,6 +1,6 @@
 ﻿@model AlertModel
 
-@if (!string.IsNullOrEmpty(Model?.Message.Value))
+@if (!Model.IsEmpty)
 {
     <div class="alert alert-@($"{Model.AlertType}".ToLower())">
         @Model.Message

--- a/src/Indice.Features.Identity.UI/ViewComponents/PageHeadingViewComponent.cs
+++ b/src/Indice.Features.Identity.UI/ViewComponents/PageHeadingViewComponent.cs
@@ -18,8 +18,8 @@ public class PageHeadingViewComponent : ViewComponent
 
 
     /// <inheritdoc/>
-    public IViewComponentResult Invoke(string? title, string? imageSrc) {
-        return View(new PageHeadingViewModel(new HtmlString(title ?? ""), string.IsNullOrEmpty(imageSrc) ? null : Url.Content(imageSrc)));
+    public IViewComponentResult Invoke(IHtmlContent? title, string? imageSrc) {
+        return View(new PageHeadingViewModel(title, string.IsNullOrEmpty(imageSrc) ? null : Url.Content(imageSrc)));
     }
 
 }

--- a/src/Indice.Features.Identity.UI/ViewComponents/PageHeadingViewComponent.cs
+++ b/src/Indice.Features.Identity.UI/ViewComponents/PageHeadingViewComponent.cs
@@ -1,4 +1,5 @@
 ﻿using Indice.Features.Identity.UI.Models;
+using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Indice.Features.Identity.UI.ViewComponents;
@@ -12,13 +13,13 @@ public class PageHeadingViewComponent : ViewComponent
     /// Constructs the PageHeading view component
     /// </summary>
     public PageHeadingViewComponent() {
-            
+
     }
 
 
     /// <inheritdoc/>
     public IViewComponentResult Invoke(string? title, string? imageSrc) {
-        return View(new PageHeadingViewModel(title, string.IsNullOrEmpty(imageSrc) ? null : Url.Content(imageSrc)));
+        return View(new PageHeadingViewModel(new HtmlString(title ?? ""), string.IsNullOrEmpty(imageSrc) ? null : Url.Content(imageSrc)));
     }
 
 }

--- a/src/Indice.Services/SmsServiceSmsUP.cs
+++ b/src/Indice.Services/SmsServiceSmsUP.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Indice.Globalization;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -16,6 +17,9 @@ public class SmsServiceSmsUp : ISmsService
     internal static readonly string SMSUP_BASE_URL = "https://api.gateway360.com/api/3.0/sms/send";
     /// <summary>The <see cref="System.Net.Http.HttpClient"/>.</summary>
     protected HttpClient HttpClient { get; }
+    /// <summary>The hosting environment.</summary>
+    public IHostEnvironment Environment { get; }
+
     /// <summary>Represents a type used to perform logging.</summary>
     protected ILogger<SmsServiceSmsUp> Logger { get; }
     /// <summary>The settings required to configure the service.</summary>
@@ -24,10 +28,12 @@ public class SmsServiceSmsUp : ISmsService
     /// <inheritdoc/>
     public SmsServiceSmsUp(
         HttpClient httpClient,
+        IHostEnvironment hostEnvironment,
         IOptionsSnapshot<SmsServiceSmsUpSettings> settings,
         ILogger<SmsServiceSmsUp> logger) {
         Settings = settings?.Value ?? throw new ArgumentNullException(nameof(settings));
         HttpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        Environment = hostEnvironment;
         Logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
         ArgumentException.ThrowIfNullOrWhiteSpace(Settings.ApiKey);
@@ -62,7 +68,7 @@ public class SmsServiceSmsUp : ISmsService
                                                 From = sender?.Id ?? Settings.Sender!, // fallback sender
                                                 To = recipient,
                                                 Text = body ?? subject ?? string.Empty,
-                                                Custom = Guid.NewGuid().ToString()
+                                                Custom = $"app:{Environment.ApplicationName}-env:{Environment.EnvironmentName}",
                                             }).ToList();
         var request = new SmsUpRequest {
             ApiKey = Settings.ApiKey!,

--- a/src/Indice.Services/SmsServiceSmsUP.cs
+++ b/src/Indice.Services/SmsServiceSmsUP.cs
@@ -33,7 +33,7 @@ public class SmsServiceSmsUp : ISmsService
         ILogger<SmsServiceSmsUp> logger) {
         Settings = settings?.Value ?? throw new ArgumentNullException(nameof(settings));
         HttpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
-        Environment = hostEnvironment;
+        Environment = hostEnvironment ?? throw new ArgumentNullException(nameof(hostEnvironment));
         Logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
         ArgumentException.ThrowIfNullOrWhiteSpace(Settings.ApiKey);

--- a/test/Indice.Services.Tests/SmsTests.cs
+++ b/test/Indice.Services.Tests/SmsTests.cs
@@ -231,8 +231,15 @@ public class SmsTests
             .AddInMemoryCollection(inMemorySettings)
             .Build();
 
+
+        // Mock IHostEnvironment
+        var hostEnvironmentMock = new Mock<Microsoft.Extensions.Hosting.IHostEnvironment>();
+        hostEnvironmentMock.Setup(x => x.ApplicationName).Returns("TestApplication");
+        hostEnvironmentMock.Setup(x => x.EnvironmentName).Returns("Testing");
+
         var collection = new ServiceCollection()
           .AddSingleton(configuration)
+          .AddSingleton(hostEnvironmentMock.Object) // Add the mocked IHostEnvironment
           .AddOptions()
           .Configure<SmsServiceSmsUpSettings>(configuration.GetSection(SmsServiceSmsUpSettings.Name))
           .AddSmsServiceSmsUp(configuration);


### PR DESCRIPTION
Updated `AlertModel.Message` and `PageHeadingViewModel.Title` to use `HtmlString` for safe handling of HTML content. Refactored static methods, constructors, and views to support the new type. Adjusted null/empty checks in `_Alert.cshtml` and `Default.cshtml` for consistency. Added necessary imports for `Microsoft.AspNetCore.Html` in affected files.