### PR TITLE
[core] Refactor and generalize rate limiting configuration

### DIFF
--- a/src/Indice.AspNetCore/Configuration/RateLimiterOptions.cs
+++ b/src/Indice.AspNetCore/Configuration/RateLimiterOptions.cs
@@ -1,18 +1,30 @@
 ﻿using System.Threading.RateLimiting;
+using Indice.Security;
 using Microsoft.AspNetCore.Http;
-using Polly;
 
-namespace Indice.Features.Identity.Server.Options;
+namespace Indice.AspNetCore.Configuration;
 
 /// <summary>Rate limiter options for Identity Server API.</summary>
-public class IdentityRateLimiterOptions
+public class RateLimiterOptions
 {
     /// <summary>Section name.</summary>
-    public const string SectionName = "IdentityServer:RateLimiter";
+    public string SectionName = "RateLimiter";
+    /// <summary>User identifier claim type.</summary>
+    public string UserIdentifierClaimType = BasicClaimTypes.Subject;
     /// <summary>The default status code to set on the response when a request is rejected.</summary>
     public int? RejectionStatusCode { get; set; } = StatusCodes.Status429TooManyRequests;
     /// <summary>Rate limiter fixed window options for Identity Server API.</summary>
     public RateLimiterEndpointRule[] Rules { get; set; } = Array.Empty<RateLimiterEndpointRule>();
+    /// <summary>List of all rate limiter policies. This is used to ensure that all policies are registered in the rate limiter middleware.</summary>
+    public IReadOnlyList<string> AllRateLimiterPolicies { get; set; } = Array.Empty<string>();
+
+    /// <summary>Custom factory function for creating policy-specific rate limiter rules. Set this to provide custom configurations based on policy names.</summary>
+    public Func<string, RateLimiterEndpointRule>? CustomPolicyFactory { get; set; }
+
+    /// <summary>Default configuration for <see cref="RateLimiterEndpointRule"/>. Returns custom rule if <see cref="CustomPolicyFactory"/> is set, otherwise returns a default rule.</summary>
+    /// <param name="policyName">The policy name to get the configuration for.</param>
+    public RateLimiterEndpointRule GetPolicySettings(string policyName) =>
+        CustomPolicyFactory?.Invoke(policyName) ?? new();
 }
 
 /// <summary>Rate limiter fixed window options for Identity Server API.</summary>
@@ -29,16 +41,6 @@ public class RateLimiterEndpointRule
     /// <summary>Specifies the time window that takes in the requests. Defaults to 1s.</summary>
     public TimeSpan? Window { get; set; } = TimeSpan.FromSeconds(1);
 
-    /// <summary>Default configuration for <see cref="RateLimiterEndpointRule"/>.</summary>
-    public static RateLimiterEndpointRule Default(string? policyName = null) => policyName switch {
-        "secure-page" => new() { PermitLimit = 5, Window = TimeSpan.FromSeconds(1), HttpMethod = "POST" },
-        "forgot-password" => new() { PermitLimit = 5, Window = TimeSpan.FromSeconds(1), HttpMethod = "POST" },
-        "login" => new() { PermitLimit = 5, Window = TimeSpan.FromSeconds(1), HttpMethod = "POST" },
-        "register" => new() { PermitLimit = 5, Window = TimeSpan.FromSeconds(1), HttpMethod = "POST" },
-        "login/add-email" => new() { PermitLimit = 1, Window = TimeSpan.FromMinutes(1), HttpMethod = "POST" },
-        "login/mfa/onboarding/add-email" => new() { PermitLimit = 1, Window = TimeSpan.FromMinutes(1), HttpMethod = "POST" },
-        _ => new()
-    };
 
     /// <summary>The Http method of the endpoint to apply the rate limiter. Optional.</summary>
     public string? HttpMethod { get; set; }

