### PR TITLE
[messaging] Bug fix template filtering logic for MessageTypeId options

### DIFF
--- a/src/Indice.Features.Messages.AspNetCore/Csv/Records/ContactCsvRecord.cs
+++ b/src/Indice.Features.Messages.AspNetCore/Csv/Records/ContactCsvRecord.cs
@@ -1,26 +1,27 @@
-﻿using Indice.Features.Messages.Core.Models;
+﻿using CsvHelper.Configuration.Attributes;
+using Indice.Features.Messages.Core.Models;
 using Indice.Features.Messages.Core.Models.Requests;
 
 namespace Indice.Features.Messages.AspNetCore.Csv.Records;
 internal record ContactCsvRecord(
-    string? RecipientId,
-    string? Salutation,
+    [Optional] string? RecipientId,
+    [Optional] string? Salutation,
     string? FirstName,
     string? LastName,
-    string? FullName,
+    [Optional] string? FullName,
     string? Email,
-    string? PhoneNumber
+    [Optional] string? PhoneNumber
 )
 {
     public CreateDistributionListContactRequest ToCreateDistributionListContactRequest() {
         return new CreateDistributionListContactRequest {
             RecipientId = string.IsNullOrWhiteSpace(RecipientId) ? null : RecipientId,
-            Salutation = Salutation,
-            FirstName = FirstName,
-            LastName = LastName,
-            FullName = FullName,
-            Email = Email,
-            PhoneNumber = PhoneNumber
+            Salutation = string.IsNullOrWhiteSpace(Salutation) ? null : Salutation,
+            FirstName = string.IsNullOrWhiteSpace(FirstName) ? null : FirstName,
+            LastName = string.IsNullOrWhiteSpace(LastName) ? null : LastName,
+            FullName = !string.IsNullOrWhiteSpace(FullName) ? FullName : !string.IsNullOrWhiteSpace($"{FirstName} {LastName}".Trim()) ? $"{FirstName} {LastName}".Trim() : null,
+            Email = string.IsNullOrWhiteSpace(Email) ? null : Email,
+            PhoneNumber = string.IsNullOrWhiteSpace(PhoneNumber) ? null : PhoneNumber
         };
     }
 
@@ -33,7 +34,6 @@ internal record ContactCsvRecord(
             contact.FullName,
             contact.Email,
             contact.PhoneNumber
-
         );
     }
 }

--- a/src/Indice.Features.Messages.Core/Services/TemplateService.cs
+++ b/src/Indice.Features.Messages.Core/Services/TemplateService.cs
@@ -108,8 +108,9 @@ public class TemplateService : ITemplateService
             query = options.Filter.IncludeItemsWithoutMessageTypeId == true
                 ? query.Where(x => x.MessageTypeId == options.Filter.MessageTypeId || x.MessageTypeId == null)
                 : query.Where(x => x.MessageTypeId == options.Filter.MessageTypeId);
-        } else if (options.Filter?.IncludeItemsWithoutMessageTypeId == true) {
-            query = query.Where(x => x.MessageTypeId == null);
+        } 
+        if (options.Filter?.IncludeItemsWithoutMessageTypeId == false) {
+            query = query.Where(x => x.MessageTypeId != null);
         }
 
         var result = await query.ToResultSetAsync(options);


### PR DESCRIPTION
Refined filtering to handle IncludeItemsWithoutMessageTypeId=false, ensuring only templates with a non-null MessageTypeId are included when specified. This provides more precise control over template selection based on filter options.