### PR TITLE
[messages] - handle race condition for multiple insertions in update preference operations

### DIFF
--- a/src/Indice.Features.Messages.Core/Services/ContactService.cs
+++ b/src/Indice.Features.Messages.Core/Services/ContactService.cs
@@ -398,11 +398,15 @@ public class ContactService : IContactService
             try {
                 await DbContext.ContactPreferences.AddAsync(recipientPreferences);
                 await DbContext.SaveChangesAsync();
+                return;
+            } catch (DbUpdateException ex) when (ex.InnerException != null && ex.InnerException.Message.Contains("Cannot insert duplicate key row")) {
+                recipientPreferences = await DbContext.ContactPreferences
+                                           .Include(x => x.CommunicationOptions)
+                                           .ThenInclude(up => up.MessageType)
+                                           .SingleAsync(x => x.RecipientId == recipientId);
+            } catch {
+                throw;
             }
-            catch (DbUpdateException) {
-
-            }
-            return;
         }
 
         recipientPreferences.Locale = request.Locale;
@@ -443,8 +447,7 @@ public class ContactService : IContactService
             try {
                 await DbContext.ContactPreferences.AddAsync(recipientPreferences);
                 await DbContext.SaveChangesAsync();
-            } 
-            catch (DbUpdateException) {
+            } catch (DbUpdateException) {
 
             }
             return;

--- a/src/Indice.Features.Messages.Core/Services/ContactService.cs
+++ b/src/Indice.Features.Messages.Core/Services/ContactService.cs
@@ -395,9 +395,13 @@ public class ContactService : IContactService
                         UpdatedAt = DateTimeOffset.UtcNow
                     }).ToList()
             };
+            try {
+                await DbContext.ContactPreferences.AddAsync(recipientPreferences);
+                await DbContext.SaveChangesAsync();
+            }
+            catch (DbUpdateException) {
 
-            await DbContext.ContactPreferences.AddAsync(recipientPreferences);
-            await DbContext.SaveChangesAsync();
+            }
             return;
         }
 
@@ -436,12 +440,15 @@ public class ContactService : IContactService
                 DefaultChannels = preference.DefaultChannels != null ? ContactChannelOption.ToContactChannelKind(preference.DefaultChannels) : null,
                 UpdatedAt = DateTimeOffset.UtcNow
             };
+            try {
+                await DbContext.ContactPreferences.AddAsync(recipientPreferences);
+                await DbContext.SaveChangesAsync();
+            } 
+            catch (DbUpdateException) {
 
-            await DbContext.ContactPreferences.AddAsync(recipientPreferences);
-            await DbContext.SaveChangesAsync();
+            }
             return;
         }
-
         recipientPreferences.Locale = preference.Locale;
         recipientPreferences.ConsentCommercial = preference.ConsentCommercial;
         recipientPreferences.ConsentCommercialDate = preference.ConsentCommercialDate;

--- a/src/Indice.Features.Messages.Core/Services/ContactService.cs
+++ b/src/Indice.Features.Messages.Core/Services/ContactService.cs
@@ -1,4 +1,5 @@
-﻿using Indice.Features.Messages.Core.Data;
+﻿using System.Data.Common;
+using Indice.Features.Messages.Core.Data;
 using Indice.Features.Messages.Core.Data.Models;
 using Indice.Features.Messages.Core.Exceptions;
 using Indice.Features.Messages.Core.Models;
@@ -399,13 +400,13 @@ public class ContactService : IContactService
                 await DbContext.ContactPreferences.AddAsync(recipientPreferences);
                 await DbContext.SaveChangesAsync();
                 return;
-            } catch (DbUpdateException ex) when (ex.InnerException != null && ex.InnerException.Message.Contains("Cannot insert duplicate key row")) {
+            } 
+            catch (DbUpdateException ex) when (IsDuplicateKeyViolation(ex)) {
+                DbContext.ChangeTracker.Clear();
                 recipientPreferences = await DbContext.ContactPreferences
                                            .Include(x => x.CommunicationOptions)
                                            .ThenInclude(up => up.MessageType)
                                            .SingleAsync(x => x.RecipientId == recipientId);
-            } catch {
-                throw;
             }
         }
 
@@ -447,16 +448,25 @@ public class ContactService : IContactService
             try {
                 await DbContext.ContactPreferences.AddAsync(recipientPreferences);
                 await DbContext.SaveChangesAsync();
-            } catch (DbUpdateException) {
-
+                return;
+            } 
+            catch (DbUpdateException ex) when(IsDuplicateKeyViolation(ex)) {
+                DbContext.ChangeTracker.Clear();
+                recipientPreferences = await DbContext.ContactPreferences
+                                             .Include(x => x.CommunicationOptions)
+                                             .ThenInclude(up => up.MessageType)
+                                             .SingleAsync(x => x.RecipientId == recipientId);
             }
-            return;
         }
         recipientPreferences.Locale = preference.Locale;
         recipientPreferences.ConsentCommercial = preference.ConsentCommercial;
         recipientPreferences.ConsentCommercialDate = preference.ConsentCommercialDate;
         recipientPreferences.DefaultChannels = preference.DefaultChannels != null ? ContactChannelOption.ToContactChannelKind(preference.DefaultChannels) : null;
         await DbContext.SaveChangesAsync();
+    }
+
+    private bool IsDuplicateKeyViolation(DbUpdateException ex) {
+        return ex.InnerException != null && ex.InnerException.Message.Contains("Cannot insert duplicate key row");
     }
 
     ///<inheritdoc/>


### PR DESCRIPTION
Add try - catch blocks to handle db exceptions regarding multiple insertions with the same recipient id