### PR TITLE
[Cases] Update lookup widget to match the new lookup endpoint contract

### DIFF
--- a/src/Indice.Features.Cases.App/src/app/shared/ajsf/json-schema-frameworks/tailwind-framework/lookup-selector-widget/lookup-selector-widget.component.ts
+++ b/src/Indice.Features.Cases.App/src/app/shared/ajsf/json-schema-frameworks/tailwind-framework/lookup-selector-widget/lookup-selector-widget.component.ts
@@ -159,7 +159,7 @@ export class LookupSelectorWidgetComponent implements OnInit, OnDestroy {
     // Do we have parameters passed from layout configuration?
     if (this.options['lookup-filter-terms']) {
       // Deep clone the array (we don't want the options to be changed)
-      lookupFilterTerms = _.cloneDeep(this.options['lookup-filter-terms']).map((ft: any) => new FilterClause(ft.key || ft.member, ft.value));
+      lookupFilterTerms = _.cloneDeep(this.options['lookup-filter-terms']).map((ft: any) => new FilterClause(ft.key, ft.value));
     }
     // Notice that we always send a customerId.
     // Not really a problem: it can be ignored server-side if not needed.

--- a/src/Indice.Features.Cases.App/src/app/shared/ajsf/json-schema-frameworks/tailwind-framework/lookup-selector-widget/lookup-selector-widget.component.ts
+++ b/src/Indice.Features.Cases.App/src/app/shared/ajsf/json-schema-frameworks/tailwind-framework/lookup-selector-widget/lookup-selector-widget.component.ts
@@ -159,7 +159,7 @@ export class LookupSelectorWidgetComponent implements OnInit, OnDestroy {
     // Do we have parameters passed from layout configuration?
     if (this.options['lookup-filter-terms']) {
       // Deep clone the array (we don't want the options to be changed)
-      lookupFilterTerms = _.cloneDeep(this.options['lookup-filter-terms']);
+      lookupFilterTerms = _.cloneDeep(this.options['lookup-filter-terms']).map((ft: any) => new FilterClause(ft.key || ft.member, ft.value));
     }
     // Notice that we always send a customerId.
     // Not really a problem: it can be ignored server-side if not needed.


### PR DESCRIPTION
# What
The ajsj widget was sending invalid query parameters due to changes in the lookup endpoint contract:

`.../api/manage/lookups/productCode?filterTerms=[object Object]&filterTerms=customerId::eq::12345`

# Fix
This fix updates the widget to correctly read from the layout, map data to the FilterClause object, and generate valid query parameters.

# Sample ajsf layout with `lookup-filter-terms`
it's an arbitrary array in the layout, with 2 `key-value` properties that will be resolved from the LookUpEndpoint
```json
{
          "type": "flex",
          "flex-flow": "row wrap",
          "items": [
            {
              "key": "productCode",
              "flex": "1 1 280px",
              "title": "Λογαριασμός",
              "type": "lookup-selector",
              "case-channel": "Agent",
              "lookup-name": "productCode",
              "lookup-filter-terms": [
                {
                  "key": "caseType",
                  "value": "Some value"
                }
              ],
              "placeholder": "Λογαριασμός",
              "readonly": true,
              "validationMessages": {
                "required": "Υποχρεωτικό Πεδίο."
              }
            }
          ]
        },
```