### PR TITLE
[identity] Fix typo in forgot password confirmation

### DIFF
--- a/src/Indice.Features.Identity.UI/IdentityLabels.el.resx
+++ b/src/Indice.Features.Identity.UI/IdentityLabels.el.resx
@@ -493,7 +493,7 @@
     <value>Ο κωδικός άλλαξε</value>
   </data>
   <data name="ForgotPasswordConfirmation_LoginLink" xml:space="preserve">
-    <value>Παρακαλώ &lt;a href="{0}"&gt;συνδεθείτε&lt;/a&gt; χρησιμοποιόντας το νέο σας συνθηματικό.</value>
+    <value>Παρακαλώ &lt;a href="{0}"&gt;συνδεθείτε&lt;/a&gt; χρησιμοποιώντας το νέο σας συνθηματικό.</value>
   </data>
   <data name="ForgotPasswordConfirmation_FillNewPassword_FieldLabel" xml:space="preserve">
     <value>Παρακαλώ εισάγετε τον νέο σας κωδικό</value>

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/ForgotPasswordConfirmation.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/ForgotPasswordConfirmation.cshtml
@@ -40,7 +40,7 @@
     else
     {
         <div class="alert alert-success" role="alert">
-            <strong>@Localizer.ForgotPasswordConfirmation_Password_Changed.</strong> @Localizer.ForgotPasswordConfirmation_LoginLink(Model.Input.ReturnUrl!))
+            <strong>@Localizer.ForgotPasswordConfirmation_Password_Changed.</strong> @Localizer.ForgotPasswordConfirmation_LoginLink(Model.Input.ReturnUrl!)
         </div>
     }
 </section>

--- a/src/Indice.Features.Identity.UI/Resources/Pages/ForgotPasswordConfirmation.el.resx
+++ b/src/Indice.Features.Identity.UI/Resources/Pages/ForgotPasswordConfirmation.el.resx
@@ -127,7 +127,7 @@
     <value>Ο κωδικός άλλαξε</value>
   </data>
   <data name="Please &lt;a href=&quot;{0}&quot;&gt;login&lt;/a&gt; with your new password" xml:space="preserve">
-    <value>Παρακαλώ &lt;a href="{0}"&gt;συνδεθείτε&lt;/a&gt; χρησιμοποιόντας το νέο σας συνθηματικό.</value>
+    <value>Παρακαλώ &lt;a href="{0}"&gt;συνδεθείτε&lt;/a&gt; χρησιμοποιώντας το νέο σας συνθηματικό.</value>
   </data>
   <data name="Please fill in your new password" xml:space="preserve">
     <value>Παρακαλώ εισάγετε τον νέο σας κωδικό</value>


### PR DESCRIPTION
This is the typo we found during testing:

<img width="441" height="185" alt="image" src="https://github.com/user-attachments/assets/85e91907-08bb-4ed4-850a-24dbec0eff4f" />
