### PR TITLE
Add rate limiting to add phone and profile pages

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,8 +7,8 @@
       <VersionPrefixBase>$(VersionPrefixMajor).41</VersionPrefixBase>
 
       <VersionPrefixCore>$(VersionPrefixBase).0</VersionPrefixCore>
-      <VersionPrefixIdentity>$(VersionPrefixBase).1</VersionPrefixIdentity>
-      <VersionPrefixIdentityUI>$(VersionPrefixBase).1</VersionPrefixIdentityUI>
+      <VersionPrefixIdentity>$(VersionPrefixBase).2</VersionPrefixIdentity>
+      <VersionPrefixIdentityUI>$(VersionPrefixBase).2</VersionPrefixIdentityUI>
       <VersionPrefixCases>$(VersionPrefixBase).0</VersionPrefixCases>
       <VersionPrefixMessages>$(VersionPrefixBase).0</VersionPrefixMessages>
       <VersionPrefixMultitenancy>$(VersionPrefixBase).0</VersionPrefixMultitenancy>

--- a/src/Indice.Features.Identity.Core/Constants.cs
+++ b/src/Indice.Features.Identity.Core/Constants.cs
@@ -154,6 +154,12 @@ public static partial class RateLimiterPolicies
     public static readonly string MfaAddEmailPage = "login/mfa/onboarding/add-email";
     /// <summary>Rate limiting policy for recaptcha endpoint.</summary>
     public static readonly string RecaptchaEndpoint = "recaptchavalidate";
+    /// <summary>Rate limiting policy for add phone page.</summary>
+    public static readonly string AddPhonePage = "login/add-phone";
+    /// <summary>Rate limiting policy for MFA onboarding add phone page.</summary>
+    public static readonly string MfaAddPhonePage = "login/mfa/onboarding/add-phone";
+    /// <summary>Rate limiting policy for profile page.</summary>
+    public static readonly string ProfilePage = "manage/profile";
 
     /// <summary>All rate limiting policies.</summary>
     public static IReadOnlyList<string> All { get; } = new List<string> {
@@ -179,6 +185,9 @@ public static partial class RateLimiterPolicies
             LoginPage,
             LoginAddEmailPage,
             MfaAddEmailPage,
-            RecaptchaEndpoint
+            RecaptchaEndpoint,
+            AddPhonePage,
+            MfaAddPhonePage,
+            ProfilePage
         };
 }

--- a/src/Indice.Features.Identity.Server/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Indice.Features.Identity.Server/Extensions/ServiceCollectionExtensions.cs
@@ -429,7 +429,10 @@ public static class IdentityServerEndpointServiceCollectionExtensions
                 "login" => new() { PermitLimit = 5, Window = TimeSpan.FromSeconds(1), HttpMethod = "POST" },
                 "register" => new() { PermitLimit = 5, Window = TimeSpan.FromSeconds(1), HttpMethod = "POST" },
                 "login/add-email" => new() { PermitLimit = 1, Window = TimeSpan.FromMinutes(1), HttpMethod = "POST" },
+                "login/add-phone" => new() { PermitLimit = 1, Window = TimeSpan.FromMinutes(1), HttpMethod = "POST" },
                 "login/mfa/onboarding/add-email" => new() { PermitLimit = 1, Window = TimeSpan.FromMinutes(1), HttpMethod = "POST" },
+                "login/mfa/onboarding/add-phone" => new() { PermitLimit = 1, Window = TimeSpan.FromMinutes(1), HttpMethod = "POST" },
+                "manage/profile" => new() { PermitLimit = 1, Window = TimeSpan.FromSeconds(3), HttpMethod = "POST" },
                 _ => new RateLimiterEndpointRule()
             };
         }, "IdentityServer:RateLimiter");

--- a/src/Indice.Features.Identity.Server/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Indice.Features.Identity.Server/Extensions/ServiceCollectionExtensions.cs
@@ -432,7 +432,7 @@ public static class IdentityServerEndpointServiceCollectionExtensions
                 "login/add-phone" => new() { PermitLimit = 1, Window = TimeSpan.FromMinutes(1), HttpMethod = "POST" },
                 "login/mfa/onboarding/add-email" => new() { PermitLimit = 1, Window = TimeSpan.FromMinutes(1), HttpMethod = "POST" },
                 "login/mfa/onboarding/add-phone" => new() { PermitLimit = 1, Window = TimeSpan.FromMinutes(1), HttpMethod = "POST" },
-                "manage/profile" => new() { PermitLimit = 1, Window = TimeSpan.FromSeconds(3), HttpMethod = "POST" },
+                "manage/profile" => new() { PermitLimit = 2, Window = TimeSpan.FromSeconds(3), HttpMethod = "POST" },
                 _ => new RateLimiterEndpointRule()
             };
         }, "IdentityServer:RateLimiter");

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/AddPhone.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/AddPhone.cshtml
@@ -1,5 +1,5 @@
 ﻿@page "/login/add-phone"
-
+@attribute [Microsoft.AspNetCore.RateLimiting.EnableRateLimiting("login/add-phone")]
 @model BaseAddPhoneModel
 
 @inject IWebHostEnvironment HostingEnvironment

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/MfaOnboardingAddPhone.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/MfaOnboardingAddPhone.cshtml
@@ -1,5 +1,5 @@
 ﻿@page "/login/mfa/onboarding/add-phone"
-
+@attribute [Microsoft.AspNetCore.RateLimiting.EnableRateLimiting("login/mfa/onboarding/add-phone")]
 @model BaseMfaOnboardingAddPhoneModel
 
 @inject IWebHostEnvironment HostingEnvironment

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Profile.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Profile.cshtml
@@ -1,5 +1,5 @@
 ﻿@page "/manage/profile"
-
+@attribute [Microsoft.AspNetCore.RateLimiting.EnableRateLimiting("manage/profile")]
 
 @inject CallingCodesProvider callingCodesProvider
 @inject IOptions<IdentityUIOptions> identityUiOptions

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/AddPhone.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/AddPhone.cshtml
@@ -1,5 +1,5 @@
 ﻿@page "/login/add-phone"
-
+@attribute [Microsoft.AspNetCore.RateLimiting.EnableRateLimiting("login/add-phone")]
 @model BaseAddPhoneModel
 
 @inject IWebHostEnvironment HostingEnvironment

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/MfaOnboardingAddPhone.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/MfaOnboardingAddPhone.cshtml
@@ -1,5 +1,5 @@
 ﻿@page "/login/mfa/onboarding/add-phone"
-
+@attribute [Microsoft.AspNetCore.RateLimiting.EnableRateLimiting("login/mfa/onboarding/add-phone")]
 @model BaseMfaOnboardingAddPhoneModel
 
 @inject IWebHostEnvironment HostingEnvironment

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/Profile.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/Profile.cshtml
@@ -1,5 +1,5 @@
 ﻿@page "/manage/profile"
-
+@attribute [Microsoft.AspNetCore.RateLimiting.EnableRateLimiting("manage/profile")]
 @inject IZoneInfoProvider zoneInfoProvider
 @inject CallingCodesProvider callingCodesProvider
 @inject IOptions<IdentityUIOptions> identityUiOptions


### PR DESCRIPTION
- Introduce new rate limiting policies for add phone, MFA onboarding add phone, and profile endpoints.
- Update Razor Pages to enable rate limiting via [EnableRateLimiting] attributes.
- Define specific rate limiting rules for these endpoints in ServiceCollectionExtensions.
- Bump Identity and IdentityUI version numbers from .1 to .2.