### PR TITLE
[signalrproxy] - Add optional prefix functionality for hub names

### DIFF
--- a/src/Indice.AspNetCore/Features/SignalRProxy/SignalRProxyApi.cs
+++ b/src/Indice.AspNetCore/Features/SignalRProxy/SignalRProxyApi.cs
@@ -34,50 +34,50 @@ public static class SignalRProxyApi
             .ProducesProblem(StatusCodes.Status403Forbidden);
 
         // my endpoints
-        var negotiateEndpoint = group.MapPost("hubs/{hub}/negotiate", SignalRProxyHandlers.Negotiate)
+        var negotiateEndpoint = group.MapPost("hubs/{hubName}/negotiate", SignalRProxyHandlers.Negotiate)
             .WithDescription(SignalRProxyHandlers.NEGOTIATE)
             .WithSummary("Negotiate a SignalR connection for the authenticated user.")
             .WithName(nameof(SignalRProxyHandlers.Negotiate)).AllowAnonymous();
         if (options.NegotiateAuthenticationSchemes.Any()) {
             negotiateEndpoint.RequireAuthorization(pb => pb.RequireAuthenticatedUser().AddAuthenticationSchemes(options.NegotiateAuthenticationSchemes.ToArray()));
         }
-        group.MapPost("hubs/{hub}/groups/join/me", SignalRProxyHandlers.JoinGroups)
+        group.MapPost("hubs/{hubName}/groups/join/me", SignalRProxyHandlers.JoinGroups)
             .WithDescription(SignalRProxyHandlers.JOINGROUPS)
             .WithSummary("Join the current user to a SignalR group")
             .WithName(nameof(SignalRProxyHandlers.JoinGroups)).AllowAnonymous();
 
-        group.MapPost("hubs/{hub}/groups/leave/me", SignalRProxyHandlers.LeaveGroups)
+        group.MapPost("hubs/{hubName}/groups/leave/me", SignalRProxyHandlers.LeaveGroups)
             .WithDescription(SignalRProxyHandlers.LEAVEGROUPS)
             .WithSummary("Remove the current user from a SignalR group")
             .WithName(nameof(SignalRProxyHandlers.LeaveGroups)).AllowAnonymous();
 
         // management endpoints
-        group.MapPost("hubs/{hub}/groups/{groupName}/join/{userId}", SignalRProxyHandlers.AddUserToGroup)
+        group.MapPost("hubs/{hubName}/groups/{groupName}/join/{userId}", SignalRProxyHandlers.AddUserToGroup)
             .WithDescription(SignalRProxyHandlers.ADDUSERTOGROUP)
             .WithSummary("Add a user to a SignalR group.")
             .WithName(nameof(SignalRProxyHandlers.AddUserToGroup))
             .RequireAuthorization(x => x.RequireAssertion(ctx => ctx.User.IsSystemClient() || ctx.User.IsAdmin()));
 
-        group.MapPost("hubs/{hub}/groups/{groupName}/leave/{userId}", SignalRProxyHandlers.RemoveUserFromGroup)
+        group.MapPost("hubs/{hubName}/groups/{groupName}/leave/{userId}", SignalRProxyHandlers.RemoveUserFromGroup)
             .WithDescription(SignalRProxyHandlers.REMOVEUSERFROMGROUP)
             .WithSummary("Remove a user from a SignalR group.")
             .WithName(nameof(SignalRProxyHandlers.RemoveUserFromGroup))
             .RequireAuthorization(x => x.RequireAssertion(ctx => ctx.User.IsSystemClient() || ctx.User.IsAdmin()));
 
 
-        group.MapPost("hubs/{hub}/users/{userId}/broadcast", SignalRProxyHandlers.BroadcastToUser)
+        group.MapPost("hubs/{hubName}/users/{userId}/broadcast", SignalRProxyHandlers.BroadcastToUser)
             .WithDescription(SignalRProxyHandlers.BROADCASTTOUSER)
             .WithSummary("Broadcast a message to a specific user.")
             .WithName(nameof(SignalRProxyHandlers.BroadcastToUser)).WithExampleRequestBody( new { Method = "broadcast", Message = "Hello!" })
             .RequireAuthorization(x => x.RequireAssertion(ctx => ctx.User.IsSystemClient() || ctx.User.IsAdmin()));
 
-        group.MapPost("hubs/{hub}/connections/{connectionId}/broadcast", SignalRProxyHandlers.BroadcastToConnection)
+        group.MapPost("hubs/{hubName}/connections/{connectionId}/broadcast", SignalRProxyHandlers.BroadcastToConnection)
             .WithDescription(SignalRProxyHandlers.BROADCASTTOCONNECTION)
             .WithSummary("Broadcast a message to a specific connection.")
             .WithName(nameof(SignalRProxyHandlers.BroadcastToConnection)).WithExampleRequestBody(new { Method = "broadcast", Message = "Hello!" })
             .RequireAuthorization(x => x.RequireAssertion(ctx => ctx.User.IsSystemClient() || ctx.User.IsAdmin()));
 
-        group.MapPost("hubs/{hub}/groups/{groupName}/broadcast", SignalRProxyHandlers.BroadcastToGroup)
+        group.MapPost("hubs/{hubName}/groups/{groupName}/broadcast", SignalRProxyHandlers.BroadcastToGroup)
             .WithDescription(SignalRProxyHandlers.BROADCASTTOGROUP)
             .WithSummary("Broadcast a message to a SignalR group.")
             .WithName(nameof(SignalRProxyHandlers.BroadcastToGroup)).WithExampleRequestBody(new { Method = "broadcast", Message = "Hello!" })

--- a/src/Indice.AspNetCore/Features/SignalRProxy/SignalRProxyFeatureExtensions.cs
+++ b/src/Indice.AspNetCore/Features/SignalRProxy/SignalRProxyFeatureExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using Indice.AspNetCore.Features.SignalRProxy;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Configuration;
+using Indice.Services;
 using Microsoft.Extensions.DependencyInjection;
 
 
@@ -14,13 +13,10 @@ public static class SignalRProxyFeatureExtensions
     /// <summary>
     /// Adds SignalR endpoint services to the application.
     /// </summary>
