### PR TITLE
[identity] Update email templates to use email specific org name localization

### DIFF
--- a/src/Indice.Features.Identity.UI/IdentityLabels.Designer.cs
+++ b/src/Indice.Features.Identity.UI/IdentityLabels.Designer.cs
@@ -828,9 +828,9 @@ namespace Indice.Features.Identity.UI {
         /// <summary>
         ///   Looks up a localized string similar to {0}.
         /// </summary>
-        public static string Email_Body_Organization {
+        public static string Email_Body_Organization_Signature {
             get {
-                return ResourceManager.GetString("Email_Body_Organization", resourceCulture);
+                return ResourceManager.GetString("Email_Body_Organization_Signature", resourceCulture);
             }
         }
         

--- a/src/Indice.Features.Identity.UI/IdentityLabels.de.resx
+++ b/src/Indice.Features.Identity.UI/IdentityLabels.de.resx
@@ -375,7 +375,7 @@
   <data name="Email_Body_Sincerely" xml:space="preserve">
     <value>Mit freundlichen Grüßen</value>
   </data>
-  <data name="Email_Body_Organization" xml:space="preserve">
+  <data name="Email_Body_Organization_Signature" xml:space="preserve">
     <value>{0}</value>
   </data>
   <data name="Email_Reset_Password_FieldLabel" xml:space="preserve">

--- a/src/Indice.Features.Identity.UI/IdentityLabels.el.resx
+++ b/src/Indice.Features.Identity.UI/IdentityLabels.el.resx
@@ -375,7 +375,7 @@
   <data name="Email_Body_Sincerely" xml:space="preserve">
     <value>Με εκτίμηση</value>
   </data>
-  <data name="Email_Body_Organization" xml:space="preserve">
+  <data name="Email_Body_Organization_Signature" xml:space="preserve">
     <value>{0}</value>
   </data>
   <data name="Email_Reset_Password_FieldLabel" xml:space="preserve">

--- a/src/Indice.Features.Identity.UI/IdentityLabels.es.resx
+++ b/src/Indice.Features.Identity.UI/IdentityLabels.es.resx
@@ -375,7 +375,7 @@
   <data name="Email_Body_Sincerely" xml:space="preserve">
     <value>Atentamente</value>
   </data>
-  <data name="Email_Body_Organization" xml:space="preserve">
+  <data name="Email_Body_Organization_Signature" xml:space="preserve">
     <value>{0}</value>
   </data>
   <data name="Email_Reset_Password_FieldLabel" xml:space="preserve">

--- a/src/Indice.Features.Identity.UI/IdentityLabels.fr.resx
+++ b/src/Indice.Features.Identity.UI/IdentityLabels.fr.resx
@@ -375,7 +375,7 @@
   <data name="Email_Body_Sincerely" xml:space="preserve">
     <value>Cordialement</value>
   </data>
-  <data name="Email_Body_Organization" xml:space="preserve">
+  <data name="Email_Body_Organization_Signature" xml:space="preserve">
     <value>{0}</value>
   </data>
   <data name="Email_Reset_Password_FieldLabel" xml:space="preserve">

--- a/src/Indice.Features.Identity.UI/IdentityLabels.it.resx
+++ b/src/Indice.Features.Identity.UI/IdentityLabels.it.resx
@@ -375,7 +375,7 @@
   <data name="Email_Body_Sincerely" xml:space="preserve">
     <value>Cordiali saluti</value>
   </data>
-  <data name="Email_Body_Organization" xml:space="preserve">
+  <data name="Email_Body_Organization_Signature" xml:space="preserve">
     <value>{0}</value>
   </data>
   <data name="Email_Reset_Password_FieldLabel" xml:space="preserve">

--- a/src/Indice.Features.Identity.UI/IdentityLabels.ja.resx
+++ b/src/Indice.Features.Identity.UI/IdentityLabels.ja.resx
@@ -375,7 +375,7 @@
   <data name="Email_Body_Sincerely" xml:space="preserve">
     <value>敬具</value>
   </data>
-  <data name="Email_Body_Organization" xml:space="preserve">
+  <data name="Email_Body_Organization_Signature" xml:space="preserve">
     <value>{0}</value>
   </data>
   <data name="Email_Reset_Password_FieldLabel" xml:space="preserve">

--- a/src/Indice.Features.Identity.UI/IdentityLabels.pt.resx
+++ b/src/Indice.Features.Identity.UI/IdentityLabels.pt.resx
@@ -375,7 +375,7 @@
   <data name="Email_Body_Sincerely" xml:space="preserve">
     <value>Atenciosamente</value>
   </data>
-  <data name="Email_Body_Organization" xml:space="preserve">
+  <data name="Email_Body_Organization_Signature" xml:space="preserve">
     <value>{0}</value>
   </data>
   <data name="Email_Reset_Password_FieldLabel" xml:space="preserve">

--- a/src/Indice.Features.Identity.UI/IdentityLabels.resx
+++ b/src/Indice.Features.Identity.UI/IdentityLabels.resx
@@ -375,7 +375,7 @@
   <data name="Email_Body_Sincerely" xml:space="preserve">
     <value>Sincerely</value>
   </data>
-  <data name="Email_Body_Organization" xml:space="preserve">
+  <data name="Email_Body_Organization_Signature" xml:space="preserve">
     <value>{0}</value>
   </data>
   <data name="Email_Reset_Password_FieldLabel" xml:space="preserve">

--- a/src/Indice.Features.Identity.UI/IdentityUILocalizer.cs
+++ b/src/Indice.Features.Identity.UI/IdentityUILocalizer.cs
@@ -239,7 +239,7 @@ public class IdentityUILocalizer
     public virtual HtmlString Email_Body_Sincerely => new HtmlString(string.Format(CultureInfo.CurrentUICulture, IdentityLabels.Email_Body_Sincerely));
 
     /// <summary>Organization name placeholder in email body.</summary>
-    public virtual HtmlString Email_Body_Organization(string organization) => new HtmlString(string.Format(CultureInfo.CurrentUICulture, IdentityLabels.Email_Body_Organization, organization));
+    public virtual HtmlString Email_Body_Organization_Signature(string organization) => new HtmlString(string.Format(CultureInfo.CurrentUICulture, IdentityLabels.Email_Body_Organization_Signature, organization));
     /// <summary>
     /// Label for the Reset password action.
     /// </summary>

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/EmailConfirmEmailChange.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/EmailConfirmEmailChange.cshtml
@@ -34,5 +34,5 @@
     @Localizer.Email_Body_Thanks.
     <br />
     <br />
-    @Localizer.Email_Body_Sincerely, @Localizer.OrganizationName(settings.Organization!).
+    @Localizer.Email_Body_Sincerely, @Localizer.Email_Body_Organization(settings.Organization!).
 </p>

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/EmailConfirmEmailChange.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/EmailConfirmEmailChange.cshtml
@@ -34,5 +34,5 @@
     @Localizer.Email_Body_Thanks.
     <br />
     <br />
-    @Localizer.Email_Body_Sincerely, @Localizer.Email_Body_Organization(settings.Organization!).
+    @Localizer.Email_Body_Sincerely, @Localizer.Email_Body_Organization_Signature(settings.Organization!).
 </p>

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/EmailConfirmYourEmail.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/EmailConfirmYourEmail.cshtml
@@ -34,5 +34,5 @@
     @Localizer.Email_Body_Thanks.
     <br />
     <br />
-    @Localizer.Email_Body_Sincerely, @Localizer.OrganizationName(settings.Organization!).
+    @Localizer.Email_Body_Sincerely, @Localizer.Email_Body_Organization(settings.Organization!).
 </p>

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/EmailConfirmYourEmail.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/EmailConfirmYourEmail.cshtml
@@ -34,5 +34,5 @@
     @Localizer.Email_Body_Thanks.
     <br />
     <br />
-    @Localizer.Email_Body_Sincerely, @Localizer.Email_Body_Organization(settings.Organization!).
+    @Localizer.Email_Body_Sincerely, @Localizer.Email_Body_Organization_Signature(settings.Organization!).
 </p>

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/EmailForgotPassword.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/EmailForgotPassword.cshtml
@@ -37,5 +37,5 @@
     @Localizer.Email_ResetPassword_IgnoreNotice
     <br /><br />
     <br /><br />
-    @Localizer.Email_Body_Sincerely @Localizer.Email_Body_Organization(Settings.Organization!).
+    @Localizer.Email_Body_Sincerely @Localizer.Email_Body_Organization_Signature(Settings.Organization!).
 </p>

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/EmailForgotPassword.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/EmailForgotPassword.cshtml
@@ -37,5 +37,5 @@
     @Localizer.Email_ResetPassword_IgnoreNotice
     <br /><br />
     <br /><br />
-    @Localizer.Email_Body_Sincerely @Localizer.OrganizationName(Settings.Organization!).
+    @Localizer.Email_Body_Sincerely @Localizer.Email_Body_Organization(Settings.Organization!).
 </p>

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/EmailMfaOnboarding.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/EmailMfaOnboarding.cshtml
@@ -34,5 +34,5 @@
     @Localizer.Email_Body_Thanks
     <br />
     <br />
-    @Localizer.Email_Body_Sincerely, @Localizer.OrganizationName(settings.Organization!).
+    @Localizer.Email_Body_Sincerely, @Localizer.Email_Body_Organization(settings.Organization!).
 </p>

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/EmailMfaOnboarding.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/EmailMfaOnboarding.cshtml
@@ -34,5 +34,5 @@
     @Localizer.Email_Body_Thanks
     <br />
     <br />
-    @Localizer.Email_Body_Sincerely, @Localizer.Email_Body_Organization(settings.Organization!).
+    @Localizer.Email_Body_Sincerely, @Localizer.Email_Body_Organization_Signature(settings.Organization!).
 </p>

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/EmailMfaOtpCode.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/EmailMfaOtpCode.cshtml
@@ -33,5 +33,5 @@
     @Localizer.Email_Body_Thanks
     <br />
     <br />
-    @Localizer.Email_Body_Sincerely, @Localizer.OrganizationName(settings.Organization!).
+    @Localizer.Email_Body_Sincerely, @Localizer.Email_Body_Organization(settings.Organization!).
 </p>

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/EmailMfaOtpCode.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/EmailMfaOtpCode.cshtml
@@ -33,5 +33,5 @@
     @Localizer.Email_Body_Thanks
     <br />
     <br />
-    @Localizer.Email_Body_Sincerely, @Localizer.Email_Body_Organization(settings.Organization!).
+    @Localizer.Email_Body_Sincerely, @Localizer.Email_Body_Organization_Signature(settings.Organization!).
 </p>

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/EmailRegister.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/EmailRegister.cshtml
@@ -45,5 +45,5 @@
     <br />
     <br />
     @Localizer.Email_Body_Sincerely,<br />
-    @Localizer.Email_Body_Organization(settings.Organization!)
+    @Localizer.Email_Body_Organization_Signature(settings.Organization!)
 </p>

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/EmailSecurityNotification.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/EmailSecurityNotification.cshtml
@@ -50,5 +50,5 @@
     </ul>
 </p>
 <p style="font-family: 'Century Gothic', Arial, sans-serif, Helvetica, Arial, sans-serif; font-size: 12px;">
-    @Localizer.Email_Body_Sincerely, @Localizer.Email_Body_Organization(settings.Organization!)
+    @Localizer.Email_Body_Sincerely, @Localizer.Email_Body_Organization_Signature(settings.Organization!)
 </p>

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/EmailConfirmEmailChange.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/EmailConfirmEmailChange.cshtml
@@ -32,5 +32,5 @@
     @Localizer.Email_Body_Thanks.
     <br />
     <br />
-    @Localizer.Email_Body_Sincerely, @Localizer.OrganizationName(settings.Organization!).
+    @Localizer.Email_Body_Sincerely, @Localizer.Email_Body_Organization(settings.Organization!).
 </p>

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/EmailConfirmEmailChange.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/EmailConfirmEmailChange.cshtml
@@ -32,5 +32,5 @@
     @Localizer.Email_Body_Thanks.
     <br />
     <br />
-    @Localizer.Email_Body_Sincerely, @Localizer.Email_Body_Organization(settings.Organization!).
+    @Localizer.Email_Body_Sincerely, @Localizer.Email_Body_Organization_Signature(settings.Organization!).
 </p>

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/EmailConfirmYourEmail.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/EmailConfirmYourEmail.cshtml
@@ -33,5 +33,5 @@
     @Localizer.Email_Body_Thanks.
     <br />
     <br />
-    @Localizer.Email_Body_Sincerely, @Localizer.Email_Body_Organization(settings.Organization!).
+    @Localizer.Email_Body_Sincerely, @Localizer.Email_Body_Organization_Signature(settings.Organization!).
 </p>

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/EmailConfirmYourEmail.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/EmailConfirmYourEmail.cshtml
@@ -33,5 +33,5 @@
     @Localizer.Email_Body_Thanks.
     <br />
     <br />
-    @Localizer.Email_Body_Sincerely, @Localizer.OrganizationName(settings.Organization!).
+    @Localizer.Email_Body_Sincerely, @Localizer.Email_Body_Organization(settings.Organization!).
 </p>

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/EmailForgotPassword.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/EmailForgotPassword.cshtml
@@ -33,5 +33,5 @@ var userName = Model?.UserName ?? UserManager.GetUserName(User);
     @Localizer.Email_ResetPassword_IgnoreNotice
     <br /><br />
     <br /><br />
-    @Localizer.Email_Body_Sincerely @Localizer.Email_Body_Organization(Settings.Organization!).
+    @Localizer.Email_Body_Sincerely @Localizer.Email_Body_Organization_Signature(Settings.Organization!).
 </p>

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/EmailForgotPassword.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/EmailForgotPassword.cshtml
@@ -33,5 +33,5 @@ var userName = Model?.UserName ?? UserManager.GetUserName(User);
     @Localizer.Email_ResetPassword_IgnoreNotice
     <br /><br />
     <br /><br />
-    @Localizer.Email_Body_Sincerely @Localizer.OrganizationName(Settings.Organization!).
+    @Localizer.Email_Body_Sincerely @Localizer.Email_Body_Organization(Settings.Organization!).
 </p>

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/EmailMfaOnboarding.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/EmailMfaOnboarding.cshtml
@@ -34,5 +34,5 @@
     @Localizer.Email_Body_Thanks
     <br />
     <br />
-    @Localizer.Email_Body_Sincerely, @Localizer.OrganizationName(settings.Organization!).
+    @Localizer.Email_Body_Sincerely, @Localizer.Email_Body_Organization(settings.Organization!).
 </p>

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/EmailMfaOnboarding.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/EmailMfaOnboarding.cshtml
@@ -34,5 +34,5 @@
     @Localizer.Email_Body_Thanks
     <br />
     <br />
-    @Localizer.Email_Body_Sincerely, @Localizer.Email_Body_Organization(settings.Organization!).
+    @Localizer.Email_Body_Sincerely, @Localizer.Email_Body_Organization_Signature(settings.Organization!).
 </p>

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/EmailMfaOtpCode.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/EmailMfaOtpCode.cshtml
@@ -33,5 +33,5 @@
     @Localizer.Email_Body_Thanks
     <br />
     <br />
-    @Localizer.Email_Body_Sincerely, @Localizer.OrganizationName(settings.Organization!).
+    @Localizer.Email_Body_Sincerely, @Localizer.Email_Body_Organization(settings.Organization!).
 </p>

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/EmailMfaOtpCode.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/EmailMfaOtpCode.cshtml
@@ -33,5 +33,5 @@
     @Localizer.Email_Body_Thanks
     <br />
     <br />
-    @Localizer.Email_Body_Sincerely, @Localizer.Email_Body_Organization(settings.Organization!).
+    @Localizer.Email_Body_Sincerely, @Localizer.Email_Body_Organization_Signature(settings.Organization!).
 </p>

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/EmailRegister.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/EmailRegister.cshtml
@@ -46,5 +46,5 @@
     <br />
     <br />
     @Localizer.Email_Body_Sincerely,<br />
-    @Localizer.Email_Body_Organization(settings.Organization!)
+    @Localizer.Email_Body_Organization_Signature(settings.Organization!)
 </p>

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/EmailRegister.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/EmailRegister.cshtml
@@ -46,5 +46,5 @@
     <br />
     <br />
     @Localizer.Email_Body_Sincerely,<br />
-    @Localizer.OrganizationName(settings.Organization!)
+    @Localizer.Email_Body_Organization(settings.Organization!)
 </p>

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/EmailSecurityNotification.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/EmailSecurityNotification.cshtml
@@ -41,5 +41,5 @@
 </p>
 <p style="font-family: 'Century Gothic', Arial, sans-serif, Helvetica, Arial, sans-serif; font-size: 12px;">
     @Localizer.EmailSecurity_Body_ContactSupport<br /><br />
-    @Localizer.Email_Body_Sincerely, @Localizer.Email_Body_Organization(settings.Organization!)
+    @Localizer.Email_Body_Sincerely, @Localizer.Email_Body_Organization_Signature(settings.Organization!)
 </p>


### PR DESCRIPTION
Replaced OrganizationName with Email_Body_Organization in all email templates for improved consistency and localization of organization names. Affected templates include email confirmation, registration, password reset, and MFA onboarding/OTP emails.