### PR TITLE
[cases] Add UserToContactMeta and enhance ownership logic

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,7 +9,7 @@
       <VersionPrefixCore>$(VersionPrefixBase).0</VersionPrefixCore>
       <VersionPrefixIdentity>$(VersionPrefixBase).0</VersionPrefixIdentity>
       <VersionPrefixIdentityUI>$(VersionPrefixBase).0</VersionPrefixIdentityUI>
-      <VersionPrefixCases>$(VersionPrefixBase).1</VersionPrefixCases>
+      <VersionPrefixCases>$(VersionPrefixBase).2</VersionPrefixCases>
       <VersionPrefixMessages>$(VersionPrefixBase).1</VersionPrefixMessages>
       <VersionPrefixMultitenancy>$(VersionPrefixBase).0</VersionPrefixMultitenancy>
       <VersionPrefixRisk>$(VersionPrefixBase).0</VersionPrefixRisk>

--- a/src/Indice.Features.Cases.Core/Extensions/ClaimsPrincipalExtensions.cs
+++ b/src/Indice.Features.Cases.Core/Extensions/ClaimsPrincipalExtensions.cs
@@ -72,5 +72,23 @@ public static class CasesClaimsPrincipalExtensions
         };
     }
 
+    /// <summary>
+    /// Get <see cref="ContactMeta"/> from a ClaimsPrincipal.
+    /// </summary>
+    /// <param name="user">The claims principal.</param>
+    /// <param name="options">Case options settings</param>
+    /// <returns></returns>
+    /// <summary>Creates a http <see cref="UserActor"/> model from the current user.</summary>
+    public static ContactMeta UserToContactMeta(this ClaimsPrincipal user, CasesOptions options) {
+        var subject = user.FindFirstValue(BasicClaimTypes.Subject);
+        return new ContactMeta {
+            UserId = string.IsNullOrWhiteSpace(subject) ? user.FindFirstValue(BasicClaimTypes.ClientId)! : subject,
+            Reference = user.FindFirstValue(options.ReferenceIdClaimType),
+            FirstName = string.IsNullOrWhiteSpace(subject) ? CasesCoreConstants.SystemUserName : $"{user.FindFirstValue(BasicClaimTypes.GivenName)}".Trim(),
+            LastName = string.IsNullOrWhiteSpace(subject) ? "" : $"{user.FindFirstValue(BasicClaimTypes.FamilyName)}".Trim(),
+            Tin = user.FindFirstValue(options.TinClaimType)
+        };
+    }
+
 
 }

--- a/src/Indice.Features.Cases.Server/Authorization/CasesAccessOwnerHandler.cs
+++ b/src/Indice.Features.Cases.Server/Authorization/CasesAccessOwnerHandler.cs
@@ -14,8 +14,7 @@ using Microsoft.Extensions.Options;
 namespace Indice.Features.Cases.Server.Authorization;
 
 /// <summary>This authorization requirement specifies that an endpoint must be accessible only to case Owners.</summary>
-public class CasesAccessOwnerHandler : AuthorizationHandler<CasesOwnerAccessRequirement>, IAuthorizationRequirement
-{
+public class CasesAccessOwnerHandler : AuthorizationHandler<CasesOwnerAccessRequirement>, IAuthorizationRequirement {
     private readonly IDistributedCache _cache;
     private readonly CasesDbContext dbContext;
     private readonly ILogger<CasesAccessOwnerHandler> _logger;
@@ -79,7 +78,7 @@ public class CasesAccessOwnerHandler : AuthorizationHandler<CasesOwnerAccessRequ
             bool.TryParse(value, out isOwner);
             return isOwner;
         }
-        isOwner = await dbContext.Cases.AnyAsync(c => c.Id == caseId && c.Owner.UserId == actor.Id);
+        isOwner = await dbContext.Cases.AnyAsync(c => c.Id == caseId && (c.Owner.UserId == actor.Id || c.CreatedBy.Id == actor.Id));
         // Add to cache. 
         var cacheEntryOptions = new DistributedCacheEntryOptions().SetSlidingExpiration(TimeSpan.FromMinutes(60));
         await _cache.SetStringAsync(cacheKey, $"{isOwner}", cacheEntryOptions);

--- a/src/Indice.Features.Cases.Server/Endpoints/MyCasesHandlers.cs
+++ b/src/Indice.Features.Cases.Server/Endpoints/MyCasesHandlers.cs
@@ -45,7 +45,7 @@ internal static class MyCasesHandlers
     /// <returns></returns>
     public static async Task<Ok<CreateCaseResponse>> CreateDraftCase(CreateDraftCaseRequest request, ClaimsPrincipal user,
         IOptions<CasesOptions> casesOptions, IMyCaseService myCaseService) =>
-        TypedResults.Ok(await myCaseService.CreateDraft(user.UserToActor(casesOptions.Value), request.CaseTypeCode, request.GroupId, request.Owner, request.Metadata, request.Channel));
+        TypedResults.Ok(await myCaseService.CreateDraft(user.UserToActor(casesOptions.Value), request.CaseTypeCode, request.GroupId, request.Owner?? user.UserToContactMeta(casesOptions.Value) , request.Metadata, request.Channel));
 
     /// <summary>Add an attachment to an existing case regardless of its status and mode (draft or not).</summary>
     /// <param name="caseId">The Id of the case.</param>


### PR DESCRIPTION
Updated `CasesAccessOwnerHandler` to broaden ownership checks by including `CreatedBy.Id` as a valid owner criterion. 
Modified `CreateDraftCase` in `MyCasesHandlers.cs` to default to `UserToContactMeta` when `Owner` is null. Made minor formatting adjustments and added XML documentation for improved readability and consistency.
