### PR TITLE
[HealthChecks] Fix NotSupportedException when exception is not null on health report

### DIFF
--- a/src/Indice.AspNetCore.Builder/ServiceDefaultsExtensions.cs
+++ b/src/Indice.AspNetCore.Builder/ServiceDefaultsExtensions.cs
@@ -26,8 +26,7 @@ public static class ServiceDefaultsExtensions
     /// <summary>
     /// Options to control JSON serialization behavior for health check responses.
     /// </summary>
-    public sealed class HealthCheckJsonOptions
-    {
+    public sealed class HealthCheckJsonOptions {
         /// <summary>
         /// When true, exceptions included in health check results will serialize their stack trace.
         /// Defaults to <c>false</c> to avoid leaking sensitive information in production.
@@ -249,8 +248,7 @@ public static class ServiceDefaultsExtensions
         return options;
     }
 
-    private class ExceptionConverter(bool IncludeStackTrace) : JsonConverter<Exception>
-    {
+    private class ExceptionConverter(bool IncludeStackTrace) : JsonConverter<Exception> {
         public override Exception? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
             throw new NotImplementedException("Deserialization is not supported.");
 

--- a/src/Indice.AspNetCore.Builder/ServiceDefaultsExtensions.cs
+++ b/src/Indice.AspNetCore.Builder/ServiceDefaultsExtensions.cs
@@ -179,7 +179,7 @@ public static class ServiceDefaultsExtensions
             // All health checks must pass for app to be considered ready to accept traffic after starting
             app.MapHealthChecks("/health");
             app.MapHealthChecks("/health/details", new HealthCheckOptions {
-                ResponseWriter = WriteResponse
+                ResponseWriter = (context, healthReport) => WriteResponse(context, healthReport, includeException: true)
             });
             // Only health checks tagged with the "live" tag must pass for app to be considered alive
             app.MapHealthChecks("/alive", new HealthCheckOptions {
@@ -196,7 +196,7 @@ public static class ServiceDefaultsExtensions
             // considered ready to accept traffic after starting
             healthChecks.MapHealthChecks("/health");
             healthChecks.MapHealthChecks("/health/details", new HealthCheckOptions {
-                ResponseWriter = WriteResponse
+                ResponseWriter = (context, healthReport) => WriteResponse(context, healthReport)
             });
             // Only health checks tagged with the "live" tag
             // must pass for app to be considered alive
@@ -208,8 +208,27 @@ public static class ServiceDefaultsExtensions
         return app;
     }
 
-    private static Task WriteResponse(HttpContext context, HealthReport healthReport) {
-        var responseJson = JsonSerializer.Serialize(healthReport, _jsonSerializerOptions.Value);
+    private static Task WriteResponse(HttpContext context, HealthReport healthReport, bool includeException = false) {
+        var report = new {
+            status = healthReport.Status.ToString(),
+            totalDuration = healthReport.TotalDuration,
+            entries = healthReport.Entries.ToDictionary(
+                e => e.Key,
+                e => new {
+                    status = e.Value.Status.ToString(),
+                    duration = e.Value.Duration,
+                    description = e.Value.Description,
+                    data = e.Value.Data,
+                    tags = e.Value.Tags,
+                    exception = includeException && e.Value.Exception is not null ? new {
+                        type = e.Value.Exception.GetType().Name,
+                        message = e.Value.Exception.Message
+                    } : null
+                }
+            )
+        };
+
+        var responseJson = JsonSerializer.Serialize(report, _jsonSerializerOptions.Value);
         context.Response.ContentType = "application/json; charset=utf-8";
         return context.Response.WriteAsync(responseJson);
     }

--- a/src/Indice.AspNetCore.Builder/ServiceDefaultsExtensions.cs
+++ b/src/Indice.AspNetCore.Builder/ServiceDefaultsExtensions.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Azure.Monitor.OpenTelemetry.AspNetCore;
+using Indice.Serialization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Http;
@@ -26,12 +27,23 @@ public static class ServiceDefaultsExtensions
     /// <summary>
     /// Options to control JSON serialization behavior for health check responses.
     /// </summary>
-    public sealed class HealthCheckJsonOptions {
+    public sealed class HealthCheckJsonOptions
+    {
         /// <summary>
-        /// When true, exceptions included in health check results will serialize their stack trace.
-        /// Defaults to <c>false</c> to avoid leaking sensitive information in production.
+        /// Determines whether exceptions in health check results include their stack trace when serialized.
+        /// <para>
+        /// Defaults to <c>false</c> to prevent leaking potentially sensitive information in production environments.
+        /// </para>
         /// </summary>
-        public bool IncludeExceptionStackTrace { get; set; } = false;
+        public bool IncludeStackTrace { get; set; } = false;
+
+        /// <summary>
+        /// Determines whether inner exceptions are included when serializing exceptions in health check results.
+        /// <para>
+        /// Defaults to <c>true</c> to provide detailed context about the cause of a failure.
+        /// </para>
+        /// </summary>
+        public bool IncludeInnerExceptions { get; set; } = true;
     }
 
     /// <summary>
@@ -244,22 +256,7 @@ public static class ServiceDefaultsExtensions
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
         };
         options.Converters.Add(new JsonStringEnumConverter());
-        options.Converters.Add(new ExceptionConverter(healthOptions.IncludeExceptionStackTrace));
+        options.Converters.Add(new ExceptionJsonConverter(healthOptions.IncludeStackTrace, healthOptions.IncludeInnerExceptions));
         return options;
-    }
-
-    private class ExceptionConverter(bool IncludeStackTrace) : JsonConverter<Exception> {
-        public override Exception? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
-            throw new NotImplementedException("Deserialization is not supported.");
-
-        public override void Write(Utf8JsonWriter writer, Exception value, JsonSerializerOptions options) {
-            writer.WriteStartObject();
-            writer.WriteString("type", value.GetType().FullName);
-            writer.WriteString("message", value.Message);
-            if (IncludeStackTrace) {
-                writer.WriteString("stackTrace", value.StackTrace);
-            }
-            writer.WriteEndObject();
-        }
     }
 }

--- a/src/Indice.AspNetCore.Builder/ServiceDefaultsExtensions.cs
+++ b/src/Indice.AspNetCore.Builder/ServiceDefaultsExtensions.cs
@@ -1,8 +1,6 @@
 using System.Reflection;
-using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Text.Unicode;
 using Azure.Monitor.OpenTelemetry.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
@@ -25,6 +23,18 @@ namespace Microsoft.Extensions.Hosting;
 /// </summary>
 public static class ServiceDefaultsExtensions
 {
+    /// <summary>
+    /// Options to control JSON serialization behavior for health check responses.
+    /// </summary>
+    public sealed class HealthCheckJsonOptions
+    {
+        /// <summary>
+        /// When true, exceptions included in health check results will serialize their stack trace.
+        /// Defaults to <c>false</c> to avoid leaking sensitive information in production.
+        /// </summary>
+        public bool IncludeExceptionStackTrace { get; set; } = false;
+    }
+
     /// <summary>
     /// Adds webserive defaults for ConfigureOpenTelemetry, AddDefaultHealthChecks, ConfigureHttpClientDefaults
     /// </summary>
@@ -147,8 +157,16 @@ public static class ServiceDefaultsExtensions
     /// Adds default healthcheck endpoints
     /// </summary>
     /// <param name="builder">The builder to configure</param>
+    /// <param name="configureHealthChecks">Health checks options to configure</param>
     /// <returns>The <see cref="IHostApplicationBuilder"/> for further configuration.</returns>
-    public static IHostApplicationBuilder AddDefaultHealthChecks(this IHostApplicationBuilder builder) {
+    public static IHostApplicationBuilder AddDefaultHealthChecks(
+        this IHostApplicationBuilder builder,
+        Action<HealthCheckJsonOptions>? configureHealthChecks = null) {
+        var options = new HealthCheckJsonOptions();
+        configureHealthChecks?.Invoke(options);
+
+        builder.Services.AddSingleton(options);
+
         // these are registered always but used in product`
         builder.Services.AddRequestTimeouts(
             configure: static timeouts =>
@@ -173,13 +191,18 @@ public static class ServiceDefaultsExtensions
     /// <param name="app">The <see cref="WebApplication"/> to configure</param>
     /// <returns>The <see cref="WebApplication"/> for further configuration</returns>
     public static WebApplication MapHealthCheckDefaults(this WebApplication app) {
+        _jsonSerializerOptions ??= new Lazy<JsonSerializerOptions>(() => {
+            var healthOptions = app.Services.GetRequiredService<HealthCheckJsonOptions>();
+            return CreateJsonOptions(healthOptions);
+        });
+
         // Adding health checks endpoints to applications in non-development environments has security implications.
         // See https://aka.ms/dotnet/aspire/healthchecks for details before enabling these endpoints in non-development environments.
         if (app.Environment.IsDevelopment()) {
             // All health checks must pass for app to be considered ready to accept traffic after starting
             app.MapHealthChecks("/health");
             app.MapHealthChecks("/health/details", new HealthCheckOptions {
-                ResponseWriter = (context, healthReport) => WriteResponse(context, healthReport, includeException: true)
+                ResponseWriter = WriteResponse
             });
             // Only health checks tagged with the "live" tag must pass for app to be considered alive
             app.MapHealthChecks("/alive", new HealthCheckOptions {
@@ -196,7 +219,7 @@ public static class ServiceDefaultsExtensions
             // considered ready to accept traffic after starting
             healthChecks.MapHealthChecks("/health");
             healthChecks.MapHealthChecks("/health/details", new HealthCheckOptions {
-                ResponseWriter = (context, healthReport) => WriteResponse(context, healthReport)
+                ResponseWriter = WriteResponse
             });
             // Only health checks tagged with the "live" tag
             // must pass for app to be considered alive
@@ -208,41 +231,37 @@ public static class ServiceDefaultsExtensions
         return app;
     }
 
-    private static Task WriteResponse(HttpContext context, HealthReport healthReport, bool includeException = false) {
-        var report = new {
-            status = healthReport.Status.ToString(),
-            totalDuration = healthReport.TotalDuration,
-            entries = healthReport.Entries.ToDictionary(
-                e => e.Key,
-                e => new {
-                    status = e.Value.Status.ToString(),
-                    duration = e.Value.Duration,
-                    description = e.Value.Description,
-                    data = e.Value.Data,
-                    tags = e.Value.Tags,
-                    exception = includeException && e.Value.Exception is not null ? new {
-                        type = e.Value.Exception.GetType().Name,
-                        message = e.Value.Exception.Message
-                    } : null
-                }
-            )
-        };
-
-        var responseJson = JsonSerializer.Serialize(report, _jsonSerializerOptions.Value);
+    private static Task WriteResponse(HttpContext context, HealthReport healthReport) {
+        var responseJson = JsonSerializer.Serialize(healthReport, _jsonSerializerOptions!.Value);
         context.Response.ContentType = "application/json; charset=utf-8";
         return context.Response.WriteAsync(responseJson);
     }
 
-    private static readonly Lazy<JsonSerializerOptions> _jsonSerializerOptions = new(CreateJsonOptions);
+    private static Lazy<JsonSerializerOptions>? _jsonSerializerOptions;
 
-    private static JsonSerializerOptions CreateJsonOptions() {
-        var options = new JsonSerializerOptions {
+    private static JsonSerializerOptions CreateJsonOptions(HealthCheckJsonOptions healthOptions) {
+        JsonSerializerOptions options = new(JsonSerializerDefaults.Web) {
             WriteIndented = true,
-            AllowTrailingCommas = true,
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
         };
         options.Converters.Add(new JsonStringEnumConverter());
+        options.Converters.Add(new ExceptionConverter(healthOptions.IncludeExceptionStackTrace));
         return options;
+    }
+
+    private class ExceptionConverter(bool IncludeStackTrace) : JsonConverter<Exception>
+    {
+        public override Exception? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+            throw new NotImplementedException("Deserialization is not supported.");
+
+        public override void Write(Utf8JsonWriter writer, Exception value, JsonSerializerOptions options) {
+            writer.WriteStartObject();
+            writer.WriteString("type", value.GetType().FullName);
+            writer.WriteString("message", value.Message);
+            if (IncludeStackTrace) {
+                writer.WriteString("stackTrace", value.StackTrace);
+            }
+            writer.WriteEndObject();
+        }
     }
 }

--- a/src/Indice.Common/Serialization/ExceptionJsonConverter.cs
+++ b/src/Indice.Common/Serialization/ExceptionJsonConverter.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Indice.Serialization;
+
+/// <summary>
+/// A JSON converter for <see cref="Exception"/> objects that allows optional inclusion
+/// of stack traces and inner exceptions when serializing to JSON.
+/// </summary>
+/// <param name="IncludeStackTrace">
+/// If <c>true</c>, the exception's stack trace and <see cref="Exception.Data"/> dictionary
+/// will be included in the JSON output. Defaults to <c>false</c> to avoid exposing sensitive information.
+/// </param>
+/// <param name="IncludeInnerExceptions">
+/// If <c>true</c>, inner exceptions (including <see cref="AggregateException.InnerExceptions"/>)
+/// will be included in the JSON output. Defaults to <c>true</c> to provide detailed context about the failure.
+/// </param>
+public sealed class ExceptionJsonConverter(bool IncludeStackTrace, bool IncludeInnerExceptions) : JsonConverter<Exception>
+{
+    /// <summary>
+    /// Deserialization is not supported.
+    /// </summary>
+    /// <exception cref="NotImplementedException">Always thrown.</exception>
+    public override Exception? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+            throw new NotImplementedException("Deserialization is not supported.");
+
+    /// <summary>
+    /// Writes an <see cref="Exception"/> object to JSON.
+    /// </summary>
+    /// <param name="writer">The <see cref="Utf8JsonWriter"/> to write to.</param>
+    /// <param name="value">The exception to serialize.</param>
+    /// <param name="options">The JSON serialization options.</param>
+    public override void Write(Utf8JsonWriter writer, Exception value, JsonSerializerOptions options) {
+        static string Name(JsonSerializerOptions opts, string name) => opts.PropertyNamingPolicy?.ConvertName(name) ?? name;
+
+        writer.WriteStartObject();
+        writer.WriteString(Name(options, "type"), value.GetType().FullName);
+        writer.WriteString(Name(options, "message"), value.Message);
+
+        if (IncludeStackTrace) {
+            writer.WriteString(Name(options, "stackTrace"), value.StackTrace ?? string.Empty);
+
+            if (value.Data?.Count > 0) {
+                writer.WritePropertyName(Name(options, "data"));
+                writer.WriteStartObject();
+                foreach (DictionaryEntry entry in value.Data) {
+                    var key = entry.Key?.ToString() ?? "null";
+                    var convertedKey = options.DictionaryKeyPolicy?.ConvertName(key) ?? key;
+                    writer.WritePropertyName(convertedKey);
+                    JsonSerializer.Serialize(writer, entry.Value, options);
+                }
+                writer.WriteEndObject();
+            }
+        }
+
+        if (IncludeInnerExceptions) {
+            if (value is AggregateException agg) {
+                writer.WritePropertyName(Name(options, "innerExceptions"));
+                JsonSerializer.Serialize(writer, agg.InnerExceptions, options);
+            } else if (value.InnerException is not null) {
+                writer.WritePropertyName(Name(options, "innerException"));
+                JsonSerializer.Serialize(writer, value.InnerException, options);
+            }
+        }
+
+        writer.WriteEndObject();
+    }
+}


### PR DESCRIPTION
An unhandled System.NotSupportedException occurs when the health check report contains any entry with an exception populated.

This PR fixes the issue by implementing a custom ExceptionConverter in JsonSerializer.
Also, it hides the exception object by default, when not in `Development` environment.

Example usage:
```csharp
builder.AddDefaultHealthChecks(x =>
    x.IncludeExceptionStackTrace = builder.Environment.IsDevelopment()
);
```

```An unhandled exception has occurred while executing the request.
      System.NotSupportedException: Serialization and deserialization of 'System.Reflection.MethodBase' instances is not supported. Path: $.Entries.Exception.TargetSite.
       ---> System.NotSupportedException: Serialization and deserialization of 'System.Reflection.MethodBase' instances is not supported.
         at System.Text.Json.Serialization.Converters.UnsupportedTypeConverter`1.Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
         at System.Text.Json.Serialization.JsonConverter`1.TryWrite(Utf8JsonWriter writer, T& value, JsonSerializerOptions options, WriteStack& state)
         at System.Text.Json.Serialization.Metadata.JsonPropertyInfo`1.GetMemberAndWriteJson(Object obj, WriteStack& state, Utf8JsonWriter writer)
         at System.Text.Json.Serialization.Converters.ObjectDefaultConverter`1.OnTryWrite(Utf8JsonWriter writer, T value, JsonSerializerOptions options, WriteStack& state)
         at System.Text.Json.Serialization.JsonConverter`1.TryWrite(Utf8JsonWriter writer, T& value, JsonSerializerOptions options, WriteStack& state)
         at System.Text.Json.Serialization.Metadata.JsonPropertyInfo`1.GetMemberAndWriteJson(Object obj, WriteStack& state, Utf8JsonWriter writer)
         at System.Text.Json.Serialization.Converters.ObjectDefaultConverter`1.OnTryWrite(Utf8JsonWriter writer, T value, JsonSerializerOptions options, WriteStack& state)
         at System.Text.Json.Serialization.JsonConverter`1.TryWrite(Utf8JsonWriter writer, T& value, JsonSerializerOptions options, WriteStack& state)
         at System.Text.Json.Serialization.Converters.DictionaryDefaultConverter`3.OnWriteResume(Utf8JsonWriter writer, TDictionary value, JsonSerializerOptions options, WriteStack& state)
         at System.Text.Json.Serialization.JsonDictionaryConverter`3.OnTryWrite(Utf8JsonWriter writer, TDictionary dictionary, JsonSerializerOptions options, WriteStack& state)
         at System.Text.Json.Serialization.JsonConverter`1.TryWrite(Utf8JsonWriter writer, T& value, JsonSerializerOptions options, WriteStack& state)
         at System.Text.Json.Serialization.Metadata.JsonPropertyInfo`1.GetMemberAndWriteJson(Object obj, WriteStack& state, Utf8JsonWriter writer)
         at System.Text.Json.Serialization.Converters.ObjectDefaultConverter`1.OnTryWrite(Utf8JsonWriter writer, T value, JsonSerializerOptions options, WriteStack& state)
         at System.Text.Json.Serialization.JsonConverter`1.TryWrite(Utf8JsonWriter writer, T& value, JsonSerializerOptions options, WriteStack& state)
```