### PR TITLE
[cases] Handle empty array and hide empty component from case-details

### DIFF
--- a/src/Indice.Features.Cases.App/src/app/features/cases/case-detail-page/case-detail-page.component.html
+++ b/src/Indice.Features.Cases.App/src/app/features/cases/case-detail-page/case-detail-page.component.html
@@ -53,7 +53,9 @@
                 </div>
               }
               @if (relatedCases$ | async; as relatedCases) {
-                <app-case-related class="bg-white shadow rounded-sm mt-2 px-4 py-1 flow-root" [relatedCases]="relatedCases"></app-case-related>
+                @if (relatedCases.length) {
+                  <app-case-related class="bg-white shadow rounded-sm mt-2 px-4 py-1 flow-root" [relatedCases]="relatedCases"></app-case-related>
+                }
               }
               <div class="bg-white shadow rounded-sm">
                 @if (timelineEntries$ | async; as timelineEntries) {

--- a/src/Indice.Features.Cases.App/src/app/shared/components/approval-buttons/approval-buttons.component.ts
+++ b/src/Indice.Features.Cases.App/src/app/shared/components/approval-buttons/approval-buttons.component.ts
@@ -38,7 +38,7 @@ export class ApprovalButtonsComponent implements OnInit {
     this.rejectionOptions$ = this._api.getCaseRejectReasons(this.caseId!)
       .pipe(
         map((response: RejectReason[]) => response.map(item => new MenuOption(item.value!, item.key!))),
-        tap((reasons: MenuOption[]) => this.selectedRejectReason = reasons[0].value)
+        tap((reasons: MenuOption[]) => this.selectedRejectReason = reasons[0]?.value)
       );
   }
 


### PR DESCRIPTION
This pull request introduces a minor UI improvement and a small bug fix in the case detail and approval buttons components. The changes ensure that related cases are rendered only when present and prevent a potential error when no rejection reasons are available.

UI improvements:

* Only render the `app-case-related` component if there are one or more related cases, preventing empty component rendering in `case-detail-page.component.html`.
<img width="534" height="109" alt="image" src="https://github.com/user-attachments/assets/bff0e7b9-8f59-4304-8bbb-6f32757ec553" />


Bug fixes:

* Safely set the default selected rejection reason only if at least one reason is available, preventing a runtime error when the list is empty in `approval-buttons.component.ts`.