### PR TITLE
[identity] Update provider selection logic for client restrictions

### DIFF
--- a/src/Indice.Features.Identity.AdminUI.App/src/app/features/clients/edit/client-store.service.ts
+++ b/src/Indice.Features.Identity.AdminUI.App/src/app/features/clients/edit/client-store.service.ts
@@ -34,6 +34,19 @@ export class ClientStore {
                 client.translations[key] = new ClientTranslation(client.translations[key]);
             }
         }
+        // Calculate identityProviderRestrictions based on provider selection
+        // If all providers are selected, save null (no restrictions)
+        // If some providers are selected, save only those (restricted to those providers)
+        // If no providers are selected, save null (will show all providers as selected on next load)
+        // If no providers are provided, keep as null
+        let identityProviderRestrictions: string[] | null = null;
+        if (providers && providers.length > 0) {
+            const selectedProviders = providers.filter(x => x.selected);
+            // Only set restrictions if some (but not all or none) providers are selected
+            if (selectedProviders.length > 0 && selectedProviders.length < providers.length) {
+                identityProviderRestrictions = selectedProviders.map(x => x.authenticationScheme);
+            }
+        }
         return this._api.updateClient(client.clientId, new UpdateClientRequest({
             accessTokenLifetime: client.accessTokenLifetime,
             absoluteRefreshTokenLifetime: client.absoluteRefreshTokenLifetime,
@@ -70,7 +83,7 @@ export class ClientStore {
             enabled: client.enabled,
             slidingRefreshTokenLifetime: client.slidingRefreshTokenLifetime,
             enableLocalLogin: client.enableLocalLogin,
-            identityProviderRestrictions: providers?.filter(x => x.selected).map(x => x.authenticationScheme) || null
+            identityProviderRestrictions: identityProviderRestrictions
         } as IUpdateClientRequest)).pipe(map(_ => {
             this._client.next(client);
             this._client.complete();

--- a/src/Indice.Features.Identity.AdminUI.App/src/app/features/clients/edit/details/client-details.component.ts
+++ b/src/Indice.Features.Identity.AdminUI.App/src/app/features/clients/edit/details/client-details.component.ts
@@ -46,8 +46,12 @@ export class ClientDetailsComponent implements OnInit, OnDestroy {
         this._getDataSubscription = forkJoin([getClient$, getExternalProviders$]).subscribe((result: [SingleClientInfo, ExternalProviderResultSet]) => {
             this.client = result[0];
             const hasRestrictions = this.client.identityProviderRestrictions && this.client.identityProviderRestrictions.length > 0;
-            this.externalProviders = result[1].items.map((provider: ExternalProvider) =>
-                new SelectableExternalProvider(!hasRestrictions || this.client.identityProviderRestrictions.indexOf(provider.authenticationScheme) > -1, provider.displayName, provider.authenticationScheme));
+            this.externalProviders = result[1].items.map((provider: ExternalProvider) => {
+                // If no restrictions, select all providers
+                // If restrictions exist, only select providers in the restrictions list
+                const isSelected = !hasRestrictions || (this.client.identityProviderRestrictions?.indexOf(provider.authenticationScheme) ?? -1) > -1;
+                return new SelectableExternalProvider(isSelected, provider.displayName, provider.authenticationScheme);
+            });
             if (!this.client.translations) {
                 this.client.translations = {} as { [key: string]: ClientTranslation; };
                 return;

--- a/src/Indice.Features.Identity.AdminUI.App/src/app/features/clients/edit/details/client-details.component.ts
+++ b/src/Indice.Features.Identity.AdminUI.App/src/app/features/clients/edit/details/client-details.component.ts
@@ -45,8 +45,9 @@ export class ClientDetailsComponent implements OnInit, OnDestroy {
         const getExternalProviders$ = this._identityApi.getExternalProviders();
         this._getDataSubscription = forkJoin([getClient$, getExternalProviders$]).subscribe((result: [SingleClientInfo, ExternalProviderResultSet]) => {
             this.client = result[0];
+            const hasRestrictions = this.client.identityProviderRestrictions && this.client.identityProviderRestrictions.length > 0;
             this.externalProviders = result[1].items.map((provider: ExternalProvider) =>
-                new SelectableExternalProvider(this.client.identityProviderRestrictions.indexOf(provider.authenticationScheme) > -1, provider.displayName, provider.authenticationScheme));
+                new SelectableExternalProvider(!hasRestrictions || this.client.identityProviderRestrictions.indexOf(provider.authenticationScheme) > -1, provider.displayName, provider.authenticationScheme));
             if (!this.client.translations) {
                 this.client.translations = {} as { [key: string]: ClientTranslation; };
                 return;


### PR DESCRIPTION
Improved how external identity providers are marked as selected for a client. Now, if a client has no identityProviderRestrictions, all providers are selected by default. This ensures correct UI behavior when restrictions are absent.