### PR TITLE
[identity] Phone number is not required in update user endpoint 

### DIFF
--- a/src/Indice.Common/Extensions/StringExtensions.cs
+++ b/src/Indice.Common/Extensions/StringExtensions.cs
@@ -102,5 +102,21 @@ public static partial class StringExtensions
     /// <returns>A hash</returns>
     public static string ToSha256Hex(this byte[] input) => string.Join("", SHA256.HashData(input).Select(x => $"{x:x2}"));
 
+    /// <summary>
+    /// Truncates the input string to the specified maximum number of characters, appending an ellipsis character ('…')
+    /// if truncation occurs.
+    /// </summary>
+    /// <remarks>If input is null or empty, the method returns input unchanged. If input is longer than
+    /// maxChars, the result will be exactly maxChars characters from input followed by a single ellipsis character
+    /// ('…').</remarks>
+    /// <param name="input">The string to truncate. Can be null.</param>
+    /// <param name="maxChars">The maximum number of characters to retain from the input string. Must be non-negative.</param>
+    /// <returns>A string truncated to at most maxChars characters, with an appended ellipsis if truncation occurs; or the
+    /// original string if it is null, empty, or shorter than maxChars.</returns>
+    public static string? Truncate(this string? input, int maxChars) =>
+        string.IsNullOrEmpty(input) ? input :
+        input.Length <= maxChars ? input :
+        input[..maxChars] + '…';
+
 }
 #nullable disable

--- a/src/Indice.Features.Identity.Server/Manager/UserHandlers.cs
+++ b/src/Indice.Features.Identity.Server/Manager/UserHandlers.cs
@@ -263,13 +263,15 @@ internal static class UserHandlers
             var errors = ValidationErrors.AddError(nameof(request.UserName), "EmailAsUserName policy is applied to the identity system. Email and UserName properties should have the same value. User is not updated.");
             return TypedResults.ValidationProblem(errors);
         }
-        if (!PhoneNumber.TryParse(request.PhoneNumber!, out var phoneNumber)) {
+        if (!PhoneNumber.TryParse(request.PhoneNumber!.Trim(), out var phoneNumber) && !string.IsNullOrWhiteSpace(request.PhoneNumber)) {
             var errors = ValidationErrors.AddError(nameof(request.PhoneNumber), "The provided phone number is not valid.");
             return TypedResults.ValidationProblem(errors);
         }
         user.UserName = request.UserName;
         user.Email = request.Email;
-        user.PhoneNumber = request.PhoneNumber;
+        if (!string.IsNullOrWhiteSpace(request.PhoneNumber)) {
+            user.PhoneNumber = phoneNumber.ToString();
+        }
         user.TwoFactorEnabled = request.TwoFactorEnabled;
         user.TwoFactorPolicy = request.TwoFactorPolicy;
         user.PasswordExpirationPolicy = request.PasswordExpirationPolicy;

--- a/src/Indice.Features.Identity.Server/Manager/UserHandlers.cs
+++ b/src/Indice.Features.Identity.Server/Manager/UserHandlers.cs
@@ -263,13 +263,14 @@ internal static class UserHandlers
             var errors = ValidationErrors.AddError(nameof(request.UserName), "EmailAsUserName policy is applied to the identity system. Email and UserName properties should have the same value. User is not updated.");
             return TypedResults.ValidationProblem(errors);
         }