-    /// <param name="builder"></param>
-    /// <param name="configureAction"></param>
+    /// <param name="builder">The application builder.</param>
+    /// <param name="configureAction">An optional action to configure the SignalR proxy options.</param>
     public static IHostApplicationBuilder AddSignalRProxy(this IHostApplicationBuilder builder, Action<SignalRProxyOptions>? configureAction = null) {
-        builder.Services.AddSignalRProxyCoreServices(options => {
-            options.ConnectionString = builder.Configuration.GetConnectionString("SignalR");
-        });
-        
+        builder.Services.AddSignalRProxyCoreServices();
         // Register default user ID resolver
         builder.Services.AddSingleton<ISignalRProxyUserIdResolver, DefaultSignalRProxyUserIdResolver>();
         
@@ -33,8 +29,10 @@ public static class SignalRProxyFeatureExtensions
         });
         
         if(configureAction is not null) {
-            builder.Services.PostConfigure(configureAction);
+            builder.Services.Configure(configureAction);
         }
+        builder.Services.ConfigureOptions<PostConfigureSignalRProxyCoreOptions>();
+
         return builder;
     }
 }

--- a/src/Indice.AspNetCore/Features/SignalRProxy/SignalRProxyHandlers.cs
+++ b/src/Indice.AspNetCore/Features/SignalRProxy/SignalRProxyHandlers.cs
@@ -25,7 +25,7 @@ internal static class SignalRProxyHandlers
         ISignalRProxyGroupNameValidator groupNameValidator,
         CancellationToken cancellationToken)
     {
-
+        var hubName = options.Value.GetHubName(hub);
         if (options.Value.AllowedHubs is null || !options.Value.AllowedHubs.Contains(hub)) {
             return TypedResults.ValidationProblem(ValidationErrors.AddError(nameof(hub), $"The hub '{hub}' is not recognized."));
         }
@@ -44,7 +44,7 @@ internal static class SignalRProxyHandlers
             return validationError;
         }
 
-        var response = await signalRNegotiateService.NegotiateAsync(hub, autoGroupNames, userId, cancellationToken);
+        var response = await signalRNegotiateService.NegotiateAsync(hubName, autoGroupNames, userId, cancellationToken);
         return TypedResults.Ok(response);
     }
 
@@ -61,6 +61,7 @@ internal static class SignalRProxyHandlers
         CancellationToken cancellationToken)
     {
 
+        var hubName = options.Value.GetHubName(hub);
         var errors = ValidationErrors.Create();
         var userId = userIdResolver.Resolve(httpContext, currentUser);
         if (options.Value.AllowedHubs is null || !options.Value.AllowedHubs.Contains(hub)) {
@@ -83,10 +84,10 @@ internal static class SignalRProxyHandlers
         }
 
         if (!string.IsNullOrWhiteSpace(connectionId)) {
-            await signalRNegotiateService.AddConnectionToGroupsAsync(hub, connectionId!, groupNames.ToList(), cancellationToken);
+            await signalRNegotiateService.AddConnectionToGroupsAsync(hubName, connectionId!, groupNames.ToList(), cancellationToken);
         }
         else {
-            await signalRNegotiateService.AddUserToGroupsAsync(hub, userId!, groupNames.ToList(), cancellationToken);
+            await signalRNegotiateService.AddUserToGroupsAsync(hubName, userId!, groupNames.ToList(), cancellationToken);
         }
         return TypedResults.NoContent();
     }
@@ -103,7 +104,7 @@ internal static class SignalRProxyHandlers
         ISignalRProxyGroupNameValidator groupNameValidator,
         CancellationToken cancellationToken)
     {
-
+        var hubName = options.Value.GetHubName(hub);
         var errors = ValidationErrors.Create();
         var userId = userIdResolver.Resolve(httpContext, currentUser);
         if (options.Value.AllowedHubs is null || !options.Value.AllowedHubs.Contains(hub)) {
@@ -126,10 +127,10 @@ internal static class SignalRProxyHandlers
         }
 
         if (!string.IsNullOrWhiteSpace(connectionId)) {
-            await signalRNegotiateService.RemoveConnectionFromGroupsAsync(hub, connectionId!, groupNames.ToList(), cancellationToken);
+            await signalRNegotiateService.RemoveConnectionFromGroupsAsync(hubName, connectionId!, groupNames.ToList(), cancellationToken);
         }
         else {
-            await signalRNegotiateService.RemoveUserFromGroupsAsync(hub, userId!, groupNames.ToList(), cancellationToken);
+            await signalRNegotiateService.RemoveUserFromGroupsAsync(hubName, userId!, groupNames.ToList(), cancellationToken);
         }
         return TypedResults.NoContent();
     }
@@ -145,6 +146,7 @@ internal static class SignalRProxyHandlers
         ISignalRProxyGroupNameValidator groupNameValidator,
         CancellationToken cancellationToken)
     {
+        var hubName = options.Value.GetHubName(hub);
         var errors = ValidationErrors.Create();
         if (options.Value.AllowedHubs is null || !options.Value.AllowedHubs.Contains(hub)) {
             errors.AddError(nameof(hub), $"The hub '{hub}' is not recognized.");
@@ -165,7 +167,7 @@ internal static class SignalRProxyHandlers
             return validationError;
         }
 
-        await signalRNegotiateService.AddUserToGroupsAsync(hub, userId!, [groupName], cancellationToken);
+        await signalRNegotiateService.AddUserToGroupsAsync(hubName, userId!, [groupName], cancellationToken);
         return TypedResults.NoContent();
     }
 
@@ -177,10 +179,11 @@ internal static class SignalRProxyHandlers
         ISignalRProxyBroadcastService signalBroadcastService,
         IOptions<SignalRProxyOptions> options)
     {
+        var hubName = options.Value.GetHubName(hub);
         if (options.Value.AllowedHubs is null || !options.Value.AllowedHubs.Contains(hub)) {
             return TypedResults.ValidationProblem(ValidationErrors.AddError(nameof(hub), $"The hub '{hub}' is not recognized."));
         }
-        await signalBroadcastService.BroadcastToUserAsync(hub, userId, command, cancellationToken);
+        await signalBroadcastService.BroadcastToUserAsync(hubName, userId, command, cancellationToken);
         return TypedResults.NoContent();
     }
 
