### PR TITLE
[cases] Update case data initialization to include owner info

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,13 +4,13 @@
       <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
       <!--<TargetFramework></TargetFramework>-->
       <VersionPrefixMajor>8</VersionPrefixMajor>
-      <VersionPrefixBase>$(VersionPrefixMajor).27</VersionPrefixBase>
+      <VersionPrefixBase>$(VersionPrefixMajor).28</VersionPrefixBase>
 
       <VersionPrefixCore>$(VersionPrefixBase).0</VersionPrefixCore>
       <VersionPrefixIdentity>$(VersionPrefixBase).0</VersionPrefixIdentity>
       <VersionPrefixIdentityUI>$(VersionPrefixBase).0</VersionPrefixIdentityUI>
-      <VersionPrefixCases>$(VersionPrefixBase).2</VersionPrefixCases>
-      <VersionPrefixMessages>$(VersionPrefixBase).1</VersionPrefixMessages>
+      <VersionPrefixCases>$(VersionPrefixBase).0</VersionPrefixCases>
+      <VersionPrefixMessages>$(VersionPrefixBase).0</VersionPrefixMessages>
       <VersionPrefixMultitenancy>$(VersionPrefixBase).0</VersionPrefixMultitenancy>
       <VersionPrefixRisk>$(VersionPrefixBase).0</VersionPrefixRisk>
       <VersionPrefixMedia>$(VersionPrefixBase).0</VersionPrefixMedia>

--- a/src/Indice.Features.Cases.Core/Extensions/ClaimsPrincipalExtensions.cs
+++ b/src/Indice.Features.Cases.Core/Extensions/ClaimsPrincipalExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System.Globalization;
-using System.Numerics;
 using Indice.Features.Cases.Core;
 using Indice.Features.Cases.Core.Models;
 using Indice.Security;
@@ -89,6 +88,4 @@ public static class CasesClaimsPrincipalExtensions
             Tin = user.FindFirstValue(options.TinClaimType)
         };
     }
-
-
 }

--- a/src/Indice.Features.Cases.Core/Models/Responses/Contact.cs
+++ b/src/Indice.Features.Cases.Core/Models/Responses/Contact.cs
@@ -1,6 +1,4 @@
-﻿using System.Text.Json.Nodes;
-
-namespace Indice.Features.Cases.Core.Models.Responses;
+﻿namespace Indice.Features.Cases.Core.Models.Responses;
 
 /// <summary>
 /// The customer response object that contains information from the integration system. Properties that have no direct mapping to this model
@@ -38,5 +36,5 @@ public class Contact
 
     /// <summary>Theis is a dynamic object that is polulated accordingly in order to populate case forms from the owner contact.</summary>
     /// <remarks>used to initialize a new case instance <strong>Data</strong> when this contact is selected as the owner/customer</remarks>
-    public object? FormData { get; set; }
+    public object? FormData { get; set; } // TODO: This can be removed, since we have `ICaseDataInitializer` service 
 }

--- a/src/Indice.Features.Cases.Core/Models/Responses/Contact.cs
+++ b/src/Indice.Features.Cases.Core/Models/Responses/Contact.cs
@@ -33,8 +33,4 @@ public class Contact
     /// <summary>Any extra metadata with consumer/integrator business logic.</summary>
     /// <remarks>Used to initialize a new case instance <strong>MetaData</strong> when this contact is selected as the owner/customer</remarks>
     public Dictionary<string, string> Metadata { get; set; } = [];
-
-    /// <summary>Theis is a dynamic object that is polulated accordingly in order to populate case forms from the owner contact.</summary>
-    /// <remarks>used to initialize a new case instance <strong>Data</strong> when this contact is selected as the owner/customer</remarks>
-    public object? FormData { get; set; } // TODO: This can be removed, since we have `ICaseDataInitializer` service 
 }

--- a/src/Indice.Features.Cases.Core/Services/Abstractions/ICaseDataInitializer.cs
+++ b/src/Indice.Features.Cases.Core/Services/Abstractions/ICaseDataInitializer.cs
@@ -1,5 +1,4 @@
 ﻿using System.Text.Json.Nodes;
-using Indice.Features.Cases.Core.Models;
 using Indice.Features.Cases.Core.Models.Responses;
 
 namespace Indice.Features.Cases.Core.Services.Abstractions;
