### PR TITLE
[cases] Add extensions for workflow case data conversions, similar to `case.DataAs`

### DIFF
--- a/src/Indice.Features.Cases.Workflows/Extensions/ActivityExecutionContextExtensions.cs
+++ b/src/Indice.Features.Cases.Workflows/Extensions/ActivityExecutionContextExtensions.cs
@@ -1,8 +1,8 @@
-﻿using Elsa.Activities.Http.Models;
+﻿using System.Text.Json;
 using System.Text.Json.Nodes;
+using Elsa.Activities.Http.Models;
 using Elsa.Services.Models;
 using Indice.Features.Cases.Workflows.Models;
-using System.Text.Json;
 
 namespace Indice.Features.Cases.Workflows.Extensions;
 

--- a/src/Indice.Features.Cases.Workflows/Extensions/CasesExtensions.cs
+++ b/src/Indice.Features.Cases.Workflows/Extensions/CasesExtensions.cs
@@ -22,11 +22,22 @@ public static class CasesExtensions
             return typedData;
         }
 
-        var json = JsonSerializer.Serialize(@case.Data, JsonSerializerOptionDefaults.GetDefaultSettings());
+        var options = JsonSerializerOptionDefaults.GetDefaultSettings();
+
+        if (@case.Data is JsonElement jsonElement) {
+            if (typeof(TData) == typeof(string)) {
+                // When the requested type is string, return the raw JSON text.
+                return (TData)(object)jsonElement.GetRawText();
+            }
+
+            return jsonElement.Deserialize<TData>(options)!;
+        }
+
+        var json = JsonSerializer.Serialize(@case.Data, options);
         if (typeof(TData) == typeof(string)) {
             return (TData)(object)json;
         }
-        return JsonSerializer.Deserialize<TData>(json, JsonSerializerOptionDefaults.GetDefaultSettings())!;
+        return JsonSerializer.Deserialize<TData>(json, options)!;
     }
 
     /// <summary>

--- a/src/Indice.Features.Cases.Workflows/Extensions/CasesExtensions.cs
+++ b/src/Indice.Features.Cases.Workflows/Extensions/CasesExtensions.cs
@@ -1,0 +1,42 @@
+﻿using System.Text.Json;
+using System.Text.Json.Nodes;
+using Indice.Serialization;
+
+namespace Indice.Features.Cases.Workflows.Extensions;
+
+/// <summary>
+/// Provides extension methods for converting the workflow data of a case to strongly typed objects or JSON
+/// representations.
+/// </summary>
+/// <remarks>These methods enable convenient access to the underlying workflow data stored in a case, allowing
+/// callers to deserialize or cast the data to the desired type. The extensions are intended for use with cases from the
+/// Indice.Features.Cases.Workflows.Integrations namespace. Thread safety depends on the usage of the underlying case
+/// object and its data.</remarks>
+public static class CasesExtensions
+{
+    /// <summary>
+    /// Convert the CaseWorkflowData (object) to TData.
+    /// </summary>    
+    public static TData CaseWorkflowDataAs<TData>(this Integrations.Case @case) {
+        if (@case.Data is TData typedData) {
+            return typedData;
+        }
+
+        var json = JsonSerializer.Serialize(@case.Data, JsonSerializerOptionDefaults.GetDefaultSettings());
+        if (typeof(TData) == typeof(string)) {
+            return (TData)(object)json;
+        }
+        return JsonSerializer.Deserialize<TData>(json, JsonSerializerOptionDefaults.GetDefaultSettings())!;
+    }
+
+    /// <summary>
+    /// Convert the CaseWorkflowData (object) to JsonNode.
+    /// </summary>    
+    public static JsonNode? CaseWorkflowDataAsJsonNode(this Integrations.Case @case) {
+        if (@case.Data is JsonElement jsonElement) {
+            return JsonSerializer.SerializeToNode(jsonElement);
+        }
+
+        return @case.CaseWorkflowDataAs<JsonNode?>();
+    }
+}

--- a/src/Indice.Features.Cases.Workflows/Extensions/CasesExtensions.cs
+++ b/src/Indice.Features.Cases.Workflows/Extensions/CasesExtensions.cs
@@ -17,7 +17,7 @@ public static class CasesExtensions
     /// <summary>
     /// Convert the CaseWorkflowData (object) to TData.
     /// </summary>    
-    public static TData CaseWorkflowDataAs<TData>(this Integrations.Case @case) {
+    public static TData? CaseWorkflowDataAs<TData>(this Integrations.Case @case) {
         if (@case.Data is TData typedData) {
             return typedData;
         }
@@ -30,14 +30,14 @@ public static class CasesExtensions
                 return (TData)(object)jsonElement.GetRawText();
             }
 
-            return jsonElement.Deserialize<TData>(options)!;
+            return jsonElement.Deserialize<TData>(options);
         }
 
         var json = JsonSerializer.Serialize(@case.Data, options);
         if (typeof(TData) == typeof(string)) {
             return (TData)(object)json;
         }
-        return JsonSerializer.Deserialize<TData>(json, options)!;
+        return JsonSerializer.Deserialize<TData>(json, options);
     }
 
     /// <summary>


### PR DESCRIPTION
A propsed way to avoid duplicate extension code in solutions and workflow activities, when the developer wants to access typed case data from wf activities.

The naming is using prefix to avoid confusion with the "original" convertors: https://github.com/indice-co/Indice.Platform/blob/71e1b52e5ec1f39a25201d032d8cb779eda67791/src/Indice.Features.Cases.Core/Models/Responses/CasePartial.cs#L70 and https://github.com/indice-co/Indice.Platform/blob/71e1b52e5ec1f39a25201d032d8cb779eda67791/src/Indice.Features.Cases.Core/Models/Responses/CasePartial.cs#L84