### PR TITLE
[risk] Add utility classes for height and width sizing to fix #935

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -12,7 +12,7 @@
       <VersionPrefixCases>$(VersionPrefixBase).0</VersionPrefixCases>
       <VersionPrefixMessages>$(VersionPrefixBase).0</VersionPrefixMessages>
       <VersionPrefixMultitenancy>$(VersionPrefixBase).0</VersionPrefixMultitenancy>
-      <VersionPrefixRisk>$(VersionPrefixBase).0</VersionPrefixRisk>
+      <VersionPrefixRisk>$(VersionPrefixBase).1</VersionPrefixRisk>
       <VersionPrefixMedia>$(VersionPrefixBase).0</VersionPrefixMedia>
       <VersionPrefixGeoIP>$(VersionPrefixBase).0</VersionPrefixGeoIP>
       <VersionPrefixGovGr>$(VersionPrefixBase).0</VersionPrefixGovGr>

--- a/src/Indice.Features.Risk.App/src/styles.css
+++ b/src/Indice.Features.Risk.App/src/styles.css
@@ -13,10 +13,10 @@
 
 @layer components {
   .h-5 {
-    @apply h-5;
+    height: 1.25rem;
   }
   .w-5 {
-    @apply w-5;
+    width: 1.25rem;
   }
   .kpi-chart-container {
     @apply h-full w-full;

--- a/src/Indice.Features.Risk.App/src/styles.css
+++ b/src/Indice.Features.Risk.App/src/styles.css
@@ -12,6 +12,12 @@
 }
 
 @layer components {
+  .h-5 {
+    @apply h-5;
+  }
+  .w-5 {
+    @apply w-5;
+  }
   .kpi-chart-container {
     @apply h-full w-full;
   }


### PR DESCRIPTION
This PR fixes an issue where pagination navigation buttons were invisible due to missing utility classes. The `@indice/ng-components` package relies on tailwind's `h-5` and w-5` classes for svg icons, but since these weren't present in the application's source code, the tailwind compiler excluded them from the final CSS bundle.