### PR TITLE
[identity] Password expired page separate message for initial password vs expired

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,7 +4,7 @@
       <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
       <!--<TargetFramework></TargetFramework>-->
       <VersionPrefixMajor>8</VersionPrefixMajor>
-      <VersionPrefixBase>$(VersionPrefixMajor).26</VersionPrefixBase>
+      <VersionPrefixBase>$(VersionPrefixMajor).27</VersionPrefixBase>
 
       <VersionPrefixCore>$(VersionPrefixBase).0</VersionPrefixCore>
       <VersionPrefixIdentity>$(VersionPrefixBase).0</VersionPrefixIdentity>

--- a/src/Indice.Features.Identity.Core/IdentityMessageDescriber.cs
+++ b/src/Indice.Features.Identity.Core/IdentityMessageDescriber.cs
@@ -125,7 +125,7 @@ public class IdentityMessageDescriber
     public virtual string PasswordExpiredMessage => IdentityResources.PasswordExpiredMessage;
 
     /// <summary>Choose Password message for new users.</summary>
-    public virtual string PasswordInitMessage => IdentityResources.PasswordInitMessage;
+    public virtual string PasswordExpiredNewUserMessage => IdentityResources.PasswordExpiredNewUserMessage;
     
     /// <summary>Profile external login added success message.</summary>
     public virtual string ProfileExternalLoginAddedSuccessMessage => IdentityResources.ProfileExternalLoginAddedSuccessMessage;

--- a/src/Indice.Features.Identity.Core/IdentityMessageDescriber.cs
+++ b/src/Indice.Features.Identity.Core/IdentityMessageDescriber.cs
@@ -125,7 +125,7 @@ public class IdentityMessageDescriber
     public virtual string PasswordExpiredMessage => IdentityResources.PasswordExpiredMessage;
 
     /// <summary>Choose Password message for new users.</summary>
-    public virtual string PasswordExpiredNewUserMessage => IdentityResources.PasswordExpiredNewUserMessage;
+    public virtual string PasswordExpiredFirstTimeUserMessage => IdentityResources.PasswordExpiredFirstTimeUserMessage;
     
     /// <summary>Profile external login added success message.</summary>
     public virtual string ProfileExternalLoginAddedSuccessMessage => IdentityResources.ProfileExternalLoginAddedSuccessMessage;

--- a/src/Indice.Features.Identity.Core/IdentityMessageDescriber.cs
+++ b/src/Indice.Features.Identity.Core/IdentityMessageDescriber.cs
@@ -123,6 +123,10 @@ public class IdentityMessageDescriber
     public virtual string PasswordChangedSuccessfully => IdentityResources.PasswordChangedSuccessfully;
     /// <summary>Password expired message.</summary>
     public virtual string PasswordExpiredMessage => IdentityResources.PasswordExpiredMessage;
+
+    /// <summary>Choose Password message for new users.</summary>
+    public virtual string PasswordInitMessage => IdentityResources.PasswordInitMessage;
+    
     /// <summary>Profile external login added success message.</summary>
     public virtual string ProfileExternalLoginAddedSuccessMessage => IdentityResources.ProfileExternalLoginAddedSuccessMessage;
     /// <summary>Registration phone confriamtion message prompt</summary>