--- a/src/Indice.AspNetCore/Configuration/RateLimiterOptions.cs
+++ b/src/Indice.AspNetCore/Configuration/RateLimiterOptions.cs
@@ -4,16 +4,16 @@ using Microsoft.AspNetCore.Http;
 
 namespace Indice.AspNetCore.Configuration;
 
-/// <summary>Rate limiter options for Identity Server API.</summary>
+/// <summary>Rate limiter options for Server API.</summary>
 public class RateLimiterOptions
 {
     /// <summary>Section name.</summary>
-    public string SectionName = "RateLimiter";
+    public const string SectionName = "RateLimiter";
     /// <summary>User identifier claim type.</summary>
-    public string UserIdentifierClaimType = BasicClaimTypes.Subject;
+    public string UserIdentifierClaimType { get; set; } = BasicClaimTypes.Subject;
     /// <summary>The default status code to set on the response when a request is rejected.</summary>
     public int? RejectionStatusCode { get; set; } = StatusCodes.Status429TooManyRequests;
-    /// <summary>Rate limiter fixed window options for Identity Server API.</summary>
+    /// <summary>Rate limiter fixed window options for Server API.</summary>
     public RateLimiterEndpointRule[] Rules { get; set; } = Array.Empty<RateLimiterEndpointRule>();
     /// <summary>List of all rate limiter policies. This is used to ensure that all policies are registered in the rate limiter middleware.</summary>
     public IReadOnlyList<string> AllRateLimiterPolicies { get; set; } = Array.Empty<string>();
@@ -27,7 +27,7 @@ public class RateLimiterOptions
         CustomPolicyFactory?.Invoke(policyName) ?? new();
 }
 
