### PR TITLE
[cases] Include comment in InvokeEditRequest in InvokeEditAsync

### DIFF
--- a/src/Indice.Features.Cases.Server/Integration/WorkflowHttpServiceClient.cs
+++ b/src/Indice.Features.Cases.Server/Integration/WorkflowHttpServiceClient.cs
@@ -64,6 +64,7 @@ public class WorkflowHttpServiceClient : ICasesWorkflowManager
         try {
             await _workflowApiClient.EditAsync(new InvokeEditRequest {
                 CaseId = caseId,
+                Comment = comment,
                 Data = request.Data,
                 Actor = user.ToActor(),
             });


### PR DESCRIPTION
This pull request makes a small update to the workflow editing process by including the `comment` field when invoking the edit API. This ensures that any comments provided by the user are now passed along with the edit request.