-        if (!PhoneNumber.TryParse(request.PhoneNumber!.Trim(), out var phoneNumber) && !string.IsNullOrWhiteSpace(request.PhoneNumber)) {
+        var trimmedPhoneNumber = request.PhoneNumber?.Trim();
+        if (!PhoneNumber.TryParse(trimmedPhoneNumber ?? string.Empty, out var phoneNumber) && !string.IsNullOrWhiteSpace(trimmedPhoneNumber)) {
             var errors = ValidationErrors.AddError(nameof(request.PhoneNumber), "The provided phone number is not valid.");
             return TypedResults.ValidationProblem(errors);
         }
-        user.UserName = request.UserName;
-        user.Email = request.Email;
-        if (!string.IsNullOrWhiteSpace(request.PhoneNumber)) {
+        user.UserName = request.UserName?.Trim();
+        user.Email = request.Email?.Trim();
+        if (!string.IsNullOrWhiteSpace(trimmedPhoneNumber)) {
             user.PhoneNumber = phoneNumber.ToString();
         }
         user.TwoFactorEnabled = request.TwoFactorEnabled;

--- a/src/Indice.Features.Identity.Server/Manager/UserHandlers.cs
+++ b/src/Indice.Features.Identity.Server/Manager/UserHandlers.cs
@@ -268,11 +268,16 @@ internal static class UserHandlers
             var errors = ValidationErrors.AddError(nameof(request.PhoneNumber), "The provided phone number is not valid.");
             return TypedResults.ValidationProblem(errors);
         }
+        if(string.IsNullOrWhiteSpace(trimmedPhoneNumber) && request.PhoneNumberConfirmed) {
+            var errors = ValidationErrors.AddError(nameof(request.PhoneNumberConfirmed), "The phone number cannot be confirmed as it is not a valid phone number.");
+            return TypedResults.ValidationProblem(errors);
+        }
         user.UserName = request.UserName?.Trim();
         user.Email = request.Email?.Trim();
-        if (!string.IsNullOrWhiteSpace(trimmedPhoneNumber)) {
-            user.PhoneNumber = phoneNumber.ToString();
-        }
+        user.PhoneNumber = trimmedPhoneNumber switch {
+            { Length: > 0 } => phoneNumber.ToString(),
+            _ => null
+        };
         user.TwoFactorEnabled = request.TwoFactorEnabled;
         user.TwoFactorPolicy = request.TwoFactorPolicy;
         user.PasswordExpirationPolicy = request.PasswordExpirationPolicy;

--- a/src/Indice.Features.Messages.Core/Manager/NotificationsManager.cs
+++ b/src/Indice.Features.Messages.Core/Manager/NotificationsManager.cs
@@ -167,7 +167,7 @@ public class NotificationsManager(
         // If a distribution list id is not set, then we create a new list.
         if (!request.RecipientListId.HasValue) {
             var createdList = await DistributionListService.Create(new CreateDistributionListRequest {
-                Name = $"{request.Title} - {timestamp}",
+                Name = $"{request.Title.Truncate(110)} - {timestamp}",
                 IsSystemGenerated = true
             }, request.GetIncludedContacts());
             request.RecipientListId = createdList.Id;

--- a/test/Indice.Features.Identity.Tests/UserHandlersTests.cs
+++ b/test/Indice.Features.Identity.Tests/UserHandlersTests.cs
@@ -9,6 +9,7 @@ using Indice.Features.Identity.Core.Data.Stores;
 using Indice.Features.Identity.Core.Events;
 using Indice.Features.Identity.Server.Manager;
 using Indice.Features.Identity.Server.Manager.Models;
+using Indice.Globalization;
 using Indice.Types;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -171,7 +172,11 @@ public class UserHandlersTests : IAsyncLifetime
             BypassPasswordValidation = true,
             FirstName = "Test",
             LastName = "User",
-            PhoneNumber = "+306912345678"
+            PhoneNumber = "+306912345678",
+            Claims = [
+                new() { Type = "customer_code", Value = "000001" },
+                new() { Type = "locale", Value = "el" }
+            ],
         });
 
         var createdUser = await identityDbContext.Users.FirstOrDefaultAsync(u => u.Email == "test.user@indice.gr");
@@ -183,7 +188,11 @@ public class UserHandlersTests : IAsyncLifetime
             UserName = "test.user@indice.gr",
             Email = "test.user@indice.gr",
             PhoneNumber = null,
-            PhoneNumberConfirmed = false
+            PhoneNumberConfirmed = false,
+            Claims = [
+                new() { Type = "customer_code", Value = "000001" },
+                new() { Type = "locale", Value = "el" }
+            ],
         });
 
         // Verify phone number was cleared
@@ -205,7 +214,11 @@ public class UserHandlersTests : IAsyncLifetime
             BypassPasswordValidation = true,
             FirstName = "Test",
             LastName = "User",
-            PhoneNumber = "+306912345678"
+            PhoneNumber = "+306912345678",
+            Claims = [
+                new() { Type = "customer_code", Value = "000001" },
+                new() { Type = "locale", Value = "el" }
+            ],
         });
 
         var createdUser = await identityDbContext.Users.FirstOrDefaultAsync(u => u.Email == "test.user2@indice.gr");
@@ -238,7 +251,11 @@ public class UserHandlersTests : IAsyncLifetime
             Password = "password",
             BypassPasswordValidation = true,
             FirstName = "Test",
