### PR TITLE
[cases] Refactor case detail page to avoid duplicate http calls for "getCaseById"

### DIFF
--- a/src/Indice.Features.Cases.App/src/app/features/cases/case-detail-page/case-detail-page.component.ts
+++ b/src/Indice.Features.Cases.App/src/app/features/cases/case-detail-page/case-detail-page.component.ts
@@ -2,7 +2,7 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ToasterService, ToastType } from '@indice/ng-components';
 import { iif, Observable, ReplaySubject, of } from 'rxjs';
-import { filter, map, switchMap, takeUntil, tap } from 'rxjs/operators';
+import { filter, map, shareReplay, switchMap, takeUntil, tap } from 'rxjs/operators';
 import { CaseDetailsService } from 'src/app/core/services/case-details.service';
 import { CaseActions, Case, CasesApiService, ActionRequest, TimelineEntry, CaseStatus, SuccessMessage, CasePartial } from 'src/app/core/services/cases-api.service';
 
@@ -47,14 +47,19 @@ export class CaseDetailPageComponent implements OnInit, OnDestroy {
     private toaster: ToasterService) { }
 
   ngOnInit(): void {
-    this.route.params.subscribe(p => {
-      this.caseId = p.caseId;
-      this.requestModel();
-      this.getCaseActions();
-      this.getTimeline();
-      this.getRelatedCases()
-    });
+    this.route.params.pipe(
+      map(p => p.caseId),
+      tap(caseId => {
+        this.caseId = caseId;
+        this.requestModel();
+        this.getCaseActions();
+        this.getTimeline();
+        this.getRelatedCases();
+      }),
+      takeUntil(this.componentDestroy$)
+    ).subscribe();
   }
+
 
   ngOnDestroy(): void {
     this.componentDestroy$.complete();
@@ -89,6 +94,7 @@ export class CaseDetailPageComponent implements OnInit, OnDestroy {
           this.caseTypeConfig = response.caseType?.config ? response.caseType?.config : {};
           this.caseDetailsService.setCaseDetails(response);
         }),
+        shareReplay(1),
         takeUntil(this.componentDestroy$)
       );
   }

--- a/src/Indice.Features.Cases.App/src/app/features/cases/case-detail-page/case-detail-page.component.ts
+++ b/src/Indice.Features.Cases.App/src/app/features/cases/case-detail-page/case-detail-page.component.ts
@@ -62,6 +62,7 @@ export class CaseDetailPageComponent implements OnInit, OnDestroy {
 
 
   ngOnDestroy(): void {
+    this.componentDestroy$.next();
     this.componentDestroy$.complete();
   }
 


### PR DESCRIPTION
1. Added the `shareReplay(1)` operator to cache the latest emitted value and avoid unnecessary repeated API calls. This was introduced with the "getRelatedCases" feature.

2. Refactor on init code, replace subscriber method call with `tap`, added `takeUntil`