@@ -193,6 +196,7 @@ internal static class SignalRProxyHandlers
         IOptions<SignalRProxyOptions> options,
         ISignalRProxyGroupNameValidator groupNameValidator)
     {
+        var hubName = options.Value.GetHubName(hub);
         if (options.Value.AllowedHubs is null || !options.Value.AllowedHubs.Contains(hub)) {
             return TypedResults.ValidationProblem(ValidationErrors.AddError(nameof(hub), $"The hub '{hub}' is not recognized."));
         }
@@ -202,8 +206,7 @@ internal static class SignalRProxyHandlers
         if (validationError is not null) {
             return validationError;
         }
-
-        await signalBroadcastService.BroadcastToGroupAsync(hub, groupName, command, cancellationToken);
+        await signalBroadcastService.BroadcastToGroupAsync(hubName, groupName, command, cancellationToken);
         return TypedResults.NoContent();
     }
 
@@ -215,10 +218,11 @@ internal static class SignalRProxyHandlers
         ISignalRProxyBroadcastService signalBroadcastService,
         IOptions<SignalRProxyOptions> options)
     {
+        var hubName = options.Value.GetHubName(hub);
         if (options.Value.AllowedHubs is null || !options.Value.AllowedHubs.Contains(hub)) {
             return TypedResults.ValidationProblem(ValidationErrors.AddError(nameof(hub), $"The hub '{hub}' is not recognized."));
         }
-        await signalBroadcastService.BroadcastToConnectionAsync(hub, connectionId, command, cancellationToken);
+        await signalBroadcastService.BroadcastToConnectionAsync(hubName, connectionId, command, cancellationToken);
         return TypedResults.NoContent();
     }
 
