### PR TITLE
[Identity] Enhance rate limiting and add login and secure-page policy

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,11 +4,11 @@
       <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
       <!--<TargetFramework></TargetFramework>-->
       <VersionPrefixMajor>8</VersionPrefixMajor>
-      <VersionPrefixBase>$(VersionPrefixMajor).22</VersionPrefixBase>
+      <VersionPrefixBase>$(VersionPrefixMajor).23</VersionPrefixBase>
 
       <VersionPrefixCore>$(VersionPrefixBase).0</VersionPrefixCore>
       <VersionPrefixIdentity>$(VersionPrefixBase).0</VersionPrefixIdentity>
-      <VersionPrefixIdentityUI>$(VersionPrefixBase).1</VersionPrefixIdentityUI>
+      <VersionPrefixIdentityUI>$(VersionPrefixBase).0</VersionPrefixIdentityUI>
       <VersionPrefixCases>$(VersionPrefixBase).0</VersionPrefixCases>
       <VersionPrefixMessages>$(VersionPrefixBase).0</VersionPrefixMessages>
       <VersionPrefixMultitenancy>$(VersionPrefixBase).0</VersionPrefixMultitenancy>

--- a/src/Indice.Features.Identity.Server/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Indice.Features.Identity.Server/Extensions/ServiceCollectionExtensions.cs
@@ -36,7 +36,6 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -44,6 +43,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.FeatureManagement;
 using Microsoft.IdentityModel.Logging;
 using Indice.Features.Identity.Core.IdentityValidation;