-            LastName = "User"
+            LastName = "User",
+            Claims = [
+                new() { Type = "customer_code", Value = "000001" },
+                new() { Type = "locale", Value = "el" }
+            ],
         });
 
         var createdUser = await identityDbContext.Users.FirstOrDefaultAsync(u => u.Email == "test.user3@indice.gr");
@@ -268,7 +285,11 @@ public class UserHandlersTests : IAsyncLifetime
             Password = "password",
             BypassPasswordValidation = true,
             FirstName = "Test",
-            LastName = "User"
+            LastName = "User",
+            Claims = [
+                new() { Type = "customer_code", Value = "000001" },
+                new() { Type = "locale", Value = "el" }
+            ],
         });
 
         var createdUser = await identityDbContext.Users.FirstOrDefaultAsync(u => u.Email == "test.user4@indice.gr");
@@ -285,7 +306,7 @@ public class UserHandlersTests : IAsyncLifetime
         var updatedUser = await identityDbContext.Users.FirstOrDefaultAsync(u => u.Id == createdUser.Id);
         Assert.NotNull(updatedUser);
         Assert.NotNull(updatedUser.PhoneNumber);
-        Assert.DoesNotContain(" ", updatedUser.PhoneNumber); // Should be trimmed/formatted
+        Assert.Equal(PhoneNumber.Parse("+306912345678").ToString(), updatedUser.PhoneNumber); // Should be trimmed/formatted
         Assert.StartsWith("+", updatedUser.PhoneNumber); // Should be a valid formatted phone number
     }
 

--- a/test/Indice.Features.Identity.Tests/UserHandlersTests.cs
+++ b/test/Indice.Features.Identity.Tests/UserHandlersTests.cs
@@ -158,6 +158,137 @@ public class UserHandlersTests : IAsyncLifetime
         await _serviceProvider.DisposeAsync();
     }
 
