### PR TITLE
[identity] Fix error message to use localized string value

### DIFF
--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/Error.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/Error.cshtml
@@ -5,7 +5,7 @@
 @model BaseErrorModel
 
 @{
-    var error = Localizer.Error_Oops_Seems_We_Encountered_An_Error;
+    var error = Localizer.Error_Oops_Seems_We_Encountered_An_Error.Value;
 }
 
 <div class="content-wrapper">


### PR DESCRIPTION
Updated assignment of the error variable to use the Value property of Localizer.Error_Oops_Seems_We_Encountered_An_Error, ensuring the localized string is passed to the view instead of the localizer object.