### PR TITLE
[cases] Fix JSON Schema Validation to Allow Custom Keywords Like enumNames

### DIFF
--- a/src/Indice.Features.Cases.Core/Services/CasesJsonSchemaValidator.cs
+++ b/src/Indice.Features.Cases.Core/Services/CasesJsonSchemaValidator.cs
@@ -17,9 +17,7 @@ public class CasesJsonSchemaValidator : ISchemaValidator
         ArgumentException.ThrowIfNullOrEmpty(schema);
         ArgumentNullException.ThrowIfNull(data);
         
-        var mySchema = JsonSchema.FromText(schema, new BuildOptions {
-            Dialect = Dialect.Draft07
-        });
+        var mySchema = JsonSchema.FromText(schema);
 
         var jsonNode = (data, data.GetType().Name) switch {
             (JsonElement element, _) => element.AsNode(),

--- a/src/Indice.Features.Cases.Core/Services/CasesJsonSchemaValidator.cs
+++ b/src/Indice.Features.Cases.Core/Services/CasesJsonSchemaValidator.cs
@@ -16,7 +16,11 @@ public class CasesJsonSchemaValidator : ISchemaValidator
     public bool IsValid(string schema, object data) {
         ArgumentException.ThrowIfNullOrEmpty(schema);
         ArgumentNullException.ThrowIfNull(data);
-        var mySchema = JsonSchema.FromText(schema);
+        
+        var mySchema = JsonSchema.FromText(schema, new BuildOptions {
+            Dialect = Dialect.Draft07
+        });
+
         var jsonNode = (data, data.GetType().Name) switch {
             (JsonElement element, _) => element.AsNode(),
             (JsonNode node, _) => node,

--- a/src/Indice.Features.Cases.Core/Services/CasesJsonSchemaValidator.cs
+++ b/src/Indice.Features.Cases.Core/Services/CasesJsonSchemaValidator.cs
@@ -16,9 +16,7 @@ public class CasesJsonSchemaValidator : ISchemaValidator
     public bool IsValid(string schema, object data) {
         ArgumentException.ThrowIfNullOrEmpty(schema);
         ArgumentNullException.ThrowIfNull(data);
-        
         var mySchema = JsonSchema.FromText(schema);
-
         var jsonNode = (data, data.GetType().Name) switch {
             (JsonElement element, _) => element.AsNode(),
             (JsonNode node, _) => node,

--- a/test/Indice.Features.Cases.AspNetCore.Tests/SchemaValidatorTests.cs
+++ b/test/Indice.Features.Cases.AspNetCore.Tests/SchemaValidatorTests.cs
@@ -38,8 +38,8 @@ public class SchemaValidatorTests
                 ""attachmentId""
             ]
         }
-    }"; 
- 
+    }";
+
     [Fact]
     public void IsValid_EmptySchema_Throws() {
         Assert.Throws<ArgumentNullException>(() => _schemaValidator.IsValid(It.IsAny<string>(), It.IsAny<string>()));
@@ -74,25 +74,58 @@ public class SchemaValidatorTests
         var result = _schemaValidator.IsValid(Schema, data);
         Assert.True(result);
     }
-    
+
     [Fact]
     public void IsValid_ValidObject_JObjectData_True() {
         var data = Newtonsoft.Json.Linq.JObject.Parse("{\"firstName\": \"john\",\"lastName\": \"doe\"}");
         var result = _schemaValidator.IsValid(Schema, data);
         Assert.True(result);
     }
-    
+
     [Fact]
     public void IsValid_NotValidObject_JArrayData_False() {
         var data = Newtonsoft.Json.Linq.JArray.Parse("[{\"propertyA\":\"123\"}]");
         var result = _schemaValidator.IsValid(SchemaArray, data);
         Assert.False(result);
-    } 
-    
+    }
+
     [Fact]
     public void IsValid_ValidObject_JArrayData_True() {
         var data = Newtonsoft.Json.Linq.JArray.Parse("[{\"attachmentId\":\"123\"}]");
         var result = _schemaValidator.IsValid(SchemaArray, data);
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsValid_PropertyEnumWithNames_True() {
+        var schema = """
+            {
+              "title": "My schema",
+              "description": "My description",
+              "type": "object",
+              "properties": {
+                "anEnumProperty": {
+                  "type": "string",
+                  "enum": [
+                    "1",
+                    "2"
+                  ],
+                  "enumNames": [
+                    "The first Value",
+                    "The second Value"
+                  ]
+                }
+              }
+            }
+            """;
+
+        var data = """
+                {
+            		"anEnumProperty": "1"
+            	}
+            """;
+
+        var result = _schemaValidator.IsValid(schema, data);
         Assert.True(result);
     }
 }

--- a/test/Indice.Features.Cases.AspNetCore.Tests/SchemaValidatorTests.cs
+++ b/test/Indice.Features.Cases.AspNetCore.Tests/SchemaValidatorTests.cs
@@ -100,6 +100,7 @@ public class SchemaValidatorTests
     public void IsValid_PropertyEnumWithNames_True() {
         var schema = """
             {
+              "$schema": "http://json-schema.org/draft-07/schema#",
               "title": "My schema",
               "description": "My description",
               "type": "object",


### PR DESCRIPTION
# Edit

This PR only adds a unit test to verify that JSON Schema validation passes when the schema version is explicitly defined as:

```json
"$schema": "http://json-schema.org/draft-07/schema#"
```

---

This is the original PR, leaving the analysis for future reference


## Problem
The `CasesJsonSchemaValidator` was failing when processing JSON schemas containing custom keywords (e.g., enumNames) with the error:

```
Unknown keywords (enumNames) are disallowed for this dialect.
```

This occurred because the JSON Schema library was using a strict default dialect that rejects unknown/custom keywords not defined in the JSON Schema specification.

## Solution

Updated `CasesJsonSchemaValidator.IsValid()` to explicitly configure the schema builder with `Dialect.Draft07`, which is more lenient with unknown keywords and allows custom extensions commonly used in JSON schema implementations (like those generated by JSON schema UI tools).

## Testing
Added a new test case IsValid_PropertyEnumWithNames_True to verify that schemas with the enumNames property are correctly validated.