--- a/src/Indice.Features.Identity.Core/IdentityResources.Designer.cs
+++ b/src/Indice.Features.Identity.Core/IdentityResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Indice.Features.Identity.Core {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class IdentityResources {
@@ -417,6 +417,15 @@ namespace Indice.Features.Identity.Core {
         internal static string PasswordExpiredMessage {
             get {
                 return ResourceManager.GetString("PasswordExpiredMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Please choose your new password to continue..
+        /// </summary>
+        internal static string PasswordInitMessage {
+            get {
+                return ResourceManager.GetString("PasswordInitMessage", resourceCulture);
             }
         }
         

--- a/src/Indice.Features.Identity.Core/IdentityResources.Designer.cs
+++ b/src/Indice.Features.Identity.Core/IdentityResources.Designer.cs
@@ -423,9 +423,9 @@ namespace Indice.Features.Identity.Core {
         /// <summary>
         ///   Looks up a localized string similar to Please choose your new password to continue..
         /// </summary>
-        internal static string PasswordExpiredNewUserMessage {
+        internal static string PasswordExpiredFirstTimeUserMessage {
             get {
-                return ResourceManager.GetString("PasswordExpiredNewUserMessage", resourceCulture);
+                return ResourceManager.GetString("PasswordExpiredFirstTimeUserMessage", resourceCulture);
             }
         }
         

--- a/src/Indice.Features.Identity.Core/IdentityResources.Designer.cs
+++ b/src/Indice.Features.Identity.Core/IdentityResources.Designer.cs
@@ -423,9 +423,9 @@ namespace Indice.Features.Identity.Core {
         /// <summary>
         ///   Looks up a localized string similar to Please choose your new password to continue..
         /// </summary>
-        internal static string PasswordInitMessage {
+        internal static string PasswordExpiredNewUserMessage {
             get {
-                return ResourceManager.GetString("PasswordInitMessage", resourceCulture);
+                return ResourceManager.GetString("PasswordExpiredNewUserMessage", resourceCulture);
             }
         }
         

--- a/src/Indice.Features.Identity.Core/IdentityResources.el.resx
+++ b/src/Indice.Features.Identity.Core/IdentityResources.el.resx
@@ -417,7 +417,7 @@
   <data name="PasswordChangedEventDescription" xml:space="preserve">
     <value>Ο κωδικός πρόσβασής σας έχει αλλάξει επιτυχώς.</value>
   </data>
-  <data name="PasswordInitMessage" xml:space="preserve">
+  <data name="PasswordExpiredNewUserMessage" xml:space="preserve">
     <value>Παρακαλώ επιλέξτε το νέο σας κωδικό πρόσβασης για να συνεχίσετε.</value>
   </data>
 </root>

--- a/src/Indice.Features.Identity.Core/IdentityResources.el.resx
+++ b/src/Indice.Features.Identity.Core/IdentityResources.el.resx
@@ -417,4 +417,7 @@
   <data name="PasswordChangedEventDescription" xml:space="preserve">
     <value>Ο κωδικός πρόσβασής σας έχει αλλάξει επιτυχώς.</value>
   </data>
+  <data name="PasswordInitMessage" xml:space="preserve">
+    <value>Παρακαλώ επιλέξτε το νέο σας κωδικό πρόσβασης για να συνεχίσετε.</value>
+  </data>
 </root>

--- a/src/Indice.Features.Identity.Core/IdentityResources.el.resx
+++ b/src/Indice.Features.Identity.Core/IdentityResources.el.resx
@@ -417,7 +417,7 @@
   <data name="PasswordChangedEventDescription" xml:space="preserve">
     <value>Ο κωδικός πρόσβασής σας έχει αλλάξει επιτυχώς.</value>
   </data>
-  <data name="PasswordExpiredNewUserMessage" xml:space="preserve">
+  <data name="PasswordExpiredFirstTimeUserMessage" xml:space="preserve">
     <value>Παρακαλώ επιλέξτε το νέο σας κωδικό πρόσβασης για να συνεχίσετε.</value>
   </data>
 </root>

--- a/src/Indice.Features.Identity.Core/IdentityResources.es.resx
+++ b/src/Indice.Features.Identity.Core/IdentityResources.es.resx
@@ -417,7 +417,7 @@
   <data name="PasswordChangedEventDescription" xml:space="preserve">
     <value>Su contraseña ha sido cambiada exitosamente.</value>
   </data>
-  <data name="PasswordExpiredNewUserMessage" xml:space="preserve">
+  <data name="PasswordExpiredFirstTimeUserMessage" xml:space="preserve">
     <value>Por favor, elija su nueva contraseña para continuar.</value>
   </data>
 </root>

--- a/src/Indice.Features.Identity.Core/IdentityResources.es.resx
+++ b/src/Indice.Features.Identity.Core/IdentityResources.es.resx
@@ -417,7 +417,7 @@
   <data name="PasswordChangedEventDescription" xml:space="preserve">
     <value>Su contraseña ha sido cambiada exitosamente.</value>
   </data>
-  <data name="PasswordInitMessage" xml:space="preserve">
+  <data name="PasswordExpiredNewUserMessage" xml:space="preserve">
     <value>Por favor, elija su nueva contraseña para continuar.</value>
   </data>
 </root>

--- a/src/Indice.Features.Identity.Core/IdentityResources.es.resx
+++ b/src/Indice.Features.Identity.Core/IdentityResources.es.resx
@@ -417,4 +417,7 @@
   <data name="PasswordChangedEventDescription" xml:space="preserve">
     <value>Su contraseña ha sido cambiada exitosamente.</value>
   </data>
+  <data name="PasswordInitMessage" xml:space="preserve">
+    <value>Por favor, elija su nueva contraseña para continuar.</value>
+  </data>
 </root>

--- a/src/Indice.Features.Identity.Core/IdentityResources.it.resx
+++ b/src/Indice.Features.Identity.Core/IdentityResources.it.resx
@@ -417,4 +417,7 @@
   <data name="PasswordChangedEventDescription" xml:space="preserve">
     <value>La tua password è stata modificata con successo.</value>
   </data>
+  <data name="PasswordInitMessage" xml:space="preserve">
+    <value>Per favore, scegli la tua nuova password per continuare.</value>
+  </data>
 </root>

--- a/src/Indice.Features.Identity.Core/IdentityResources.it.resx
+++ b/src/Indice.Features.Identity.Core/IdentityResources.it.resx
@@ -417,7 +417,7 @@
   <data name="PasswordChangedEventDescription" xml:space="preserve">
     <value>La tua password è stata modificata con successo.</value>
   </data>
-  <data name="PasswordInitMessage" xml:space="preserve">
+  <data name="PasswordExpiredNewUserMessage" xml:space="preserve">
     <value>Per favore, scegli la tua nuova password per continuare.</value>
   </data>
 </root>

--- a/src/Indice.Features.Identity.Core/IdentityResources.it.resx
+++ b/src/Indice.Features.Identity.Core/IdentityResources.it.resx
@@ -417,7 +417,7 @@
   <data name="PasswordChangedEventDescription" xml:space="preserve">
     <value>La tua password è stata modificata con successo.</value>
   </data>
-  <data name="PasswordExpiredNewUserMessage" xml:space="preserve">
+  <data name="PasswordExpiredFirstTimeUserMessage" xml:space="preserve">
     <value>Per favore, scegli la tua nuova password per continuare.</value>
   </data>
 </root>

--- a/src/Indice.Features.Identity.Core/IdentityResources.ja.resx
+++ b/src/Indice.Features.Identity.Core/IdentityResources.ja.resx
@@ -417,4 +417,7 @@
   <data name="PasswordChangedEventDescription" xml:space="preserve">
     <value>パスワードが正常に変更されました。</value>
   </data>
+  <data name="PasswordInitMessage" xml:space="preserve">
+    <value>続行するには、新しいパスワードを選択してください。</value>
+  </data>
 </root>

--- a/src/Indice.Features.Identity.Core/IdentityResources.ja.resx
+++ b/src/Indice.Features.Identity.Core/IdentityResources.ja.resx
@@ -417,7 +417,7 @@
   <data name="PasswordChangedEventDescription" xml:space="preserve">
     <value>パスワードが正常に変更されました。</value>
   </data>
-  <data name="PasswordExpiredNewUserMessage" xml:space="preserve">
+  <data name="PasswordExpiredFirstTimeUserMessage" xml:space="preserve">
     <value>続行するには、新しいパスワードを選択してください。</value>
   </data>
 </root>

--- a/src/Indice.Features.Identity.Core/IdentityResources.ja.resx
+++ b/src/Indice.Features.Identity.Core/IdentityResources.ja.resx
@@ -417,7 +417,7 @@
   <data name="PasswordChangedEventDescription" xml:space="preserve">
     <value>パスワードが正常に変更されました。</value>
   </data>
-  <data name="PasswordInitMessage" xml:space="preserve">
+  <data name="PasswordExpiredNewUserMessage" xml:space="preserve">
     <value>続行するには、新しいパスワードを選択してください。</value>
   </data>
 </root>

--- a/src/Indice.Features.Identity.Core/IdentityResources.resx
+++ b/src/Indice.Features.Identity.Core/IdentityResources.resx
@@ -461,4 +461,7 @@
   <data name="PasswordChangedEventDescription" xml:space="preserve">
     <value>Your password has been successfully changed.</value>
   </data>
+  <data name="PasswordInitMessage" xml:space="preserve">
+    <value>Please choose your new password to continue.</value>
+  </data>
 </root>

--- a/src/Indice.Features.Identity.Core/IdentityResources.resx
+++ b/src/Indice.Features.Identity.Core/IdentityResources.resx
@@ -461,7 +461,7 @@
   <data name="PasswordChangedEventDescription" xml:space="preserve">
     <value>Your password has been successfully changed.</value>
   </data>
-  <data name="PasswordExpiredNewUserMessage" xml:space="preserve">
+  <data name="PasswordExpiredFirstTimeUserMessage" xml:space="preserve">
     <value>Please choose your new password to continue.</value>
   </data>
 </root>

--- a/src/Indice.Features.Identity.Core/IdentityResources.resx
+++ b/src/Indice.Features.Identity.Core/IdentityResources.resx
@@ -461,7 +461,7 @@
   <data name="PasswordChangedEventDescription" xml:space="preserve">
     <value>Your password has been successfully changed.</value>
   </data>
-  <data name="PasswordInitMessage" xml:space="preserve">
+  <data name="PasswordExpiredNewUserMessage" xml:space="preserve">
     <value>Please choose your new password to continue.</value>
   </data>
 </root>

--- a/src/Indice.Features.Identity.SignInLogs/EventHandlers/AccountLockedEventHandler.cs
+++ b/src/Indice.Features.Identity.SignInLogs/EventHandlers/AccountLockedEventHandler.cs
@@ -17,6 +17,7 @@ using Indice.Features.Identity.SignInLogs.Events;
 using Indice.Features.GeoIP;
 using Indice.Security;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Net.Http.Headers;
 
 namespace Indice.Features.Identity.SignInLogs.EventHandlers;
 
@@ -64,6 +65,11 @@ public sealed class AccountLockedEventHandler : IPlatformEventHandler<AccountLoc
         if (!deviceId.IsEmpty) {
             // If the device id is available populate data.
             device = await userManager.GetDeviceByIdAsync(user!, deviceId.Value!);
+
+        }
+        if (device is null) {
+            var userAgentHeader = _httpContextAccessor?.HttpContext?.Request.Headers[HeaderNames.UserAgent];
+            device = UserDevice.FromUserAgent(userAgentHeader!, deviceId, user.Id, 1);
         }
         Client? client = null;
         if (!string.IsNullOrWhiteSpace(clientId)) {

--- a/src/Indice.Features.Identity.SignInLogs/EventHandlers/AccountLockedEventHandler.cs
+++ b/src/Indice.Features.Identity.SignInLogs/EventHandlers/AccountLockedEventHandler.cs
@@ -65,11 +65,12 @@ public sealed class AccountLockedEventHandler : IPlatformEventHandler<AccountLoc
         if (!deviceId.IsEmpty) {
             // If the device id is available populate data.
             device = await userManager.GetDeviceByIdAsync(user!, deviceId.Value!);
-
         }
         if (device is null) {
             var userAgentHeader = _httpContextAccessor?.HttpContext?.Request.Headers[HeaderNames.UserAgent];
-            device = UserDevice.FromUserAgent(userAgentHeader!, deviceId, user.Id, 1);
+            if (!string.IsNullOrWhiteSpace(userAgentHeader)) {
+                device = UserDevice.FromUserAgent(userAgentHeader!, deviceId, user.Id, 0);
+            }
         }
         Client? client = null;
         if (!string.IsNullOrWhiteSpace(clientId)) {

--- a/src/Indice.Features.Identity.SignInLogs/EventHandlers/UserPasswordChangedEventHandler.cs
+++ b/src/Indice.Features.Identity.SignInLogs/EventHandlers/UserPasswordChangedEventHandler.cs
@@ -17,6 +17,7 @@ using Indice.Features.Identity.SignInLogs.Events;
 using Indice.Features.GeoIP;
 using Indice.Security;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Net.Http.Headers;
 
 namespace Indice.Features.Identity.SignInLogs.EventHandlers;
 
@@ -64,6 +65,10 @@ public sealed class UserPasswordChangedEventHandler : IPlatformEventHandler<Pass
         if (!deviceId.IsEmpty) {
             // If the device id is available polulate data.
             device = await userManager.GetDeviceByIdAsync(user!, deviceId.Value!);
+        }
+        if (device is null) {
+            var userAgentHeader = _httpContextAccessor?.HttpContext?.Request.Headers[HeaderNames.UserAgent];
+            device = UserDevice.FromUserAgent(userAgentHeader!, deviceId, user.Id, 1);
         }
         Client? client = null;
         if (!string.IsNullOrWhiteSpace(clientId)) {

--- a/src/Indice.Features.Identity.SignInLogs/EventHandlers/UserPasswordChangedEventHandler.cs
+++ b/src/Indice.Features.Identity.SignInLogs/EventHandlers/UserPasswordChangedEventHandler.cs
@@ -63,12 +63,14 @@ public sealed class UserPasswordChangedEventHandler : IPlatformEventHandler<Pass
 
         UserDevice? device = null;
         if (!deviceId.IsEmpty) {
-            // If the device id is available polulate data.
+            // If the device id is available populate data.
             device = await userManager.GetDeviceByIdAsync(user!, deviceId.Value!);
         }
         if (device is null) {
             var userAgentHeader = _httpContextAccessor?.HttpContext?.Request.Headers[HeaderNames.UserAgent];
-            device = UserDevice.FromUserAgent(userAgentHeader!, deviceId, user.Id, 1);
+            if (!string.IsNullOrWhiteSpace(userAgentHeader)) {
+                device = UserDevice.FromUserAgent(userAgentHeader!, deviceId, user.Id, 0);
+            }
         }
         Client? client = null;
         if (!string.IsNullOrWhiteSpace(clientId)) {

--- a/src/Indice.Features.Identity.UI/Pages/PasswordExpired.cs
+++ b/src/Indice.Features.Identity.UI/Pages/PasswordExpired.cs
@@ -45,7 +45,6 @@ public abstract class BasePasswordExpiredModel : BasePageModel
     /// <summary>Extended validation password expired page GET handler.</summary>
     /// <param name="returnUrl">The return URL.</param>
     public virtual async Task<IActionResult> OnGetAsync([FromQuery] string? returnUrl) {
-        await Task.CompletedTask;
         var user = await UserManager.GetUserAsync(User) ?? throw new InvalidOperationException("User cannot be null.");
         var message = user.LastSignInDate is null ?
             UserManager.MessageDescriber.PasswordInitMessage :

--- a/src/Indice.Features.Identity.UI/Pages/PasswordExpired.cs
+++ b/src/Indice.Features.Identity.UI/Pages/PasswordExpired.cs
@@ -47,7 +47,7 @@ public abstract class BasePasswordExpiredModel : BasePageModel
     public virtual async Task<IActionResult> OnGetAsync([FromQuery] string? returnUrl) {
         var user = await UserManager.GetUserAsync(User) ?? throw new InvalidOperationException("User cannot be null.");
         var message = user.LastSignInDate is null ?
-            UserManager.MessageDescriber.PasswordInitMessage :
+            UserManager.MessageDescriber.PasswordExpiredNewUserMessage :
             UserManager.MessageDescriber.PasswordExpiredMessage;
         TempData.Put(TempDataKey, new ExtendedValidationTempDataModel {
             Alert = AlertModel.Info(message)

--- a/src/Indice.Features.Identity.UI/Pages/PasswordExpired.cs
+++ b/src/Indice.Features.Identity.UI/Pages/PasswordExpired.cs
@@ -46,8 +46,12 @@ public abstract class BasePasswordExpiredModel : BasePageModel
     /// <param name="returnUrl">The return URL.</param>
     public virtual async Task<IActionResult> OnGetAsync([FromQuery] string? returnUrl) {
         await Task.CompletedTask;
+        var user = await UserManager.GetUserAsync(User) ?? throw new InvalidOperationException("User cannot be null.");
+        var message = user.LastSignInDate is null ?
+            UserManager.MessageDescriber.PasswordInitMessage :
+            UserManager.MessageDescriber.PasswordExpiredMessage;
         TempData.Put(TempDataKey, new ExtendedValidationTempDataModel {
-            Alert = AlertModel.Info(UserManager.MessageDescriber.PasswordExpiredMessage)
+            Alert = AlertModel.Info(message)
         });
         Input.ReturnUrl = returnUrl;
         return Page();

--- a/src/Indice.Features.Identity.UI/Pages/PasswordExpired.cs
+++ b/src/Indice.Features.Identity.UI/Pages/PasswordExpired.cs
@@ -47,7 +47,7 @@ public abstract class BasePasswordExpiredModel : BasePageModel
     public virtual async Task<IActionResult> OnGetAsync([FromQuery] string? returnUrl) {
         var user = await UserManager.GetUserAsync(User) ?? throw new InvalidOperationException("User cannot be null.");
         var message = user.LastSignInDate is null ?
-            UserManager.MessageDescriber.PasswordExpiredNewUserMessage :
+            UserManager.MessageDescriber.PasswordExpiredFirstTimeUserMessage :
             UserManager.MessageDescriber.PasswordExpiredMessage;
         TempData.Put(TempDataKey, new ExtendedValidationTempDataModel {
             Alert = AlertModel.Info(message)


### PR DESCRIPTION
Introduced a new `PasswordInitMessage` property in `IdentityMessageDescriber` to support messaging for new users setting their initial password. Added localized versions of this message in multiple resource files.

Enhanced `AccountLockedEventHandler` and `UserPasswordChangedEventHandler` to handle cases where `UserDevice` is null by creating a `UserDevice` instance using the `UserAgent` header.

Updated `PasswordExpired.cs` to dynamically select the appropriate message (`PasswordInitMessage` or `PasswordExpiredMessage`) based on the user's sign-in history.