### PR TITLE
[hotfix] Bump version to 8.34, fix IdentityModel compatibility

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,7 +4,7 @@
       <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
       <!--<TargetFramework></TargetFramework>-->
       <VersionPrefixMajor>8</VersionPrefixMajor>
-      <VersionPrefixBase>$(VersionPrefixMajor).33</VersionPrefixBase>
+      <VersionPrefixBase>$(VersionPrefixMajor).34</VersionPrefixBase>
 
       <VersionPrefixCore>$(VersionPrefixBase).0</VersionPrefixCore>
       <VersionPrefixIdentity>$(VersionPrefixBase).0</VersionPrefixIdentity>

--- a/src/Indice.AspNetCore.Builder/Indice.AspNetCore.Builder.csproj
+++ b/src/Indice.AspNetCore.Builder/Indice.AspNetCore.Builder.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.14.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.14.0" />
     <PackageReference Include="OpenTelemetry.Resources.Container" Version="1.13.0-beta.1" />
-    <PackageReference Include="Duende.AspNetCore.Authentication.OAuth2Introspection" Version="7.0.0" />
+    <PackageReference Include="Duende.AspNetCore.Authentication.OAuth2Introspection" Version="6.3.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">

--- a/src/Indice.AspNetCore.Builder/WebApplicationBuilderExtensions.cs
+++ b/src/Indice.AspNetCore.Builder/WebApplicationBuilderExtensions.cs
@@ -114,6 +114,7 @@ public static class WebApplicationBuilderExtensions
             // Having multiple instances of the same application with distributed cache configured (Redis, Sql) is not an issue.
             // Having same distributed cache configuration for difference applications, regardless of instance count, is a problem.
             // Add cache key to avoid caching the same token for different api hosts
+            options.EnableCaching = true;
             options.CacheKeyPrefix = $"{options.ClientId}_";
             options.CacheDuration = TimeSpan.FromMinutes(5); // 5 minutes is the default. Should potentially go back up to defaults.
         };


### PR DESCRIPTION
Updated project version to 8.34.x. Downgraded Duende OAuth2Introspection package from 7.0.0 to 6.3.0 for compatibility. Explicitly enabled token introspection caching in WebApplicationBuilderExtensions.cs.