@@ -231,7 +235,7 @@ internal static class SignalRProxyHandlers
         IOptions<SignalRProxyOptions> options,
         CancellationToken cancellationToken)
     {
-
+        var hubName = options.Value.GetHubName(hub);
         var errors = ValidationErrors.Create();
         if (options.Value.AllowedHubs is null || !options.Value.AllowedHubs.Contains(hub)) {
             errors.AddError(nameof(hub), $"The hub '{hub}' is not recognized.");
@@ -245,7 +249,7 @@ internal static class SignalRProxyHandlers
         if (errors.Count > 0) {
             return TypedResults.ValidationProblem(errors);
         }
-        await signalRNegotiateService.RemoveUserFromGroupsAsync(hub, userId!, [groupName], cancellationToken);
+        await signalRNegotiateService.RemoveUserFromGroupsAsync(hubName, userId!, [groupName], cancellationToken);
         return TypedResults.NoContent();
     }
 

--- a/src/Indice.AspNetCore/Features/SignalRProxy/SignalRProxyHandlers.cs
+++ b/src/Indice.AspNetCore/Features/SignalRProxy/SignalRProxyHandlers.cs
@@ -15,7 +15,7 @@ internal static class SignalRProxyHandlers
     //here I want to add a from query parameters groups to join automatically
     //the groupNames below are different types of groups that the user belongs to based on claims
     public static async Task<Results<Ok<SignalRNegotiationResponse>, ValidationProblem>> Negotiate(
-        [Description("The name of the SignalR hub to connect to.")] string hub,
+        [Description("The name of the SignalR hub to connect to.")] string hubName,
         [FromQuery(Name = "gps")] [Description("Optional array of group names to join upon connection.")] string[]? groupNames,
         ClaimsPrincipal currentUser,
         HttpContext httpContext,
@@ -25,31 +25,24 @@ internal static class SignalRProxyHandlers
         ISignalRProxyGroupNameValidator groupNameValidator,
         CancellationToken cancellationToken)
     {
-        var hubName = options.Value.GetHubName(hub);
-        if (options.Value.AllowedHubs is null || !options.Value.AllowedHubs.Contains(hub)) {
-            return TypedResults.ValidationProblem(ValidationErrors.AddError(nameof(hub), $"The hub '{hub}' is not recognized."));
+        if (options.Value.AllowedHubs is null || !options.Value.AllowedHubs.Contains(hubName)) {
+            return TypedResults.ValidationProblem(ValidationErrors.AddError(nameof(hubName), $"The hub '{hubName}' is not recognized."));
         }
         var userId = userIdResolver.Resolve(httpContext, currentUser);
-        var autoGroupNames = currentUser.Claims.Where(x => x.Type is not null && !string.IsNullOrWhiteSpace(x.Value))
-                                           .Where(x => options.Value.ClaimTypesForAutoGroups.Contains(x.Type))
-                                           .Select(x => options.Value.ClaimTypeToGroupName(x))
-                                           .ToList();
-        if (groupNames is not null && groupNames.Any()) {
-            autoGroupNames.AddRange(groupNames);
-        }
 
         // Validate group names
-        var validationError = await ValidateGroupNamesAsync(groupNameValidator, autoGroupNames);
-        if (validationError is not null) {
-            return validationError;
+        var messages = await ValidateGroupNamesAsync(groupNameValidator, groupNames);
+
+        if (messages.Any()) {
+            return TypedResults.ValidationProblem(ValidationErrors.AddErrors(nameof(groupNames), messages));
         }
 
-        var response = await signalRNegotiateService.NegotiateAsync(hubName, autoGroupNames, userId, cancellationToken);
+        var response = await signalRNegotiateService.NegotiateAsync(hubName, groupNames?.ToList() ?? [], userId, cancellationToken);
         return TypedResults.Ok(response);
     }
 
     public static async Task<Results<NoContent, ValidationProblem>> JoinGroups(
-        [Description("The name of the SignalR hub.")] string hub,
+        [Description("The name of the SignalR hub.")] string hubName,
         [FromQuery(Name = "gps")] [Description("Array of group names to join.")] string[] groupNames,
         [FromHeader(Name = "X-Connection-ID")] [Description("The connection ID of the SignalR client.")] string? connectionId,
         ClaimsPrincipal currentUser,
@@ -61,11 +54,10 @@ internal static class SignalRProxyHandlers
         CancellationToken cancellationToken)
     {
 
-        var hubName = options.Value.GetHubName(hub);
         var errors = ValidationErrors.Create();
         var userId = userIdResolver.Resolve(httpContext, currentUser);
-        if (options.Value.AllowedHubs is null || !options.Value.AllowedHubs.Contains(hub)) {
-            errors.AddError(nameof(hub), $"The hub '{hub}' is not recognized.");
+        if (options.Value.AllowedHubs is null || !options.Value.AllowedHubs.Contains(hubName)) {
+            errors.AddError(nameof(hubName), $"The hub '{hubName}' is not recognized.");
         }
         if (groupNames.Length == 0) {
             errors.AddError(nameof(groupNames), "The group names cannot be null or empty.");
@@ -78,9 +70,10 @@ internal static class SignalRProxyHandlers
         }
 
         // Validate group names
-        var validationError = await ValidateGroupNamesAsync(groupNameValidator, groupNames);
-        if (validationError is not null) {
-            return validationError;
+        errors.AddErrors(nameof(groupNames), await ValidateGroupNamesAsync(groupNameValidator, groupNames));
+
+        if (errors.Count > 0) {
+            return TypedResults.ValidationProblem(errors);
         }
 
         if (!string.IsNullOrWhiteSpace(connectionId)) {
@@ -93,7 +86,7 @@ internal static class SignalRProxyHandlers
     }
 
     public static async Task<Results<NoContent, ValidationProblem>> LeaveGroups(
-        [Description("The name of the SignalR hub.")] string hub,
+        [Description("The name of the SignalR hub.")] string hubName,
         [FromQuery(Name = "gps")] [Description("Array of group names to leave.")] string[] groupNames,
         [FromHeader(Name = "X-Connection-ID")] [Description("The connection ID of the SignalR client.")] string? connectionId,
         ClaimsPrincipal currentUser,
@@ -104,11 +97,10 @@ internal static class SignalRProxyHandlers
         ISignalRProxyGroupNameValidator groupNameValidator,
         CancellationToken cancellationToken)
     {
-        var hubName = options.Value.GetHubName(hub);
         var errors = ValidationErrors.Create();
         var userId = userIdResolver.Resolve(httpContext, currentUser);
-        if (options.Value.AllowedHubs is null || !options.Value.AllowedHubs.Contains(hub)) {
-            errors.AddError(nameof(hub), $"The hub '{hub}' is not recognized.");
+        if (options.Value.AllowedHubs is null || !options.Value.AllowedHubs.Contains(hubName)) {
+            errors.AddError(nameof(hubName), $"The hub '{hubName}' is not recognized.");
         }
         if (groupNames.Length == 0) {
             errors.AddError(nameof(groupNames), "The group names cannot be null or empty.");
@@ -121,9 +113,10 @@ internal static class SignalRProxyHandlers
         }
 
         // Validate group names
-        var validationError = await ValidateGroupNamesAsync(groupNameValidator, groupNames);
-        if (validationError is not null) {
-            return validationError;
+        errors.AddErrors(nameof(groupNames), await ValidateGroupNamesAsync(groupNameValidator, groupNames));
+
+        if (errors.Count > 0) {
+            return TypedResults.ValidationProblem(errors);
         }
 
         if (!string.IsNullOrWhiteSpace(connectionId)) {
@@ -138,7 +131,7 @@ internal static class SignalRProxyHandlers
     // these methods are meant to be used for administering purposes only. For example, adding a user to groups based on external events.
 
     public static async Task<Results<NoContent, ValidationProblem>> AddUserToGroup(
-        [Description("The name of the SignalR hub.")] string hub,
+        [Description("The name of the SignalR hub.")] string hubName,
         [Description("The name of the group to add the user to.")] string groupName,
         [Description("The ID of the user to add to the group.")] string userId,
         ISignalRProxyNegotiatiationService signalRNegotiateService,
@@ -146,10 +139,9 @@ internal static class SignalRProxyHandlers
         ISignalRProxyGroupNameValidator groupNameValidator,
         CancellationToken cancellationToken)
     {
-        var hubName = options.Value.GetHubName(hub);
         var errors = ValidationErrors.Create();
-        if (options.Value.AllowedHubs is null || !options.Value.AllowedHubs.Contains(hub)) {
-            errors.AddError(nameof(hub), $"The hub '{hub}' is not recognized.");
+        if (options.Value.AllowedHubs is null || !options.Value.AllowedHubs.Contains(hubName)) {
+            errors.AddError(nameof(hubName), $"The hub '{hubName}' is not recognized.");
         }
         if (string.IsNullOrWhiteSpace(groupName)) {
             errors.AddError(nameof(groupName), "The groupName cannot be null or empty.");
@@ -157,14 +149,10 @@ internal static class SignalRProxyHandlers
         if (string.IsNullOrWhiteSpace(userId)) {
             errors.AddError(nameof(userId), "The userId cannot be null or empty.");
         }
+        // Validate group name
+        errors.AddErrors(nameof(groupName), await ValidateGroupNameAsync(groupNameValidator, groupName));
         if (errors.Count > 0) {
             return TypedResults.ValidationProblem(errors);
-        }
-
-        // Validate group name
-        var validationError = await ValidateGroupNameAsync(groupNameValidator, groupName);
-        if (validationError is not null) {
-            return validationError;
         }
 
         await signalRNegotiateService.AddUserToGroupsAsync(hubName, userId!, [groupName], cancellationToken);
@@ -172,23 +160,22 @@ internal static class SignalRProxyHandlers
     }
 
     public static async Task<Results<NoContent, ValidationProblem>> BroadcastToUser(
-        [Description("The name of the SignalR hub to broadcast through.")] string hub,
+        [Description("The name of the SignalR hub to broadcast through.")] string hubName,
         [Description("The ID of the user to broadcast the message to.")] string userId,
         [Description("The SignalR broadcast command containing the method name and message.")] SignalRBroadcastCommand command,
         CancellationToken cancellationToken,
         ISignalRProxyBroadcastService signalBroadcastService,
         IOptions<SignalRProxyOptions> options)
     {
-        var hubName = options.Value.GetHubName(hub);
-        if (options.Value.AllowedHubs is null || !options.Value.AllowedHubs.Contains(hub)) {
-            return TypedResults.ValidationProblem(ValidationErrors.AddError(nameof(hub), $"The hub '{hub}' is not recognized."));
+        if (options.Value.AllowedHubs is null || !options.Value.AllowedHubs.Contains(hubName)) {
+            return TypedResults.ValidationProblem(ValidationErrors.AddError(nameof(hubName), $"The hub '{hubName}' is not recognized."));
         }
         await signalBroadcastService.BroadcastToUserAsync(hubName, userId, command, cancellationToken);
         return TypedResults.NoContent();
     }
 
     public static async Task<Results<NoContent, ValidationProblem>> BroadcastToGroup(
-        [Description("The name of the SignalR hub to broadcast through.")] string hub,
+        [Description("The name of the SignalR hub to broadcast through.")] string hubName,
         [Description("The name of the group to broadcast to.")] string groupName,
         [Description("The SignalR broadcast command containing the method name and message.")] SignalRBroadcastCommand command,
         CancellationToken cancellationToken,
@@ -196,31 +183,29 @@ internal static class SignalRProxyHandlers
         IOptions<SignalRProxyOptions> options,
         ISignalRProxyGroupNameValidator groupNameValidator)
     {
-        var hubName = options.Value.GetHubName(hub);
-        if (options.Value.AllowedHubs is null || !options.Value.AllowedHubs.Contains(hub)) {
-            return TypedResults.ValidationProblem(ValidationErrors.AddError(nameof(hub), $"The hub '{hub}' is not recognized."));
+        if (options.Value.AllowedHubs is null || !options.Value.AllowedHubs.Contains(hubName)) {
+            return TypedResults.ValidationProblem(ValidationErrors.AddError(nameof(hubName), $"The hub '{hubName}' is not recognized."));
         }
 
         // Validate group name
-        var validationError = await ValidateGroupNameAsync(groupNameValidator, groupName);
-        if (validationError is not null) {
-            return validationError;
+        var validationErrors = await ValidateGroupNameAsync(groupNameValidator, groupName);
+        if (validationErrors.Any()) {
+            return TypedResults.ValidationProblem(ValidationErrors.AddErrors(nameof(groupName),  validationErrors));
         }
         await signalBroadcastService.BroadcastToGroupAsync(hubName, groupName, command, cancellationToken);
         return TypedResults.NoContent();
     }
 
     public static async Task<Results<NoContent, ValidationProblem>> BroadcastToConnection(
-        [Description("The name of the SignalR hub to broadcast through.")] string hub,
+        [Description("The name of the SignalR hub to broadcast through.")] string hubName,
         [Description("The connection ID to broadcast the message to.")] string connectionId,
         [Description("The SignalR broadcast command containing the method name and message.")] SignalRBroadcastCommand command,
         CancellationToken cancellationToken,
         ISignalRProxyBroadcastService signalBroadcastService,
         IOptions<SignalRProxyOptions> options)
     {
-        var hubName = options.Value.GetHubName(hub);
-        if (options.Value.AllowedHubs is null || !options.Value.AllowedHubs.Contains(hub)) {
-            return TypedResults.ValidationProblem(ValidationErrors.AddError(nameof(hub), $"The hub '{hub}' is not recognized."));
+        if (options.Value.AllowedHubs is null || !options.Value.AllowedHubs.Contains(hubName)) {
+            return TypedResults.ValidationProblem(ValidationErrors.AddError(nameof(hubName), $"The hub '{hubName}' is not recognized."));
         }
         await signalBroadcastService.BroadcastToConnectionAsync(hubName, connectionId, command, cancellationToken);
         return TypedResults.NoContent();
@@ -228,17 +213,16 @@ internal static class SignalRProxyHandlers
 
 
     public static async Task<Results<NoContent, ValidationProblem>> RemoveUserFromGroup(
-        [Description("The name of the SignalR hub.")] string hub,
+        [Description("The name of the SignalR hub.")] string hubName,
         [Description("The name of the group to remove the user from.")] string groupName,
         [Description("The ID of the user to remove from the group.")] string userId,
         ISignalRProxyNegotiatiationService signalRNegotiateService,
         IOptions<SignalRProxyOptions> options,
         CancellationToken cancellationToken)
     {
-        var hubName = options.Value.GetHubName(hub);
         var errors = ValidationErrors.Create();
-        if (options.Value.AllowedHubs is null || !options.Value.AllowedHubs.Contains(hub)) {
-            errors.AddError(nameof(hub), $"The hub '{hub}' is not recognized.");
+        if (options.Value.AllowedHubs is null || !options.Value.AllowedHubs.Contains(hubName)) {
+            errors.AddError(nameof(hubName), $"The hub '{hubName}' is not recognized.");
         }
         if (string.IsNullOrWhiteSpace(groupName)) {
             errors.AddError(nameof(groupName), "The groupName cannot be null or empty.");
@@ -259,35 +243,29 @@ internal static class SignalRProxyHandlers
     /// </summary>
     /// <param name="groupNameValidator">The group name validator.</param>
     /// <param name="groupName">The group name to validate.</param>
-    /// <returns>A ValidationProblem result if validation fails, otherwise null.</returns>
-    private static async Task<ValidationProblem?> ValidateGroupNameAsync(ISignalRProxyGroupNameValidator groupNameValidator, string groupName)
-    {
-        var isValid = await groupNameValidator.ValidateAsync(groupName);
-        if (!isValid) {
-            return TypedResults.ValidationProblem(ValidationErrors.AddError(nameof(groupName), $"The group name '{groupName}' is not valid."));
-        }
-        return null;
-    }
+    /// <returns>A list of validation errors.</returns>
+    private static Task<IEnumerable<string>> ValidateGroupNameAsync(ISignalRProxyGroupNameValidator groupNameValidator, string groupName)
+        => ValidateGroupNamesAsync(groupNameValidator, [groupName]);
+
 
     /// <summary>
     /// Validates multiple group names using the registered validator.
     /// </summary>
     /// <param name="groupNameValidator">The group name validator.</param>
     /// <param name="groupNames">The group names to validate.</param>
-    /// <returns>A ValidationProblem result if validation fails, otherwise null.</returns>
-    private static async Task<ValidationProblem?> ValidateGroupNamesAsync(ISignalRProxyGroupNameValidator groupNameValidator, IEnumerable<string> groupNames)
-    {
-        var errors = ValidationErrors.Create();
+    /// <returns>A list of validation errors.</returns>
+    private static async Task<IEnumerable<string>> ValidateGroupNamesAsync(ISignalRProxyGroupNameValidator groupNameValidator, IEnumerable<string>? groupNames) {
+        List<string> errors = [];
+        if (groupNames is null) {
+            return errors;
+        }
         foreach (var groupName in groupNames) {
             var isValid = await groupNameValidator.ValidateAsync(groupName);
             if (!isValid) {
-                errors.AddError(nameof(groupNames), $"The group name '{groupName}' is not valid.");
+                errors.Add($"The group name '{groupName}' is not valid.");
             }
         }
-        if (errors.Count > 0) {
-            return TypedResults.ValidationProblem(errors);
-        }
-        return null;
+        return errors;
     }
     #endregion
 

--- a/src/Indice.AspNetCore/Features/SignalRProxy/SignalRProxyOptions.cs
+++ b/src/Indice.AspNetCore/Features/SignalRProxy/SignalRProxyOptions.cs
@@ -1,4 +1,5 @@
 using Indice.Services;
+using Microsoft.Azure.SignalR.Management;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
@@ -37,6 +38,11 @@ public class SignalRProxyOptions
     public bool UseEnvironmentNameAsHubPrefix { get; set; }
     /// <summary>Gets or sets the ApplicationName which will be prefixed to each hub name</summary>
     public string? ApplicationName { get; set; }
+
+    /// <summary>
+    /// Gets or sets an optional action to configure the <see cref="ServiceManagerOptions"/> for the SignalR service manager.
+    /// </summary>
+    public Action<ServiceManagerOptions>? ConfigureServiceManager { get; set; }
 
     /// <summary>Gets or sets the service collection for dependency injection.</summary>
     /// <remarks>This property is set during service registration and should not be modified directly.</remarks>
@@ -102,5 +108,7 @@ internal class PostConfigureSignalRProxyCoreOptions : IPostConfigureOptions<Sign
     /// </remarks>
     public void PostConfigure(string? name, SignalRProxyCoreOptions options) {
         options.AutoPrefixWithEnvironmentName = ApiOptions.Value.UseEnvironmentNameAsHubPrefix;
+        options.ApplicationName = ApiOptions.Value.ApplicationName;
+        options.ConfigureServiceManager = ApiOptions.Value.ConfigureServiceManager;
     }
 }

--- a/src/Indice.AspNetCore/Features/SignalRProxy/SignalRProxyOptions.cs
+++ b/src/Indice.AspNetCore/Features/SignalRProxy/SignalRProxyOptions.cs
@@ -34,6 +34,19 @@ public class SignalRProxyOptions
     /// <summary>List of allowed Hubs</summary>
     public List<string> AllowedHubs { get; set; } = [];
 
+    /// <summary>Optional prefix for Hub names.</summary>
+    public string? HubPrefix { get; set; } = null;
+
+    /// <summary>Delimeter for the optional prefix.</summary>
+    public char HubPrefixDelimiter { get; set; } = '_';
+
+    /// <summary>
+    /// Gets the full Hub name, by adding the optional prefix and delimiter if it is set.
+    /// </summary>
+    /// <param name="hubName"></param>
+    /// <returns></returns>
+    public string GetHubName(string hubName) => string.IsNullOrWhiteSpace(HubPrefix) ? hubName : $"{HubPrefix}{HubPrefixDelimiter}{hubName}";
+
     /// <summary>Gets or sets the service collection for dependency injection.</summary>
     /// <remarks>This property is set during service registration and should not be modified directly.</remarks>
     internal IServiceCollection Services

--- a/src/Indice.AspNetCore/Features/SignalRProxy/SignalRProxyOptions.cs
+++ b/src/Indice.AspNetCore/Features/SignalRProxy/SignalRProxyOptions.cs
@@ -43,7 +43,7 @@ public class SignalRProxyOptions
     /// <summary>
     /// Gets the full Hub name, by adding the optional prefix and delimiter if it is set.
     /// </summary>
-    /// <param name="hubName"></param>
+    /// <param name="hubName">The name of the Hub.</param>
     /// <returns></returns>
     public string GetHubName(string hubName) => string.IsNullOrWhiteSpace(HubPrefix) ? hubName : $"{HubPrefix}{HubPrefixDelimiter}{hubName}";
 

--- a/src/Indice.AspNetCore/Features/SignalRProxy/SignalRProxyOptions.cs
+++ b/src/Indice.AspNetCore/Features/SignalRProxy/SignalRProxyOptions.cs
@@ -1,7 +1,7 @@
-using System.Security.Claims;
-using Indice.Extensions;
+using Indice.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
 namespace Indice.AspNetCore.Features.SignalRProxy;
 
@@ -25,27 +25,17 @@ public class SignalRProxyOptions
     public string RequiredScope { get; set; } = null!;
     /// <summary>Decides whether to enable swagger/openapi documentation for the endpoint</summary>
     public bool ExcludeFromDescription { get; set; }
-    /// <summary>List of Claims types to auto-populate Groups if available on the current claim principal</summary>
-    public List<string> ClaimTypesForAutoGroups { get; set; } = [];
-
-    /// <summary>List of Claims types to auto-populate Groups if available on the current claim principal</summary>
-    /// <remarks>Defaults to <c>x => $"{x.Type}|{x.Value}"</c></remarks>
-    public SignalRClaimTypeToGroupNameTransformer ClaimTypeToGroupName { get; set; } = x => $"{x.Type}|{x.Value}";
     /// <summary>List of allowed Hubs</summary>
     public List<string> AllowedHubs { get; set; } = [];
-
-    /// <summary>Optional prefix for Hub names.</summary>
-    public string? HubPrefix { get; set; } = null;
-
-    /// <summary>Delimiter for the optional prefix.</summary>
-    public char HubPrefixDelimiter { get; set; } = '_';
-
     /// <summary>
-    /// Gets the full Hub name, by adding the optional prefix and delimiter if it is set.
+    /// Gets or sets a value indicating whether the environment name should be used as a prefix for SignalR hub names.
     /// </summary>
-    /// <param name="hubName">The name of the Hub.</param>
-    /// <returns></returns>
-    public string GetHubName(string hubName) => string.IsNullOrWhiteSpace(HubPrefix) ? hubName : $"{HubPrefix}{HubPrefixDelimiter}{hubName}";
+    /// <remarks>When enabled, the environment name (such as Development, Staging, or Production) is prepended
+    /// to the hub name. This can help isolate SignalR traffic between different deployment environments and prevent
+    /// cross-environment communication issues.</remarks>
+    public bool UseEnvironmentNameAsHubPrefix { get; set; }
+    /// <summary>Gets or sets the ApplicationName which will be prefixed to each hub name</summary>
+    public string? ApplicationName { get; set; }
 
     /// <summary>Gets or sets the service collection for dependency injection.</summary>
     /// <remarks>This property is set during service registration and should not be modified directly.</remarks>
@@ -79,8 +69,37 @@ public class SignalRProxyOptions
 }
 
 /// <summary>
-/// A delegate to transform a Claim to a SignalR Group Name
+/// Post-configures <see cref="SignalRProxyCoreOptions"/> by synchronizing configuration values from <see cref="SignalRProxyOptions"/>.
 /// </summary>
-/// <param name="claim">The claim to transform.</param>
-/// <returns>The transformed group name.</returns>
-public delegate string SignalRClaimTypeToGroupNameTransformer(Claim claim);
+/// <remarks>
+/// This class is part of the options pattern and is executed after the initial configuration to ensure that
+/// core options are properly aligned with the proxy options, specifically transferring the environment name prefix setting.
+/// </remarks>
+internal class PostConfigureSignalRProxyCoreOptions : IPostConfigureOptions<SignalRProxyCoreOptions>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PostConfigureSignalRProxyCoreOptions"/> class.
+    /// </summary>
+    /// <param name="apiOptions">The SignalR proxy options containing the configuration values to transfer.</param>
+    public PostConfigureSignalRProxyCoreOptions(IOptions<SignalRProxyOptions> apiOptions) {
+        ApiOptions = apiOptions;
+    }
+
+    /// <summary>
+    /// Gets the SignalR proxy options used for post-configuration.
+    /// </summary>
+    public IOptions<SignalRProxyOptions> ApiOptions { get; }
+
+    /// <summary>
+    /// Post-configures the SignalR proxy core options by transferring configuration values.
+    /// </summary>
+    /// <param name="name">The name of the options instance being configured.</param>
+    /// <param name="options">The options instance to configure.</param>
+    /// <remarks>
+    /// This method synchronizes the <see cref="SignalRProxyOptions.UseEnvironmentNameAsHubPrefix"/> value
+    /// to the <see cref="SignalRProxyCoreOptions.AutoPrefixWithEnvironmentName"/> property.
+    /// </remarks>
+    public void PostConfigure(string? name, SignalRProxyCoreOptions options) {
+        options.AutoPrefixWithEnvironmentName = ApiOptions.Value.UseEnvironmentNameAsHubPrefix;
+    }
+}

--- a/src/Indice.AspNetCore/Features/SignalRProxy/SignalRProxyOptions.cs
+++ b/src/Indice.AspNetCore/Features/SignalRProxy/SignalRProxyOptions.cs
@@ -37,7 +37,7 @@ public class SignalRProxyOptions
     /// <summary>Optional prefix for Hub names.</summary>
     public string? HubPrefix { get; set; } = null;
 
-    /// <summary>Delimeter for the optional prefix.</summary>
+    /// <summary>Delimiter for the optional prefix.</summary>
     public char HubPrefixDelimiter { get; set; } = '_';
 
     /// <summary>

--- a/src/Indice.AspNetCore/Features/SignalRProxy/SignalRProxyOptions.cs
+++ b/src/Indice.AspNetCore/Features/SignalRProxy/SignalRProxyOptions.cs
@@ -32,9 +32,13 @@ public class SignalRProxyOptions
     /// <remarks>Defaults to <c>x => $"{x.Type}|{x.Value}"</c></remarks>
     public SignalRClaimTypeToGroupNameTransformer ClaimTypeToGroupName { get; set; } = x => $"{x.Type}|{x.Value}";
     /// <summary>List of allowed Hubs</summary>
+    /// <remarks> If empty, all hubs are allowed.
+    /// Populate the list without using the optional prefix <see cref="HubPrefix"/>
+    /// </remarks>
     public List<string> AllowedHubs { get; set; } = [];
 
     /// <summary>Optional prefix for Hub names.</summary>
+    /// <remarks> Hub prefix must follow SignalR Hub naming conventions.</remarks>
     public string? HubPrefix { get; set; } = null;
 
     /// <summary>Delimiter for the optional prefix.</summary>

--- a/src/Indice.AspNetCore/Http/Extensions/ValidationErrors.cs
+++ b/src/Indice.AspNetCore/Http/Extensions/ValidationErrors.cs
@@ -21,6 +21,9 @@ public static class ValidationErrors
     /// <param name="key">The error category key.</param>
     /// <param name="messages">A range of error messages.</param>
     public static IDictionary<string, string[]> AddErrors(this IDictionary<string, string[]> errors, string key, IEnumerable<string> messages) {
+        if (!messages.Any()) { 
+            return errors;
+        }
         if (errors.TryGetValue(key, out var array)) {
             errors[key] = [.. array, .. messages];
         } else {

--- a/src/Indice.Services/Extensions/IServiceCollectionSignalRExtensions.cs
+++ b/src/Indice.Services/Extensions/IServiceCollectionSignalRExtensions.cs
@@ -28,6 +28,7 @@ public static class IServiceCollectionSignalRExtensions
                 serviceManagerOptions.ServiceTransportType = ServiceTransportType.Transient;
                 serviceManagerOptions.UseJsonObjectSerializer(
                     new JsonObjectSerializer(JsonSerializerOptionDefaults.GetDefaultSettings()));
+                
             })
             .BuildServiceManager();
         services.AddSingleton(serviceManager);

--- a/src/Indice.Services/Extensions/IServiceCollectionSignalRExtensions.cs
+++ b/src/Indice.Services/Extensions/IServiceCollectionSignalRExtensions.cs
@@ -24,6 +24,7 @@ public static class IServiceCollectionSignalRExtensions
             .WithOptions(serviceManagerOptions => {
                 var options = serviceProvider.GetRequiredService<IOptions<SignalRProxyCoreOptions>>().Value;
                 serviceManagerOptions.ConnectionString = options.ConnectionString;
+                serviceManagerOptions.ApplicationName = options.ApplicationName;
                 if (options.AutoPrefixWithEnvironmentName) {
                     serviceManagerOptions.ApplicationName = 
                         string.IsNullOrWhiteSpace(serviceManagerOptions.ApplicationName) ? options.EnvironmentName : 

--- a/src/Indice.Services/Extensions/IServiceCollectionSignalRExtensions.cs
+++ b/src/Indice.Services/Extensions/IServiceCollectionSignalRExtensions.cs
@@ -3,6 +3,7 @@ using Indice.Serialization;
 using Indice.Services;
 using Microsoft.Azure.SignalR.Management;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -18,19 +19,29 @@ public static class IServiceCollectionSignalRExtensions
     /// <param name="configureAction">An optional action to configure the SignalR service manager options.</param>
     /// <returns>The updated service collection.</returns>
     /// <exception cref="InvalidOperationException">Thrown when the Azure SignalR connection string is not configured.</exception>
-    public static IServiceCollection AddSignalRProxyCoreServices(this IServiceCollection services, Action<ServiceManagerOptions>? configureAction = null) {
-        var serviceManager = new ServiceManagerBuilder()
+    public static IServiceCollection AddSignalRProxyCoreServices(this IServiceCollection services, Action<SignalRProxyCoreOptions>? configureAction = null) {
+        services.AddSingleton((serviceProvider) => new ServiceManagerBuilder()
             .WithOptions(serviceManagerOptions => {
-                configureAction?.Invoke(serviceManagerOptions);
-                 if (string.IsNullOrEmpty(serviceManagerOptions.ConnectionString)) {
-                     throw new InvalidOperationException("SignalR ConnectionString is not configured.");
+                var options = serviceProvider.GetRequiredService<IOptions<SignalRProxyCoreOptions>>().Value;
+                serviceManagerOptions.ConnectionString = options.ConnectionString;
+                if (options.AutoPrefixWithEnvironmentName) {
+                    serviceManagerOptions.ApplicationName = 
+                        string.IsNullOrWhiteSpace(serviceManagerOptions.ApplicationName) ? options.EnvironmentName : 
+                                                                                           $"{options.EnvironmentName}_{serviceManagerOptions.ApplicationName}";
+                }
+                options.ConfigureServiceManager?.Invoke(serviceManagerOptions);
+                
+                if (string.IsNullOrEmpty(serviceManagerOptions.ConnectionString)) {
+                    throw new InvalidOperationException("SignalR ConnectionString is not configured.");
                 }
                 serviceManagerOptions.ServiceTransportType = ServiceTransportType.Transient;
-                serviceManagerOptions.UseJsonObjectSerializer(
-                    new JsonObjectSerializer(JsonSerializerOptionDefaults.GetDefaultSettings()));
+                serviceManagerOptions.UseJsonObjectSerializer(new JsonObjectSerializer(JsonSerializerOptionDefaults.GetDefaultSettings()));
             })
-            .BuildServiceManager();
-        services.AddSingleton(serviceManager);
+            .BuildServiceManager());
+        services.ConfigureOptions<SignalRProxyCoreConfigureOptions>();
+        if (configureAction != null) {
+            services.PostConfigure(configureAction);
+        }
         services.TryAddSingleton<SignalRProxyHubContextStore>();
         services.TryAddTransient<ISignalRProxyNegotiatiationService, SignalRProxyNegotiatiationService>();
         services.TryAddTransient<ISignalRProxyBroadcastService, SignalRProxyBroadcastService>();

--- a/src/Indice.Services/SignalRProxyCoreOptions.cs
+++ b/src/Indice.Services/SignalRProxyCoreOptions.cs
@@ -1,0 +1,66 @@
+﻿using Microsoft.Azure.SignalR.Management;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace Indice.Services;
+
+/// <summary>
+/// Configuration options for SignalR proxy core services.
+/// </summary>
+public class SignalRProxyCoreOptions
+{
+    /// <summary>
+    /// The name of the connection string used to retrieve the SignalR connection string from configuration.
+    /// </summary>
+    public const string ConnectionStringName = "SignalR";
+    
+    /// <summary>
+    /// Gets or sets the connection string for Azure SignalR Service.
+    /// </summary>
+    public string ConnectionString { get; set; } = null!;
+    
+    /// <summary>
+    /// Gets or sets the name of the current hosting environment.
+    /// </summary>
+    public string EnvironmentName { get; set; } = null!;
+    
+    /// <summary>
+    /// Gets or sets a value indicating whether hub names should be automatically prefixed with the environment name.
+    /// </summary>
+    public bool AutoPrefixWithEnvironmentName { get; set; }
+    
+    /// <summary>
+    /// Gets or sets an optional action to configure the <see cref="ServiceManagerOptions"/> for the SignalR service manager.
+    /// </summary>
+    public Action<ServiceManagerOptions>? ConfigureServiceManager { get; set; }
+}
+
+/// <summary>
+/// Provides configuration and post-configuration for <see cref="SignalRProxyCoreOptions"/>.
+/// Automatically retrieves the SignalR connection string from configuration and sets the environment name.
+/// </summary>
+public class SignalRProxyCoreConfigureOptions : IConfigureOptions<SignalRProxyCoreOptions>
+{
+    private readonly IConfiguration _configuration;
+    private readonly IHostEnvironment _environment;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SignalRProxyCoreConfigureOptions"/> class.
+    /// </summary>
+    /// <param name="configuration">The application configuration.</param>
+    /// <param name="environment">The hosting environment information.</param>
+    public SignalRProxyCoreConfigureOptions(IConfiguration configuration, IHostEnvironment environment) {
+        _configuration = configuration;
+        _environment = environment;
+    }
+    
+    /// <summary>
+    /// Configures the <see cref="SignalRProxyCoreOptions"/> by retrieving the connection string and environment name.
+    /// </summary>
+    /// <param name="options">The options instance to configure.</param>
+    public void Configure(SignalRProxyCoreOptions options) {
+        options.ConnectionString = _configuration.GetConnectionString(SignalRProxyCoreOptions.ConnectionStringName)!;
+        options.EnvironmentName = _environment.EnvironmentName;
+    }
+}

--- a/src/Indice.Services/SignalRProxyCoreOptions.cs
+++ b/src/Indice.Services/SignalRProxyCoreOptions.cs
@@ -24,7 +24,13 @@ public class SignalRProxyCoreOptions
     /// Gets or sets the name of the current hosting environment.
     /// </summary>
     public string EnvironmentName { get; set; } = null!;
-    
+
+    /// <summary>
+    /// Gets or sets the name of the current application name.
+    /// </summary>
+    /// <remarks>Will be used as a prefix for all SignalR hub names.</remarks>
+    public string? ApplicationName { get; set; }
+
     /// <summary>
     /// Gets or sets a value indicating whether hub names should be automatically prefixed with the environment name.
     /// </summary>


### PR DESCRIPTION
Add optional/configurable prefix for hub names.
Useful for when you want to use the same signalr instance for multiple envs