@@ -10,12 +9,11 @@ namespace Indice.Features.Cases.Core.Services.Abstractions;
 public interface ICaseDataInitializer
 {
     /// <summary>
-    /// Initializes a new case asynchronously for the specified user and case type.
+    /// Initializes a new case for the specified contact and case type asynchronously.
     /// </summary>
-    /// <param name="user">The user on whose behalf the case is being initialized. Cannot be null.</param>
-    /// <param name="caseTypeCode">The code that identifies the type of case to initialize. Cannot be null or empty.</param>
-    /// <param name="owner">An optional contact to associate data initialization.</param>
+    /// <param name="owner">The contact for whom the case is being initialized. Cannot be null.</param>
+    /// <param name="caseTypeCode">The code representing the type of case to initialize. Cannot be null or empty.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains a JsonNode with the initialized case
     /// data, or null if initialization fails.</returns>
-    Task<JsonNode?> InitializeAsync(UserActor user, string caseTypeCode, Contact? owner = null);
+    Task<JsonNode?> InitializeAsync(Contact owner, string caseTypeCode);
 }

--- a/src/Indice.Features.Cases.Core/Services/NoOpServices/NoOpCaseDataInitializer.cs
+++ b/src/Indice.Features.Cases.Core/Services/NoOpServices/NoOpCaseDataInitializer.cs
@@ -6,7 +6,7 @@ namespace Indice.Features.Cases.Core.Services.NoOpServices;
 
 internal class NoOpCaseDataInitializer : ICaseDataInitializer
 {
-    public Task<JsonNode?> InitializeAsync(Contact contact, string caseTypeCode) =>
+    public Task<JsonNode?> InitializeAsync(Contact owner, string caseTypeCode) =>
         Task.FromResult(
             caseTypeCode is "SampleAddress"
             ? JsonNode.Parse("""

--- a/src/Indice.Features.Cases.Core/Services/NoOpServices/NoOpCaseDataInitializer.cs
+++ b/src/Indice.Features.Cases.Core/Services/NoOpServices/NoOpCaseDataInitializer.cs
@@ -1,5 +1,4 @@
 ﻿using System.Text.Json.Nodes;
-using Indice.Features.Cases.Core.Models;
 using Indice.Features.Cases.Core.Models.Responses;
 using Indice.Features.Cases.Core.Services.Abstractions;
 
@@ -7,6 +6,19 @@ namespace Indice.Features.Cases.Core.Services.NoOpServices;
 
 internal class NoOpCaseDataInitializer : ICaseDataInitializer
 {
-    public Task<JsonNode?> InitializeAsync(UserActor user, string caseTypeCode, Contact? contact = null) =>
-        Task.FromResult(JsonNode.Parse("{}"));
+    public Task<JsonNode?> InitializeAsync(Contact? contact, string caseTypeCode) =>
+        Task.FromResult(
+            caseTypeCode is "SampleAddress"
+            ? JsonNode.Parse("""
+                {
+                    "postOfficeBox" : "123",
+                    "streetAddress" : "456 Main St",
+                    "locality" : "Cityville",
+                    "region" : "Attica",
+                    "postalCode" : "12345",
+                    "countryName": "Greece"
+                }
+                """)
+            : JsonNode.Parse("{}")
+        );
 }

--- a/src/Indice.Features.Cases.Core/Services/NoOpServices/NoOpCaseDataInitializer.cs
+++ b/src/Indice.Features.Cases.Core/Services/NoOpServices/NoOpCaseDataInitializer.cs
@@ -6,7 +6,7 @@ namespace Indice.Features.Cases.Core.Services.NoOpServices;
 
 internal class NoOpCaseDataInitializer : ICaseDataInitializer
 {
-    public Task<JsonNode?> InitializeAsync(Contact? contact, string caseTypeCode) =>
+    public Task<JsonNode?> InitializeAsync(Contact contact, string caseTypeCode) =>
         Task.FromResult(
             caseTypeCode is "SampleAddress"
             ? JsonNode.Parse("""

--- a/src/Indice.Features.Cases.Core/Services/NoOpServices/NoOpContactProvider.cs
+++ b/src/Indice.Features.Cases.Core/Services/NoOpServices/NoOpContactProvider.cs
@@ -23,7 +23,7 @@ internal class NoOpContactProvider : IContactProvider
             Task.FromResult(new ResultSet<Contact>([ToContact(user)], 1));
 
 
-    public Task<Contact?> GetByReferenceAsync(UserActor user, string reference) => 
+    public Task<Contact?> GetByReferenceAsync(UserActor user, string reference) =>
         Task.FromResult<Contact?>(ToContact(user));
 
     private Contact ToContact(UserActor workflowActor) => new () {
@@ -49,15 +49,6 @@ internal class NoOpContactProvider : IContactProvider
         Metadata = new () {
             [options.TinClaimType] = "999999999",
             [options.GroupIdClaimType] = "010",
-        },
-        // used to initialize an new case instance the SampleAddress caseType from the selected contact as Owner.
-        FormData = new {
-            postOfficeBox = "123",
-            streetAddress = "456 Main St",
-            locality = "Cityville",
-            region = "State",
-            postalCode = "12345",
-            countryName = "Country"
-        }    
+        }
     };
 }

--- a/src/Indice.Features.Cases.Server/Endpoints/AdminCasesHandlers.cs
+++ b/src/Indice.Features.Cases.Server/Endpoints/AdminCasesHandlers.cs
@@ -299,7 +299,7 @@ internal static class AdminCasesHandlers
             Reference = @case.OwnerId,
             Tin = @case.OwnerTin,
             GroupId = @case.GroupId,
-            FirstName = @case.OwnerName?.Trim()?.Split(" ", StringSplitOptions.RemoveEmptyEntries)?.FirstOrDefault(),
+            FirstName = @case.OwnerName?.Trim().Split(" ", StringSplitOptions.RemoveEmptyEntries)?.FirstOrDefault(),
             LastName = @case.OwnerName is not null
                 ? string.Join(' ', @case.OwnerName.Trim().Split(" ", StringSplitOptions.RemoveEmptyEntries).Skip(1))
                 : null

--- a/src/Indice.Features.Cases.Server/Endpoints/AdminCasesHandlers.cs
+++ b/src/Indice.Features.Cases.Server/Endpoints/AdminCasesHandlers.cs
@@ -294,7 +294,12 @@ internal static class AdminCasesHandlers
             return TypedResults.NotFound();
         }
 