+using IdentityServer4.Configuration;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -414,11 +414,15 @@ public static class IdentityServerEndpointServiceCollectionExtensions
         services.AddRateLimiter(rateLimiterOptions => {
             foreach (var endpoint in IdentityEndpoints.RateLimiter.Endpoints) {
                 var endpointOptions = identityRateLimiterOptions.Rules.FirstOrDefault(rule => rule.Endpoint == endpoint) ?? RateLimiterEndpointRule.Default();
-                rateLimiterOptions.AddFixedWindowLimiter(endpoint, fixedWindowOptions => {
-                    fixedWindowOptions.PermitLimit = endpointOptions.PermitLimit.GetValueOrDefault();
-                    fixedWindowOptions.QueueLimit = endpointOptions.QueueLimit.GetValueOrDefault();
-                    fixedWindowOptions.QueueProcessingOrder = endpointOptions.QueueProcessingOrder.GetValueOrDefault();
-                    fixedWindowOptions.Window = endpointOptions.Window.GetValueOrDefault();
+                rateLimiterOptions.AddPolicy(endpoint, context => {
+                    return RateLimitPartition.GetFixedWindowLimiter(
+                        partitionKey: context.User.FindSubjectId() ?? context.Connection.RemoteIpAddress?.ToString() ?? context.Request.Headers.Host.ToString(), 
+                        factory: _ => new FixedWindowRateLimiterOptions {
+                            PermitLimit = endpointOptions.PermitLimit.GetValueOrDefault(),
+                            QueueLimit = endpointOptions.QueueLimit.GetValueOrDefault(),
+                            QueueProcessingOrder = endpointOptions.QueueProcessingOrder.GetValueOrDefault(),
+                            Window = endpointOptions.Window.GetValueOrDefault()
+                        });
                 });
             }
             rateLimiterOptions.RejectionStatusCode = identityRateLimiterOptions.RejectionStatusCode.GetValueOrDefault();

--- a/src/Indice.Features.Identity.Server/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Indice.Features.Identity.Server/Extensions/ServiceCollectionExtensions.cs
@@ -43,7 +43,6 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.FeatureManagement;
 using Microsoft.IdentityModel.Logging;
 using Indice.Features.Identity.Core.IdentityValidation;
-using IdentityServer4.Configuration;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -413,10 +412,13 @@ public static class IdentityServerEndpointServiceCollectionExtensions
         configuration.GetSection(IdentityRateLimiterOptions.SectionName).Bind(identityRateLimiterOptions);
         services.AddRateLimiter(rateLimiterOptions => {
             foreach (var endpoint in IdentityEndpoints.RateLimiter.Endpoints) {
-                var endpointOptions = identityRateLimiterOptions.Rules.FirstOrDefault(rule => rule.Endpoint == endpoint) ?? RateLimiterEndpointRule.Default();
+                var endpointOptions = identityRateLimiterOptions.Rules.FirstOrDefault(rule => rule.Endpoint == endpoint) ?? RateLimiterEndpointRule.Default(endpoint);
                 rateLimiterOptions.AddPolicy(endpoint, context => {
+                    if (!endpointOptions.CanLimitHttpMethod(context.Request.Method)) {
+                        return RateLimitPartition.GetNoLimiter("NoRateLimiting");
+                    }
                     return RateLimitPartition.GetFixedWindowLimiter(
-                        partitionKey: context.User.FindSubjectId() ?? context.Connection.RemoteIpAddress?.ToString() ?? context.Request.Headers.Host.ToString(), 
+                        partitionKey: context.User.FindSubjectId() ?? context.Connection.RemoteIpAddress?.ToString() ?? context.Request.Headers.Host.ToString(),
                         factory: _ => new FixedWindowRateLimiterOptions {
                             PermitLimit = endpointOptions.PermitLimit.GetValueOrDefault(),
                             QueueLimit = endpointOptions.QueueLimit.GetValueOrDefault(),

--- a/src/Indice.Features.Identity.Server/Manager/IdentityEndpoints.cs
+++ b/src/Indice.Features.Identity.Server/Manager/IdentityEndpoints.cs
@@ -77,7 +77,8 @@ public static partial class IdentityEndpoints
             "my/account/phone-number/confirmation",
             "my/account/email/change-confirmation",
             "my/account/phone-number/change-confirmation",
-            "public-page" // this is the policy name for the public Razor Pages 
+            "secure-page", // this is the generic policy name for any public Razor Pages that require throttling
+            "login" 
     };
 
         public static class Policies

--- a/src/Indice.Features.Identity.Server/Manager/IdentityEndpoints.cs
+++ b/src/Indice.Features.Identity.Server/Manager/IdentityEndpoints.cs
@@ -76,8 +76,9 @@ public static partial class IdentityEndpoints
             "my/account/email/confirmation",
             "my/account/phone-number/confirmation",
             "my/account/email/change-confirmation",
-            "my/account/phone-number/change-confirmation"
-        };
+            "my/account/phone-number/change-confirmation",
+            "public-page" // this is the policy name for the public Razor Pages 
+    };
 
         public static class Policies
         {
@@ -97,6 +98,7 @@ public static partial class IdentityEndpoints
             public static readonly string PhoneNumberConfirmation = Endpoints[13];
             public static readonly string EmailChangeConfirmation = Endpoints[14];
             public static readonly string ChangePhoneNumberConfirmation = Endpoints[15];
+            public static readonly string PublicPage = Endpoints[16];
         }
     }
 }

--- a/src/Indice.Features.Identity.Server/Options/IdentityRateLimiterOptions.cs
+++ b/src/Indice.Features.Identity.Server/Options/IdentityRateLimiterOptions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.RateLimiting;
 using Microsoft.AspNetCore.Http;
+using Polly;
 
 namespace Indice.Features.Identity.Server.Options;
 
@@ -29,5 +30,19 @@ public class RateLimiterEndpointRule
     public TimeSpan? Window { get; set; } = TimeSpan.FromSeconds(1);
 
     /// <summary>Default configuration for <see cref="RateLimiterEndpointRule"/>.</summary>
-    public static RateLimiterEndpointRule Default() => new();
+    public static RateLimiterEndpointRule Default(string? policyName = null) => policyName switch {
+        "secure-page" => new() { PermitLimit = 5, Window = TimeSpan.FromSeconds(1), HttpMethod = "POST" },
+        "login" => new() { PermitLimit = 5, Window = TimeSpan.FromSeconds(1), HttpMethod = "POST" },
+        _ => new()
+    };
+
+    /// <summary>The Http method of the endpoint to apply the rate limiter. Optional.</summary>
+    public string? HttpMethod { get; set; }
+
+    /// <summary>Determines whether <see cref="HttpMethod"/> has a value.</summary>
+    public bool HasHttpMehtod => !string.IsNullOrWhiteSpace(HttpMethod);
+
+    /// <summary>Determines whether the rate limiter can be applied based on the http method.</summary>
+    public bool CanLimitHttpMethod(string? httpMethod) =>
+        !HasHttpMehtod || string.Equals(HttpMethod, httpMethod, StringComparison.OrdinalIgnoreCase);
 }

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/ForgotPassword.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/ForgotPassword.cshtml
@@ -1,4 +1,5 @@
 ﻿@page "/forgot-password"
+@attribute [Microsoft.AspNetCore.RateLimiting.EnableRateLimiting("public-page")]
 
 @model BaseForgotPasswordModel
 

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/ForgotPassword.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/ForgotPassword.cshtml
@@ -1,5 +1,5 @@
 ﻿@page "/forgot-password"
-@attribute [Microsoft.AspNetCore.RateLimiting.EnableRateLimiting("public-page")]
+@attribute [Microsoft.AspNetCore.RateLimiting.EnableRateLimiting("secure-page")]
 
 @model BaseForgotPasswordModel
 

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Login.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Login.cshtml
@@ -1,4 +1,5 @@
 ﻿@page "/login"
+@attribute [Microsoft.AspNetCore.RateLimiting.EnableRateLimiting("login")]
 
 @model BaseLoginModel
 

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Register.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Register.cshtml
@@ -1,4 +1,5 @@
 ﻿@page "/register"
+@attribute [Microsoft.AspNetCore.RateLimiting.EnableRateLimiting("public-page")]
 
 @model BaseRegisterModel
 

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Register.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Register.cshtml
@@ -1,5 +1,5 @@
 ﻿@page "/register"
-@attribute [Microsoft.AspNetCore.RateLimiting.EnableRateLimiting("public-page")]
+@attribute [Microsoft.AspNetCore.RateLimiting.EnableRateLimiting("secure-page")]
 
 @model BaseRegisterModel
 

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/ForgotPassword.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/ForgotPassword.cshtml
@@ -1,4 +1,5 @@
 ﻿@page "/forgot-password"
+@attribute [Microsoft.AspNetCore.RateLimiting.EnableRateLimiting("public-page")]
 
 @model BaseForgotPasswordModel
 

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/ForgotPassword.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/ForgotPassword.cshtml
@@ -1,5 +1,5 @@
 ﻿@page "/forgot-password"
-@attribute [Microsoft.AspNetCore.RateLimiting.EnableRateLimiting("public-page")]
+@attribute [Microsoft.AspNetCore.RateLimiting.EnableRateLimiting("secure-page")]
 
 @model BaseForgotPasswordModel
 

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/Login.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/Login.cshtml
@@ -1,4 +1,5 @@
 ﻿@page "/login"
+@attribute [Microsoft.AspNetCore.RateLimiting.EnableRateLimiting("login")]
 
 @model BaseLoginModel
 

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/Register.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/Register.cshtml
@@ -1,4 +1,5 @@
 ﻿@page "/register"
+@attribute [Microsoft.AspNetCore.RateLimiting.EnableRateLimiting("public-page")]
 
 @model BaseRegisterModel
 

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/Register.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/Register.cshtml
@@ -1,5 +1,5 @@
 ﻿@page "/register"
-@attribute [Microsoft.AspNetCore.RateLimiting.EnableRateLimiting("public-page")]
+@attribute [Microsoft.AspNetCore.RateLimiting.EnableRateLimiting("secure-page")]
 
 @model BaseRegisterModel
 


### PR DESCRIPTION
### Changes
- Updated rate limiter to use `RateLimitPartition.GetFixedWindowLimiter` for dynamic, user-specific rate limiting.

### Added
- Introduced `public-page` endpoint and corresponding policy in `IdentityEndpoints`.
- Applied `public-page` rate-limiting policy to `ForgotPassword.cshtml` and `Register.cshtml` Razor Pages.