### PR TITLE
[messages] Fix hardcoded wrong message in edit template

### DIFF
--- a/src/Indice.Features.Messages.App/src/app/features/templates/edit/details/rightpane/template-edit-details-rightpane.component.html
+++ b/src/Indice.Features.Messages.App/src/app/features/templates/edit/details/rightpane/template-edit-details-rightpane.component.html
@@ -1,4 +1,3 @@
-.\..\..\AppData\Local\Temp\TFSTemp\vctmp19464_519056.template-edit-details-rightpane.component.2cfe7e3c.Result.html
 <lib-side-view-layout [title]="'Templates.EditTemplateDialogTitle' | translate"
                       [ok-close-dialog]="false"
                       [ok-label]="'Templates.Save' | translate"


### PR DESCRIPTION
There was some hardcoded - wrong text on the top of the page.