+    [Fact]
+    public async Task UpdateUser_WithNullPhoneNumber_ShouldClearPhoneNumber() {
+        var userManager = _serviceProvider.GetRequiredService<ExtendedUserManager<User>>();
+        var identityDbContext = _serviceProvider.GetRequiredService<ExtendedIdentityDbContext<User, Role>>();
+
+        // Create a user first
+        await UserHandlers.CreateUser(userManager, identityDbContext, new CreateUserRequest {
+            UserName = "test.user@indice.gr",
+            Email = "test.user@indice.gr",
+            Password = "password",
+            BypassPasswordValidation = true,
+            FirstName = "Test",
+            LastName = "User",
+            PhoneNumber = "+306912345678"
+        });
+
+        var createdUser = await identityDbContext.Users.FirstOrDefaultAsync(u => u.Email == "test.user@indice.gr");
+        Assert.NotNull(createdUser);
+        Assert.NotNull(createdUser.PhoneNumber); // Ensure it starts with a phone number
+
+        // Update user with null phone number
+        var result = await UserHandlers.UpdateUser(identityDbContext, userManager, createdUser.Id, new UpdateUserRequest {
+            UserName = "test.user@indice.gr",
+            Email = "test.user@indice.gr",
+            PhoneNumber = null,
+            PhoneNumberConfirmed = false
+        });
+
+        // Verify phone number was cleared
+        var updatedUser = await identityDbContext.Users.FirstOrDefaultAsync(u => u.Id == createdUser.Id);
+        Assert.NotNull(updatedUser);
+        Assert.Null(updatedUser.PhoneNumber);
+    }
+
+    [Fact]
+    public async Task UpdateUser_WithWhitespaceOnlyPhoneNumber_ShouldClearPhoneNumber() {
+        var userManager = _serviceProvider.GetRequiredService<ExtendedUserManager<User>>();
+        var identityDbContext = _serviceProvider.GetRequiredService<ExtendedIdentityDbContext<User, Role>>();
+
+        // Create a user first
+        await UserHandlers.CreateUser(userManager, identityDbContext, new CreateUserRequest {
+            UserName = "test.user2@indice.gr",
+            Email = "test.user2@indice.gr",
+            Password = "password",
+            BypassPasswordValidation = true,
+            FirstName = "Test",
+            LastName = "User",
+            PhoneNumber = "+306912345678"
+        });
+
+        var createdUser = await identityDbContext.Users.FirstOrDefaultAsync(u => u.Email == "test.user2@indice.gr");
+        Assert.NotNull(createdUser);
+        Assert.NotNull(createdUser.PhoneNumber); // Ensure it starts with a phone number
+
+        // Update user with whitespace-only phone number
+        var result = await UserHandlers.UpdateUser(identityDbContext, userManager, createdUser.Id, new UpdateUserRequest {
+            UserName = "test.user2@indice.gr",
+            Email = "test.user2@indice.gr",
+            PhoneNumber = "   ",
+            PhoneNumberConfirmed = false
+        });
+
+        // Verify phone number was cleared
+        var updatedUser = await identityDbContext.Users.FirstOrDefaultAsync(u => u.Id == createdUser.Id);
+        Assert.NotNull(updatedUser);
+        Assert.Null(updatedUser.PhoneNumber);
+    }
+
+    [Fact]
+    public async Task UpdateUser_WithInvalidPhoneNumber_ShouldReturnValidationProblem() {
+        var userManager = _serviceProvider.GetRequiredService<ExtendedUserManager<User>>();
+        var identityDbContext = _serviceProvider.GetRequiredService<ExtendedIdentityDbContext<User, Role>>();
+
+        // Create a user first
+        await UserHandlers.CreateUser(userManager, identityDbContext, new CreateUserRequest {
+            UserName = "test.user3@indice.gr",
+            Email = "test.user3@indice.gr",
+            Password = "password",
+            BypassPasswordValidation = true,
+            FirstName = "Test",
+            LastName = "User"
+        });
+
+        var createdUser = await identityDbContext.Users.FirstOrDefaultAsync(u => u.Email == "test.user3@indice.gr");
+        Assert.NotNull(createdUser);
+
+        // Update user with invalid phone number
+        var result = await UserHandlers.UpdateUser(identityDbContext, userManager, createdUser.Id, new UpdateUserRequest {
+            UserName = "test.user3@indice.gr",
+            Email = "test.user3@indice.gr",
+            PhoneNumber = "invalid-phone"
+        });
+
+        // Verify validation error
+        var validationProblem = result.Result as Microsoft.AspNetCore.Http.HttpResults.ValidationProblem;
+        Assert.NotNull(validationProblem);
+    }
+
+    [Fact]
+    public async Task UpdateUser_WithValidPhoneNumberAndWhitespace_ShouldPersistFormattedValue() {
+        var userManager = _serviceProvider.GetRequiredService<ExtendedUserManager<User>>();
+        var identityDbContext = _serviceProvider.GetRequiredService<ExtendedIdentityDbContext<User, Role>>();
+
+        // Create a user first
+        await UserHandlers.CreateUser(userManager, identityDbContext, new CreateUserRequest {
+            UserName = "test.user4@indice.gr",
+            Email = "test.user4@indice.gr",
+            Password = "password",
+            BypassPasswordValidation = true,
+            FirstName = "Test",
+            LastName = "User"
+        });
+
+        var createdUser = await identityDbContext.Users.FirstOrDefaultAsync(u => u.Email == "test.user4@indice.gr");
+        Assert.NotNull(createdUser);
+
+        // Update user with valid phone number that has surrounding whitespace
+        var result = await UserHandlers.UpdateUser(identityDbContext, userManager, createdUser.Id, new UpdateUserRequest {
+            UserName = "test.user4@indice.gr",
+            Email = "test.user4@indice.gr",
+            PhoneNumber = "  +306912345678  "
+        });
+
+        // Verify phone number was formatted and stored
+        var updatedUser = await identityDbContext.Users.FirstOrDefaultAsync(u => u.Id == createdUser.Id);
+        Assert.NotNull(updatedUser);
+        Assert.NotNull(updatedUser.PhoneNumber);
+        Assert.DoesNotContain(" ", updatedUser.PhoneNumber); // Should be trimmed/formatted
+        Assert.StartsWith("+", updatedUser.PhoneNumber); // Should be a valid formatted phone number
+    }
+
     public class UserCreatedAssetionHanbdler : IPlatformEventHandler<UserCreatedEvent>
     {
         public Task Handle(UserCreatedEvent @event, PlatformEventArgs args) {


### PR DESCRIPTION
Whitespace is now trimmed from phone number input before parsing. Validation only fails if a non-empty phone number is invalid, allowing empty or whitespace-only values. The user's PhoneNumber property is set only if a valid, non-empty number is provided, and uses the parsed, formatted value.