-        var data = await caseDataInitializer.InitializeAsync(currentUser.UserToActor(casesOptions.Value), @case.CaseType.Code.ToString());
+        var owner = new Contact() {
+            Reference = @case.OwnerId,
+            Tin = @case.OwnerTin
+        };
+
+        var data = await caseDataInitializer.InitializeAsync(currentUser.UserToActor(casesOptions.Value), @case.CaseType.Code.ToString(), owner);
         return data is null
             ? TypedResults.Ok(JsonNode.Parse("{}"))
             : TypedResults.Ok(data);

--- a/src/Indice.Features.Cases.Server/Endpoints/AdminCasesHandlers.cs
+++ b/src/Indice.Features.Cases.Server/Endpoints/AdminCasesHandlers.cs
@@ -295,11 +295,17 @@ internal static class AdminCasesHandlers
         }
 
         var owner = new Contact() {
+            UserId = @case.UserId,
             Reference = @case.OwnerId,
-            Tin = @case.OwnerTin
+            Tin = @case.OwnerTin,
+            GroupId = @case.GroupId,
+            FirstName = @case.OwnerName?.Trim()?.Split(" ", StringSplitOptions.RemoveEmptyEntries)?.FirstOrDefault(),
+            LastName = @case.OwnerName is not null
+                ? string.Join(' ', @case.OwnerName.Trim().Split(" ", StringSplitOptions.RemoveEmptyEntries).Skip(1))
+                : null
         };
 
-        var data = await caseDataInitializer.InitializeAsync(currentUser.UserToActor(casesOptions.Value), @case.CaseType.Code.ToString(), owner);
+        var data = await caseDataInitializer.InitializeAsync(owner, @case.CaseType.Code.ToString());
         return data is null
             ? TypedResults.Ok(JsonNode.Parse("{}"))
             : TypedResults.Ok(data);


### PR DESCRIPTION
- Add the missing `onwer` param to `AdminCasesHandlers.InitializeCaseData` so the integration service can retrieve the owner.reference
- some refactors

please check `TODO`, I think we can safely remove this property