-/// <summary>Rate limiter fixed window options for Identity Server API.</summary>
+/// <summary>Rate limiter fixed window options for Server API.</summary>
 public class RateLimiterEndpointRule
 {
     /// <summary>The endpoint name.</summary>

--- a/src/Indice.AspNetCore/Extensions/RateLimiterExtensions.cs
+++ b/src/Indice.AspNetCore/Extensions/RateLimiterExtensions.cs
@@ -1,35 +1,38 @@
 ﻿using System.Security.Claims;
 using System.Threading.RateLimiting;
 using Indice.AspNetCore.Configuration;
+using Indice.Security;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Extensions.DependencyInjection;
-/// <summary>
-/// 
-/// </summary>
+
+/// <summary>Extensions related to RateLimiter</summary>
 public static class RateLimiterExtensions
 {
     /// <summary>Registers the rate limiter services.</summary>
     /// <param name="services">The service collection.</param>
     /// <param name="configuration">The configuration.</param>
     /// <param name="configureOptions">An action to configure the rate limiter options.</param>
-    public static IServiceCollection AddRateLimiting(this IServiceCollection services, 
-        IConfiguration configuration, Action<RateLimiterOptions> configureOptions) {
-        var myRateLimiterOptions = new RateLimiterOptions();
-        configureOptions?.Invoke(myRateLimiterOptions);
-        configuration.GetSection(myRateLimiterOptions.SectionName).Bind(myRateLimiterOptions);
+    /// <param name="configurationSectionName">The configuration section name. Optional.</param>
+    public static IServiceCollection AddRateLimiting(this IServiceCollection services,
+        IConfiguration configuration, Action<RateLimiterOptions> configureOptions, string? configurationSectionName = null) {
+        var sectionName = string.IsNullOrEmpty(configurationSectionName) ? RateLimiterOptions.SectionName : configurationSectionName;
 
-        services.AddRateLimiter(rateLimiterOptions => {
-            foreach (var endpoint in myRateLimiterOptions.AllRateLimiterPolicies) {
-                var endpointOptions = myRateLimiterOptions.Rules.FirstOrDefault(rule => rule.Endpoint == endpoint) ?? myRateLimiterOptions.GetPolicySettings(endpoint);
-                rateLimiterOptions.AddPolicy(endpoint, context => {
+        var rateLimiterOptions = new RateLimiterOptions();
+        configuration.GetSection(sectionName).Bind(rateLimiterOptions);
+        configureOptions.Invoke(rateLimiterOptions);
+
+        services.AddRateLimiter(options => {
+            foreach (var endpoint in rateLimiterOptions.AllRateLimiterPolicies) {
+                var endpointOptions = rateLimiterOptions.Rules.FirstOrDefault(rule => rule.Endpoint == endpoint) ?? rateLimiterOptions.GetPolicySettings(endpoint);
+                options.AddPolicy(endpoint, context => {
                     if (!endpointOptions.CanLimitHttpMethod(context.Request.Method)) {
                         return RateLimitPartition.GetNoLimiter("NoRateLimiting");
                     }
                     return RateLimitPartition.GetFixedWindowLimiter(
-                        partitionKey: context.User.FindClaimValue(myRateLimiterOptions.UserIdentifierClaimType) ?? context.Connection.RemoteIpAddress?.ToString() ?? context.Request.Headers.Host.ToString(),
+                        partitionKey: context.User.FindFirstValue(rateLimiterOptions.UserIdentifierClaimType) ?? context.Connection.RemoteIpAddress?.ToString() ?? context.Request.Headers.Host.ToString(),
                         factory: _ => new FixedWindowRateLimiterOptions {
                             PermitLimit = endpointOptions.PermitLimit.GetValueOrDefault(),
                             QueueLimit = endpointOptions.QueueLimit.GetValueOrDefault(),
@@ -38,8 +41,8 @@ public static class RateLimiterExtensions
                         });
                 });
             }
-            rateLimiterOptions.RejectionStatusCode = myRateLimiterOptions.RejectionStatusCode.GetValueOrDefault();
-            rateLimiterOptions.OnRejected = (context, cancellationToken) => {
+            options.RejectionStatusCode = rateLimiterOptions.RejectionStatusCode.GetValueOrDefault();
+            options.OnRejected = (context, cancellationToken) => {
                 if (context.Lease.TryGetMetadata(MetadataName.RetryAfter, out var retryAfter)) {
                     context.HttpContext.Items.Add("retry-after", retryAfter.TotalSeconds);
                 }
@@ -48,10 +51,4 @@ public static class RateLimiterExtensions
         });
         return services;
     }
-
-    /// <summary>Gets the user's unique id.</summary>
-    /// <param name="principal">The current principal.</param>
-    /// <param name="claimType"></param>
-    public static string? FindClaimValue(this ClaimsPrincipal principal, string claimType) => principal.FindFirst(claimType)?.Value;
 }
-

--- a/src/Indice.AspNetCore/Extensions/RateLimiterExtensions.cs
+++ b/src/Indice.AspNetCore/Extensions/RateLimiterExtensions.cs
@@ -1,0 +1,57 @@
+﻿using System.Security.Claims;
+using System.Threading.RateLimiting;
+using Indice.AspNetCore.Configuration;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.Extensions.DependencyInjection;
+/// <summary>
+/// 
+/// </summary>
+public static class RateLimiterExtensions
+{
+    /// <summary>Registers the rate limiter services.</summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configuration">The configuration.</param>
+    /// <param name="configureOptions">An action to configure the rate limiter options.</param>
+    public static IServiceCollection AddRateLimiting(this IServiceCollection services, 
+        IConfiguration configuration, Action<RateLimiterOptions> configureOptions) {
+        var myRateLimiterOptions = new RateLimiterOptions();
+        configureOptions?.Invoke(myRateLimiterOptions);
+        configuration.GetSection(myRateLimiterOptions.SectionName).Bind(myRateLimiterOptions);
+
+        services.AddRateLimiter(rateLimiterOptions => {
+            foreach (var endpoint in myRateLimiterOptions.AllRateLimiterPolicies) {
+                var endpointOptions = myRateLimiterOptions.Rules.FirstOrDefault(rule => rule.Endpoint == endpoint) ?? myRateLimiterOptions.GetPolicySettings(endpoint);
+                rateLimiterOptions.AddPolicy(endpoint, context => {
+                    if (!endpointOptions.CanLimitHttpMethod(context.Request.Method)) {
+                        return RateLimitPartition.GetNoLimiter("NoRateLimiting");
+                    }
+                    return RateLimitPartition.GetFixedWindowLimiter(
+                        partitionKey: context.User.FindClaimValue(myRateLimiterOptions.UserIdentifierClaimType) ?? context.Connection.RemoteIpAddress?.ToString() ?? context.Request.Headers.Host.ToString(),
+                        factory: _ => new FixedWindowRateLimiterOptions {
+                            PermitLimit = endpointOptions.PermitLimit.GetValueOrDefault(),
+                            QueueLimit = endpointOptions.QueueLimit.GetValueOrDefault(),
+                            QueueProcessingOrder = endpointOptions.QueueProcessingOrder.GetValueOrDefault(),
+                            Window = endpointOptions.Window.GetValueOrDefault()
+                        });
+                });
+            }
+            rateLimiterOptions.RejectionStatusCode = myRateLimiterOptions.RejectionStatusCode.GetValueOrDefault();
+            rateLimiterOptions.OnRejected = (context, cancellationToken) => {
+                if (context.Lease.TryGetMetadata(MetadataName.RetryAfter, out var retryAfter)) {
+                    context.HttpContext.Items.Add("retry-after", retryAfter.TotalSeconds);
+                }
+                return ValueTask.CompletedTask;
+            };
+        });
+        return services;
+    }
+
+    /// <summary>Gets the user's unique id.</summary>
+    /// <param name="principal">The current principal.</param>
+    /// <param name="claimType"></param>
+    public static string? FindClaimValue(this ClaimsPrincipal principal, string claimType) => principal.FindFirst(claimType)?.Value;
+}
+

--- a/src/Indice.Features.Identity.Server/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Indice.Features.Identity.Server/Extensions/ServiceCollectionExtensions.cs
@@ -2,7 +2,6 @@
 using System.Security.Cryptography.X509Certificates;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Threading.RateLimiting;
 using FluentValidation;
 using Duende.IdentityModel;
 #if NET9_0_OR_GREATER
@@ -31,7 +30,6 @@ using Indice.Services;
 using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
-using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
@@ -410,31 +408,17 @@ public static class IdentityServerEndpointServiceCollectionExtensions
     }
 
     private static IServiceCollection AddIdentityRateLimiter(this IServiceCollection services, IConfiguration configuration) {
-        var identityRateLimiterOptions = new IdentityRateLimiterOptions();
-        configuration.GetSection(IdentityRateLimiterOptions.SectionName).Bind(identityRateLimiterOptions);
-        services.AddRateLimiter(rateLimiterOptions => {
-            foreach (var endpoint in RateLimiterPolicies.All) {
-                var endpointOptions = identityRateLimiterOptions.Rules.FirstOrDefault(rule => rule.Endpoint == endpoint) ?? RateLimiterEndpointRule.Default(endpoint);
-                rateLimiterOptions.AddPolicy(endpoint, context => {
-                    if (!endpointOptions.CanLimitHttpMethod(context.Request.Method)) {
-                        return RateLimitPartition.GetNoLimiter("NoRateLimiting");
-                    }
-                    return RateLimitPartition.GetFixedWindowLimiter(
-                        partitionKey: context.User.FindSubjectId() ?? context.Connection.RemoteIpAddress?.ToString() ?? context.Request.Headers.Host.ToString(),
-                        factory: _ => new FixedWindowRateLimiterOptions {
-                            PermitLimit = endpointOptions.PermitLimit.GetValueOrDefault(),
-                            QueueLimit = endpointOptions.QueueLimit.GetValueOrDefault(),
-                            QueueProcessingOrder = endpointOptions.QueueProcessingOrder.GetValueOrDefault(),
-                            Window = endpointOptions.Window.GetValueOrDefault()
-                        });
-                });
-            }
-            rateLimiterOptions.RejectionStatusCode = identityRateLimiterOptions.RejectionStatusCode.GetValueOrDefault();
-            rateLimiterOptions.OnRejected = (context, cancellationToken) => {
-                if (context.Lease.TryGetMetadata(MetadataName.RetryAfter, out var retryAfter)) {
-                    context.HttpContext.Items.Add("retry-after", retryAfter.TotalSeconds);
-                }
-                return ValueTask.CompletedTask;
+        services.AddRateLimiting(configuration, options => {
+            options.SectionName = "IdentityServer:RateLimiter";
+            options.AllRateLimiterPolicies = RateLimiterPolicies.All;
+            options.CustomPolicyFactory = (policyName) => policyName switch {
+                "secure-page" => new() { PermitLimit = 5, Window = TimeSpan.FromSeconds(1), HttpMethod = "POST" },
+                "forgot-password" => new() { PermitLimit = 5, Window = TimeSpan.FromSeconds(1), HttpMethod = "POST" },
+                "login" => new() { PermitLimit = 5, Window = TimeSpan.FromSeconds(1), HttpMethod = "POST" },
+                "register" => new() { PermitLimit = 5, Window = TimeSpan.FromSeconds(1), HttpMethod = "POST" },
+                "login/add-email" => new() { PermitLimit = 1, Window = TimeSpan.FromMinutes(1), HttpMethod = "POST" },
+                "login/mfa/onboarding/add-email" => new() { PermitLimit = 1, Window = TimeSpan.FromMinutes(1), HttpMethod = "POST" },
+                _ => new()
             };
         });
         return services;

--- a/src/Indice.Features.Identity.Server/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Indice.Features.Identity.Server/Extensions/ServiceCollectionExtensions.cs
@@ -41,6 +41,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.FeatureManagement;
 using Microsoft.IdentityModel.Logging;
 using Indice.Features.Identity.Core.IdentityValidation;
+using Indice.AspNetCore.Configuration;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -409,7 +410,7 @@ public static class IdentityServerEndpointServiceCollectionExtensions
 
     private static IServiceCollection AddIdentityRateLimiter(this IServiceCollection services, IConfiguration configuration) {
         services.AddRateLimiting(configuration, options => {
-            options.SectionName = "IdentityServer:RateLimiter";
+
             options.AllRateLimiterPolicies = RateLimiterPolicies.All;
             options.CustomPolicyFactory = (policyName) => policyName switch {
                 "secure-page" => new() { PermitLimit = 5, Window = TimeSpan.FromSeconds(1), HttpMethod = "POST" },
@@ -418,9 +419,9 @@ public static class IdentityServerEndpointServiceCollectionExtensions
                 "register" => new() { PermitLimit = 5, Window = TimeSpan.FromSeconds(1), HttpMethod = "POST" },
                 "login/add-email" => new() { PermitLimit = 1, Window = TimeSpan.FromMinutes(1), HttpMethod = "POST" },
                 "login/mfa/onboarding/add-email" => new() { PermitLimit = 1, Window = TimeSpan.FromMinutes(1), HttpMethod = "POST" },
-                _ => new()
+                _ => new RateLimiterEndpointRule()
             };
-        });
+        }, "IdentityServer:RateLimiter");
         return services;
     }
 }


### PR DESCRIPTION
Replaced Identity-specific rate limiter options with a generic, reusable RateLimiterOptions and endpoint rule model. Introduced AddRateLimiting extension for flexible policy registration and user-based partitioning. Updated ServiceCollectionExtensions to use the new approach. Adjusted appsettings.json for phone confirmation and formatting. This enables broader, more maintainable rate limiting across endpoints.