### PR TITLE
[identity] Add granular auto-provisioning for external providers

### DIFF
--- a/src/Indice.Features.Identity.UI/IdentityBuilderUIExtensions.cs
+++ b/src/Indice.Features.Identity.UI/IdentityBuilderUIExtensions.cs
@@ -39,7 +39,7 @@ public static class IdentityBuilderUIExtensions
             options.AutomaticRedirectAfterSignOut = configuredOptions.AutomaticRedirectAfterSignOut;
             options.AutomaticSigninAfterRegister = configuredOptions.AutomaticSigninAfterRegister;
             options.AutoProvisionExternalUsers = configuredOptions.AutoProvisionExternalUsers;
-            options.AutoProvisionExtrenalUsersFor = configuredOptions.AutoProvisionExtrenalUsersFor;
+            options.AutoProvisionExternalUsersFor = configuredOptions.AutoProvisionExternalUsersFor;
             options.AvatarColorHex = configuredOptions.AvatarColorHex;
             options.OnBoardingPage = configuredOptions.OnBoardingPage;
             options.ContactUsUrl = configuredOptions.ContactUsUrl;

--- a/src/Indice.Features.Identity.UI/IdentityBuilderUIExtensions.cs
+++ b/src/Indice.Features.Identity.UI/IdentityBuilderUIExtensions.cs
@@ -39,6 +39,7 @@ public static class IdentityBuilderUIExtensions
             options.AutomaticRedirectAfterSignOut = configuredOptions.AutomaticRedirectAfterSignOut;
             options.AutomaticSigninAfterRegister = configuredOptions.AutomaticSigninAfterRegister;
             options.AutoProvisionExternalUsers = configuredOptions.AutoProvisionExternalUsers;
+            options.AutoProvisionExtrenalUsersFor = configuredOptions.AutoProvisionExtrenalUsersFor;
             options.AvatarColorHex = configuredOptions.AvatarColorHex;
             options.OnBoardingPage = configuredOptions.OnBoardingPage;
             options.ContactUsUrl = configuredOptions.ContactUsUrl;

--- a/src/Indice.Features.Identity.UI/IdentityUIOptions.cs
+++ b/src/Indice.Features.Identity.UI/IdentityUIOptions.cs
@@ -42,6 +42,9 @@ public class IdentityUIOptions
     public bool HasCustomOnBoarding => !"/Register".Equals(OnBoardingPage);
     /// <summary>Controls whether an external Identity user will go through the associate screen or not.</summary>
     public bool AutoProvisionExternalUsers { get; set; } = true;
+    /// <summary>Controls which external login providers should be auto provisioned.</summary>
+    /// <remarks>use scheme names like Microsoft, Apple, Google etc </remarks>
+    public List<string> AutoProvisionExtrenalUsersFor { get; set; } = [];
     /// <summary>Controls whether an external identity user be associated to an existing one using the email account.</summary>
     public bool AutoAssociateExternalUsers { get; set; } = true;
     /// <summary>Controls whether The self service /register page is accessible.</summary>

--- a/src/Indice.Features.Identity.UI/IdentityUIOptions.cs
+++ b/src/Indice.Features.Identity.UI/IdentityUIOptions.cs
@@ -44,7 +44,7 @@ public class IdentityUIOptions
     public bool AutoProvisionExternalUsers { get; set; } = true;
     /// <summary>Controls which external login providers should be auto provisioned.</summary>
     /// <remarks>use scheme names like Microsoft, Apple, Google etc </remarks>
-    public List<string> AutoProvisionExtrenalUsersFor { get; set; } = [];
+    public List<string> AutoProvisionExternalUsersFor { get; set; } = [];
     /// <summary>Controls whether an external identity user be associated to an existing one using the email account.</summary>
     public bool AutoAssociateExternalUsers { get; set; } = true;
     /// <summary>Controls whether The self service /register page is accessible.</summary>

--- a/src/Indice.Features.Identity.UI/Pages/Associate.cs
+++ b/src/Indice.Features.Identity.UI/Pages/Associate.cs
@@ -46,7 +46,7 @@ public abstract class BaseAssociateModel : BasePageModel
     public AssociateInputModel Input { get; set; } = new AssociateInputModel();
 
     /// <summary>Associate page GET handler.</summary>
-    public async Task<IActionResult> OnGet() {
+    public virtual async Task<IActionResult> OnGet() {
         // if i got here then there was an external login for a new user not present in the database.
         // This following view will help to review the data coming in before proceeding with the user provisioning.
         var associateViewModel = TempData.Peek<AssociateViewModel>("UserDetails");
@@ -54,7 +54,8 @@ public abstract class BaseAssociateModel : BasePageModel
             return RedirectToPage("/Login");
         }
         Input = View = associateViewModel;
-        if (UiOptions.AutoProvisionExternalUsers) {
+        var externalLoginInfo = await SignInManager.GetExternalLoginInfoAsync();
+        if (UiOptions.AutoProvisionExternalUsers || UiOptions.AutoProvisionExtrenalUsersFor.Contains(externalLoginInfo?.LoginProvider ?? string.Empty)) {
             return await OnPostAsync();
         }
         return Page();

--- a/src/Indice.Features.Identity.UI/Pages/Associate.cs
+++ b/src/Indice.Features.Identity.UI/Pages/Associate.cs
@@ -55,7 +55,7 @@ public abstract class BaseAssociateModel : BasePageModel
         }
         Input = View = associateViewModel;
         var externalLoginInfo = await SignInManager.GetExternalLoginInfoAsync();
-        if (UiOptions.AutoProvisionExternalUsers || UiOptions.AutoProvisionExtrenalUsersFor.Contains(externalLoginInfo?.LoginProvider ?? string.Empty)) {
+        if (UiOptions.AutoProvisionExternalUsers || UiOptions.AutoProvisionExternalUsersFor.Contains(externalLoginInfo?.LoginProvider ?? string.Empty)) {
             return await OnPostAsync();
         }
         return Page();

--- a/src/Indice.Features.Identity.UI/Pages/Challenge.cs
+++ b/src/Indice.Features.Identity.UI/Pages/Challenge.cs
@@ -65,7 +65,7 @@ public abstract class BaseChallengeModel : BasePageModel
     protected IAuthenticationSchemeProvider SchemeProvider { get; }
 
     /// <summary>Challenge page GET handler.</summary>
-    public async Task<IActionResult> OnGet(string provider, string returnUrl, string prompt) {
+    public virtual async Task<IActionResult> OnGet(string provider, string returnUrl, string prompt) {
         if (string.IsNullOrEmpty(returnUrl)) {
             returnUrl = "/";
         }


### PR DESCRIPTION
Introduce AutoProvisionExtrenalUsersFor option to specify which external login providers should trigger automatic user provisioning. Update IdentityBuilderUIExtensions to support this option. Make OnGet methods in BaseAssociateModel and BaseChallengeModel virtual for easier customization and enhance auto-provisioning logic for external users.