### PR TITLE
[signinlogs] Fix - Move AutoDetectChangesEnabled to constructor

### DIFF
--- a/src/Indice.Features.Identity.SignInLogs/EntityFrameworkCore/SignInLogDbContext.cs
+++ b/src/Indice.Features.Identity.SignInLogs/EntityFrameworkCore/SignInLogDbContext.cs
@@ -24,6 +24,5 @@ internal class SignInLogDbContext : DbContext
         base.OnModelCreating(modelBuilder);
         var schemaName = Database.GetService<IOptions<SignInLogOptions>>().Value.DatabaseSchema;
         modelBuilder.ApplyConfiguration(new DbSignInLogEntryMap(schemaName));
-        //ChangeTracker.AutoDetectChangesEnabled = false;
     }
 }

--- a/src/Indice.Features.Identity.SignInLogs/EntityFrameworkCore/SignInLogDbContext.cs
+++ b/src/Indice.Features.Identity.SignInLogs/EntityFrameworkCore/SignInLogDbContext.cs
@@ -12,7 +12,7 @@ internal class SignInLogDbContext : DbContext
     /// <summary>Constructs the <see cref="SignInLogDbContext"/> passing the configured options.</summary>
     /// <param name="options">The options to be used by a <see cref="SignInLogDbContext"/>.</param>
     public SignInLogDbContext(DbContextOptions<SignInLogDbContext> options) : base(options) {
-
+        ChangeTracker.AutoDetectChangesEnabled = false;
     }
 
     /// <summary>Stores all sign log entries.</summary>
@@ -24,6 +24,6 @@ internal class SignInLogDbContext : DbContext
         base.OnModelCreating(modelBuilder);
         var schemaName = Database.GetService<IOptions<SignInLogOptions>>().Value.DatabaseSchema;
         modelBuilder.ApplyConfiguration(new DbSignInLogEntryMap(schemaName));
-        ChangeTracker.AutoDetectChangesEnabled = false;
+        //ChangeTracker.AutoDetectChangesEnabled = false;
     }
 }


### PR DESCRIPTION
ChangeTracker.AutoDetectChangesEnabled is now set to false in the SignInLogDbContext constructor instead of in OnModelCreating. This ensures automatic change detection is disabled immediately upon context creation. The previous setting in OnModelCreating has been commented out.