### PR TITLE
[hosting] Add PostgreSQL mapping for RowVersion and explicit query columns

### DIFF
--- a/src/Indice.Hosting/Data/Mappings/DbQMessageMap.cs
+++ b/src/Indice.Hosting/Data/Mappings/DbQMessageMap.cs
@@ -19,3 +19,17 @@ public sealed class DbQMessageMap : IEntityTypeConfiguration<DbQMessage>
         builder.Property(x => x.RowVersion).IsRowVersion();
     }
 }
+
+/// <summary>EF Core configuration for <see cref="DbQMessage"/> entity.</summary>
+public sealed class DbQMessagePostgreSQLMap : IEntityTypeConfiguration<DbQMessage>
+{
+    /// <inheritdoc />
+    public void Configure(EntityTypeBuilder<DbQMessage> builder) {
+        builder.Property(x => x.RowVersion)
+           .HasColumnName("RowVersion")
+           .HasColumnType("bytea")
+           .IsConcurrencyToken()
+           .ValueGeneratedOnAddOrUpdate()
+           .HasDefaultValueSql("encode(('x' || lpad(extract(epoch from now())::bigint::text, 16, '0'))::text::bytea, 'hex')::bytea");
+    }
+}

--- a/src/Indice.Hosting/Data/Mappings/DbQMessageMap.cs
+++ b/src/Indice.Hosting/Data/Mappings/DbQMessageMap.cs
@@ -20,7 +20,12 @@ public sealed class DbQMessageMap : IEntityTypeConfiguration<DbQMessage>
     }
 }
 
-/// <summary>EF Core configuration for <see cref="DbQMessage"/> entity.</summary>
+/// <summary>
+/// EF Core configuration for <see cref="DbQMessage"/> entity specific to PostgreSQL.
+/// This configuration provides PostgreSQL-specific mappings for the <c>RowVersion</c> property,
+/// including the use of the <c>bytea</c> column type and custom default value generation,
+/// to ensure proper concurrency control in PostgreSQL environments.
+/// </summary>
 public sealed class DbQMessagePostgreSQLMap : IEntityTypeConfiguration<DbQMessage>
 {
     /// <inheritdoc />
@@ -30,6 +35,6 @@ public sealed class DbQMessagePostgreSQLMap : IEntityTypeConfiguration<DbQMessag
            .HasColumnType("bytea")
            .IsConcurrencyToken()
            .ValueGeneratedOnAddOrUpdate()
-           .HasDefaultValueSql("encode(('x' || lpad(extract(epoch from now())::bigint::text, 16, '0'))::text::bytea, 'hex')::bytea");
+           .HasDefaultValueSql("gen_random_bytes(8)");
     }
 }

--- a/src/Indice.Hosting/Data/Mappings/DbQMessageMap.cs
+++ b/src/Indice.Hosting/Data/Mappings/DbQMessageMap.cs
@@ -35,6 +35,7 @@ public sealed class DbQMessagePostgreSQLMap : IEntityTypeConfiguration<DbQMessag
            .HasColumnType("bytea")
            .IsConcurrencyToken()
            .ValueGeneratedOnAddOrUpdate()
-           .HasDefaultValueSql("gen_random_bytes(8)");
+           .HasDefaultValueSql("encode(('x' || lpad(extract(epoch from now())::bigint::text, 16, '0'))::text::bytea, 'hex')::bytea");
+
     }
 }

--- a/src/Indice.Hosting/Data/TaskDbContext.cs
+++ b/src/Indice.Hosting/Data/TaskDbContext.cs
@@ -1,7 +1,6 @@
 ﻿using Indice.Hosting.Data.Models;
 using Indice.Hosting.Services;
 using Microsoft.EntityFrameworkCore;
-using Polly;
 
 namespace Indice.Hosting.Data;
 

--- a/src/Indice.Hosting/Data/TaskDbContext.cs
+++ b/src/Indice.Hosting/Data/TaskDbContext.cs
@@ -1,6 +1,7 @@
 ﻿using Indice.Hosting.Data.Models;
 using Indice.Hosting.Services;
 using Microsoft.EntityFrameworkCore;
+using Polly;
 
 namespace Indice.Hosting.Data;
 
@@ -26,6 +27,9 @@ public class TaskDbContext : DbContext
     protected override void OnModelCreating(ModelBuilder builder) {
         base.OnModelCreating(builder);
         builder.ApplyConfiguration(new DbQMessageMap());
+        if (Database.ProviderName == "Npgsql.EntityFrameworkCore.PostgreSQL") {
+            builder.ApplyConfiguration(new DbQMessagePostgreSQLMap());
+        }
         builder.ApplyConfiguration(new DbScheduledTaskMap());
         builder.ApplyConfiguration(new DbLockMap());
     }

--- a/src/Indice.Hosting/Services/MessageQueueRelational.cs
+++ b/src/Indice.Hosting/Services/MessageQueueRelational.cs
@@ -172,7 +172,7 @@ internal static class SqlServerMessageQueueQueries
                 ORDER BY [Date] ASC
             )
             DELETE FROM cte 
-            OUTPUT [deleted].*;";
+            OUTPUT [deleted].[Id], [deleted].[QueueName], [deleted].[Payload], [deleted].[Date], [deleted].[RowVersion], [deleted].[DequeueCount], [deleted].[State];";
     public const string Enqueue = @"
             INSERT INTO [work].[QMessage] ([Id], [QueueName], [Payload], [Date], [DequeueCount], [State]) 
             VALUES (@Id, @QueueName, @Payload, @Date, @DequeueCount, 0);";
@@ -203,7 +203,13 @@ internal static class PostgreSqlMessageQueueQueries
                 FOR UPDATE SKIP LOCKED
             ) q
             WHERE q.""Id"" = ""work"".""QMessage"".""Id"" AND q.""Date"" <= CURRENT_TIMESTAMP
-            RETURNING ""work"".""QMessage"".*;
+            RETURNING ""work"".""QMessage"".""Id"",
+                      ""work"".""QMessage"".""QueueName"",
+                      ""work"".""QMessage"".""Payload"",
+                      ""work"".""QMessage"".""Date"",
+                      ""work"".""QMessage"".""RowVersion"",
+                      ""work"".""QMessage"".""DequeueCount"",
+                      ""work"".""QMessage"".""State"";
         ";
     public const string Enqueue = @"
             INSERT INTO ""work"".""QMessage"" (""Id"", ""QueueName"", ""Payload"", ""Date"", ""DequeueCount"", ""State"")


### PR DESCRIPTION
Added DbQMessagePostgreSQLMap for PostgreSQL-specific RowVersion handling using bytea and a default value expression. TaskDbContext now applies this mapping when using Npgsql. Updated SQL Server and PostgreSQL message queue queries to explicitly list returned columns instead of using wildcards.