### PR TITLE
[identity] Fix forgot password so it now uses the user's actual name and add For…

### DIFF
--- a/src/Indice.Features.Identity.Core/Data/Models/User.cs
+++ b/src/Indice.Features.Identity.Core/Data/Models/User.cs
@@ -95,20 +95,4 @@ public class User : IdentityUser
             UserId = Id
         });
     }
-
-    /// <summary>Finds a display name for the user based on <see cref="BasicClaimTypes.GivenName"/>, <see cref="BasicClaimTypes.FamilyName"/> claims and <see cref="User.Email"/>.</summary>
-    public string? FindDisplayName() {
-        var displayName = default(string);
-        var name = Claims.FirstOrDefault(x => x.ClaimType is BasicClaimTypes.Name)?.ClaimValue;
-        var firstName = Claims.FirstOrDefault(x => x.ClaimType is BasicClaimTypes.GivenName)?.ClaimValue;
-        var lastName = Claims.FirstOrDefault(x => x.ClaimType is BasicClaimTypes.FamilyName)?.ClaimValue;
-        if (!string.IsNullOrEmpty(firstName) || !string.IsNullOrEmpty(lastName)) {
-            displayName = $"{firstName} {lastName}".Trim();
-        } else if (!string.IsNullOrEmpty(name)) {
-            displayName = name;
-        } else if (!string.IsNullOrEmpty(Email)) {
-            displayName = Email;
-        }
-        return displayName;
-    }
 }

--- a/src/Indice.Features.Identity.Core/Data/Models/User.cs
+++ b/src/Indice.Features.Identity.Core/Data/Models/User.cs
@@ -95,4 +95,20 @@ public class User : IdentityUser
             UserId = Id
         });
     }
+
+    /// <summary>Finds a display name for the user based on <see cref="BasicClaimTypes.GivenName"/>, <see cref="BasicClaimTypes.FamilyName"/> claims and <see cref="User.Email"/>.</summary>
+    public string? FindDisplayName() {
+        var displayName = default(string);
+        var name = Claims.FirstOrDefault(x => x.ClaimType is BasicClaimTypes.Name)?.ClaimValue;
+        var firstName = Claims.FirstOrDefault(x => x.ClaimType is BasicClaimTypes.GivenName)?.ClaimValue;
+        var lastName = Claims.FirstOrDefault(x => x.ClaimType is BasicClaimTypes.FamilyName)?.ClaimValue;
+        if (!string.IsNullOrEmpty(firstName) || !string.IsNullOrEmpty(lastName)) {
+            displayName = $"{firstName} {lastName}".Trim();
+        } else if (!string.IsNullOrEmpty(name)) {
+            displayName = name;
+        } else if (!string.IsNullOrEmpty(Email)) {
+            displayName = Email;
+        }
+        return displayName;
+    }
 }

--- a/src/Indice.Features.Identity.Core/Extensions/UserExtensions.cs
+++ b/src/Indice.Features.Identity.Core/Extensions/UserExtensions.cs
@@ -6,7 +6,7 @@ namespace Indice.Features.Identity.Core.Extensions;
 /// <summary>Extension methods on <see cref="User"/> type.</summary>
 public static class UserExtensions
 {
-    /// <summary>Finds a display name for the user based on <see cref="BasicClaimTypes.GivenName"/>, <see cref="BasicClaimTypes.FamilyName"/> claims or user email.</summary>
+    /// <summary>Finds a display name for the user based on <see cref="BasicClaimTypes.Name"/>, <see cref="BasicClaimTypes.GivenName"/>, <see cref="BasicClaimTypes.FamilyName"/> claims or user email.</summary>
     /// <param name="user">The user instance.</param>
     public static string? FindDisplayName(this User user) {
         var displayName = default(string);

--- a/src/Indice.Features.Identity.Core/Extensions/UserExtensions.cs
+++ b/src/Indice.Features.Identity.Core/Extensions/UserExtensions.cs
@@ -1,0 +1,25 @@
+﻿using Indice.Features.Identity.Core.Data.Models;
+using Indice.Security;
+
+namespace Indice.Features.Identity.Core.Extensions;
+
+/// <summary>Extension methods on <see cref="User"/> type.</summary>
+public static class UserExtensions
+{
+    /// <summary>Finds a display name for the user based on <see cref="BasicClaimTypes.GivenName"/>, <see cref="BasicClaimTypes.FamilyName"/> claims or user email.</summary>
+    /// <param name="user">The user instance.</param>
+    public static string? FindDisplayName(this User user) {
+        var displayName = default(string);
+        var name = user.Claims.FirstOrDefault(x => x.ClaimType is BasicClaimTypes.Name)?.ClaimValue;
+        var firstName = user.Claims.FirstOrDefault(x => x.ClaimType is BasicClaimTypes.GivenName)?.ClaimValue;
+        var lastName = user.Claims.FirstOrDefault(x => x.ClaimType is BasicClaimTypes.FamilyName)?.ClaimValue;
+        if (!string.IsNullOrEmpty(firstName) || !string.IsNullOrEmpty(lastName)) {
+            displayName = $"{firstName} {lastName}".Trim();
+        } else if (!string.IsNullOrEmpty(name)) {
+            displayName = name;
+        } else if (!string.IsNullOrEmpty(user.Email)) {
+            displayName = user.Email;
+        }
+        return displayName;
+    }
+}

--- a/src/Indice.Features.Identity.Core/Models/ForgotPasswordEmailModel.cs
+++ b/src/Indice.Features.Identity.Core/Models/ForgotPasswordEmailModel.cs
@@ -1,0 +1,18 @@
+using Indice.Features.Identity.Core.Data.Models;
+namespace Indice.Features.Identity.Core.Models;
+
+/// <summary>
+/// Represents the data model used for constructing an email sent to a user requesting a password reset.
+/// </summary>
+public class ForgotPasswordEmailModel
+{
+    /// <summary>
+    /// Gets or sets the display name of the user to greet in the email. In case their name is not found this will default to the <see cref="User.UserName"/>
+    /// </summary>
+    public required string UserName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the password reset callback URL.
+    /// </summary>
+    public required string Url { get; set; }
+}

--- a/src/Indice.Features.Identity.Core/Models/ForgotPasswordEmailModel.cs
+++ b/src/Indice.Features.Identity.Core/Models/ForgotPasswordEmailModel.cs
@@ -1,17 +1,8 @@
+using Indice.Features.Identity.Server.Manager.Models;
+
 namespace Indice.Features.Identity.Core.Models;
 
 /// <summary>
 /// Represents the data model used for constructing an email sent to a user requesting a password reset.
 /// </summary>
-public class ForgotPasswordEmailModel
-{
-    /// <summary>
-    /// Gets or sets the display name of the user to greet in the email.
-    /// </summary>
-    public required string UserName { get; set; }
-
-    /// <summary>
-    /// Gets or sets the password reset callback URL.
-    /// </summary>
-    public required string Url { get; set; }
-}
+public class ForgotPasswordEmailModel : TokenBasedEmailModel { }

--- a/src/Indice.Features.Identity.Core/Models/ForgotPasswordEmailModel.cs
+++ b/src/Indice.Features.Identity.Core/Models/ForgotPasswordEmailModel.cs
@@ -1,4 +1,3 @@
-using Indice.Features.Identity.Core.Data.Models;
 namespace Indice.Features.Identity.Core.Models;
 
 /// <summary>
@@ -7,7 +6,7 @@ namespace Indice.Features.Identity.Core.Models;
 public class ForgotPasswordEmailModel
 {
     /// <summary>
-    /// Gets or sets the display name of the user to greet in the email. In case their name is not found this will default to the <see cref="User.UserName"/>
+    /// Gets or sets the display name of the user to greet in the email.
     /// </summary>
     public required string UserName { get; set; }
 

--- a/src/Indice.Features.Identity.Server/Manager/MyAccountHandlers.cs
+++ b/src/Indice.Features.Identity.Server/Manager/MyAccountHandlers.cs
@@ -35,6 +35,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 using Microsoft.FeatureManagement;
+using Indice.Features.Identity.Core.Extensions;
 
 namespace Indice.Features.Identity.Server.Manager;
 
@@ -348,9 +349,12 @@ internal static partial class MyAccountHandlers
         if (user == null) {
             return TypedResults.NoContent();
         }
+        if (user.Claims.Count is 0) {
+            _ = await userManager.GetClaimsAsync(user); 
+        }
         var code = await userManager.GeneratePasswordResetTokenAsync(user);
         var data = new ForgotPasswordEmailModel {
-            UserName = user.UserName ?? user.Email!,
+            UserName = user.FindDisplayName() ?? user.Email!,
             Url = linkGenerator.GetUriByPage(httpContext, "/ForgotPasswordConfirmation", values: new { email = request.Email, token = code, request.ReturnUrl })!
         };
         await emailService.SendAsync(message => {

--- a/src/Indice.Features.Identity.Server/Manager/MyAccountHandlers.cs
+++ b/src/Indice.Features.Identity.Server/Manager/MyAccountHandlers.cs
@@ -353,6 +353,7 @@ internal static partial class MyAccountHandlers
             _ = await userManager.GetClaimsAsync(user);
         }
         var code = await userManager.GeneratePasswordResetTokenAsync(user);
+        
         var data = new ForgotPasswordEmailModel {
             DisplayName = user.FindDisplayName() ?? user.Email!,
             ReturnUrl = request.ReturnUrl,
@@ -364,7 +365,7 @@ internal static partial class MyAccountHandlers
         await emailService.SendAsync(message => {
             var builder = message
                 .To(user.Email!)
-                .WithSubject(userManager.MessageDescriber.ForgotPasswordMessageSubject);
+                .WithSubject(data.Subject);
             if (!string.IsNullOrWhiteSpace(endpointOptions.Value.Email.ForgotPasswordTemplate)) {
                 builder.UsingTemplate(endpointOptions.Value.Email.ForgotPasswordTemplate)
                        .WithData(data);

--- a/src/Indice.Features.Identity.Server/Manager/MyAccountHandlers.cs
+++ b/src/Indice.Features.Identity.Server/Manager/MyAccountHandlers.cs
@@ -350,12 +350,16 @@ internal static partial class MyAccountHandlers
             return TypedResults.NoContent();
         }
         if (user.Claims.Count is 0) {
-            _ = await userManager.GetClaimsAsync(user); 
+            _ = await userManager.GetClaimsAsync(user);
         }
         var code = await userManager.GeneratePasswordResetTokenAsync(user);
         var data = new ForgotPasswordEmailModel {
-            UserName = user.FindDisplayName() ?? user.Email!,
-            Url = linkGenerator.GetUriByPage(httpContext, "/ForgotPasswordConfirmation", values: new { email = request.Email, token = code, request.ReturnUrl })!
+            DisplayName = user.FindDisplayName() ?? user.Email!,
+            ReturnUrl = request.ReturnUrl,
+            Subject = userManager.MessageDescriber.ForgotPasswordMessageSubject,
+            Token = code,
+            User = user,
+            Url = linkGenerator.GetUriByPage(httpContext, "/ForgotPasswordConfirmation", values: new { email = request.Email, token = code, request.ReturnUrl })
         };
         await emailService.SendAsync(message => {
             var builder = message
@@ -365,7 +369,7 @@ internal static partial class MyAccountHandlers
                 builder.UsingTemplate(endpointOptions.Value.Email.ForgotPasswordTemplate)
                        .WithData(data);
             } else {
-                builder.WithBody(userManager.MessageDescriber.ForgotPasswordMessageBody(user, code, data.Url));
+                builder.WithBody(userManager.MessageDescriber.ForgotPasswordMessageBody(user, data.Token, data.Url));
             }
         });
         return TypedResults.NoContent();
@@ -574,7 +578,7 @@ internal static partial class MyAccountHandlers
     }
 
     internal static async Task<Results<NoContent, NotFound>> RevokeConsents(
-        ExtendedUserManager<User> userManager, 
+        ExtendedUserManager<User> userManager,
         IPersistedGrantService grants,
         IEventService events,
         ClaimsPrincipal currentUser,
@@ -917,7 +921,7 @@ internal static partial class MyAccountHandlers
                                       }
                                       return info;
                                   }).ToList();
-            
+
             return consents;
         } catch (Exception) { }
         return [];

--- a/src/Indice.Features.Identity.Server/Manager/MyAccountHandlers.cs
+++ b/src/Indice.Features.Identity.Server/Manager/MyAccountHandlers.cs
@@ -349,13 +349,9 @@ internal static partial class MyAccountHandlers
             return TypedResults.NoContent();
         }
         var code = await userManager.GeneratePasswordResetTokenAsync(user);
-        var data = new EmailChangeEmailModel {
-            DisplayName = currentUser.FindDisplayName() ?? user.UserName,
-            ReturnUrl = request.ReturnUrl,
-            Subject = userManager.MessageDescriber.ForgotPasswordMessageSubject,
-            Token = code,
-            User = user,
-            Url = linkGenerator.GetUriByPage(httpContext, "/ForgotPasswordConfirmation", values: new { email = request.Email, token = code, request.ReturnUrl })
+        var data = new ForgotPasswordEmailModel {
+            UserName = user.UserName ?? user.Email!,
+            Url = linkGenerator.GetUriByPage(httpContext, "/ForgotPasswordConfirmation", values: new { email = request.Email, token = code, request.ReturnUrl })!
         };
         await emailService.SendAsync(message => {
             var builder = message
@@ -365,7 +361,7 @@ internal static partial class MyAccountHandlers
                 builder.UsingTemplate(endpointOptions.Value.Email.ForgotPasswordTemplate)
                        .WithData(data);
             } else {
-                builder.WithBody(userManager.MessageDescriber.ForgotPasswordMessageBody(user, data.Token, data.Url));
+                builder.WithBody(userManager.MessageDescriber.ForgotPasswordMessageBody(user, code, data.Url));
             }
         });
         return TypedResults.NoContent();

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/EmailForgotPassword.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/EmailForgotPassword.cshtml
@@ -9,6 +9,7 @@
 @{
     var Settings = SettingsWrapper.Value;
     var subject = ViewData["Subject"];
+    var userName = @Model.DisplayName ?? @Model.UserName;
 }
 
 @section preheader {
@@ -20,7 +21,7 @@
 }
 
 <p style="font-family: 'Century Gothic', Arial, sans-serif ,Helvetica, Arial, sans-serif; font-size: 12px;">
-    @Localizer.Email_Body_Hi @Model.UserName,
+    @Localizer.Email_Body_Hi @(userName ?? string.Empty),
     <br />
     <br />
     @Localizer.Email_ResetPassword_RequestInfo

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/EmailForgotPassword.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/EmailForgotPassword.cshtml
@@ -1,7 +1,6 @@
 ﻿@inject IOptions<GeneralSettings> SettingsWrapper
 @inject IOptions<IdentityUIOptions> UIOptions
 @inject IdentityUILocalizer Localizer
-@model Indice.Features.Identity.Core.Models.ForgotPasswordEmailModel
 
 @{
     Layout = "_LayoutEmail.cshtml";

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/EmailForgotPassword.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/EmailForgotPassword.cshtml
@@ -9,7 +9,6 @@
 @{
     var Settings = SettingsWrapper.Value;
     var subject = @Model.Subject;
-    var userName = @Model.DisplayName ?? @Model.UserName;
 }
 
 @section preheader {
@@ -21,7 +20,7 @@
 }
 
 <p style="font-family: 'Century Gothic', Arial, sans-serif ,Helvetica, Arial, sans-serif; font-size: 12px;">
-    @Localizer.Email_Body_Hi @(userName ?? string.Empty),
+    @Localizer.Email_Body_Hi @Model.DisplayName,
     <br />
     <br />
     @Localizer.Email_ResetPassword_RequestInfo

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/EmailForgotPassword.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/EmailForgotPassword.cshtml
@@ -10,7 +10,6 @@
 @{
     var Settings = SettingsWrapper.Value;
     var subject = ViewData["Subject"];
-    var body = ViewData["Body"];
 }
 
 @section preheader {

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/EmailForgotPassword.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/EmailForgotPassword.cshtml
@@ -1,8 +1,7 @@
 ﻿@inject IOptions<GeneralSettings> SettingsWrapper
 @inject IOptions<IdentityUIOptions> UIOptions
-@inject UserManager<User> UserManager
 @inject IdentityUILocalizer Localizer
-
+@model Indice.Features.Identity.Core.Models.ForgotPasswordEmailModel
 
 @{
     Layout = "_LayoutEmail.cshtml";
@@ -12,7 +11,6 @@
     var Settings = SettingsWrapper.Value;
     var subject = ViewData["Subject"];
     var body = ViewData["Body"];
-    var userName = Model?.UserName ?? UserManager.GetUserName(User);
 }
 
 @section preheader {
@@ -24,7 +22,7 @@
 }
 
 <p style="font-family: 'Century Gothic', Arial, sans-serif ,Helvetica, Arial, sans-serif; font-size: 12px;">
-    @Localizer.Email_Body_Hi @(userName ?? string.Empty),
+    @Localizer.Email_Body_Hi @Model.UserName,
     <br />
     <br />
     @Localizer.Email_ResetPassword_RequestInfo

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/EmailForgotPassword.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/EmailForgotPassword.cshtml
@@ -8,7 +8,7 @@
 
 @{
     var Settings = SettingsWrapper.Value;
-    var subject = ViewData["Subject"];
+    var subject = @Model.Subject;
     var userName = @Model.DisplayName ?? @Model.UserName;
 }
 

--- a/src/Indice.Features.Identity.UI/Pages/ForgotPassword.cs
+++ b/src/Indice.Features.Identity.UI/Pages/ForgotPassword.cs
@@ -2,6 +2,7 @@ using Indice.AspNetCore.Features.Recaptcha;
 using Indice.AspNetCore.Filters;
 using Indice.Features.Identity.Core;
 using Indice.Features.Identity.Core.Data.Models;
+using Indice.Features.Identity.Core.Models;
 using Indice.Features.Identity.UI.Models;
 using Indice.Security;
 using Indice.Services;
@@ -91,17 +92,23 @@ public abstract class BaseForgotPasswordModel : BasePageModel
         if (user is null) {
             return Page();
         }
+        if (user.Claims.Count is 0) {
+            _ = await UserManager.GetClaimsAsync(user); // Lazy load claims if not already loaded
+        }
         var token = await UserManager.GeneratePasswordResetTokenAsync(user);
         var callbackUrl = Url.PageLink("/ForgotPasswordConfirmation", values: new { email = user.Email, token, client_id = HttpContext.GetClientIdFromReturnUrl() });
-
+        if (string.IsNullOrWhiteSpace(callbackUrl)) {
+            Logger.LogError("Failed to generate callback URL for forgot password confirmation email for user: {userId}.", user.Id);
+            return RedirectToPage("/Error");
+        }
         var maskedToken = token.Length > 4 ? string.Concat(token.AsSpan(0, 2), new string('*', token.Length - 4), token.AsSpan(token.Length - 2)) : token;
         Logger.LogDebug("{PageTitle}: Confirmation token is {Token}", "Forgot password", maskedToken);
         await EmailService.SendAsync(builder =>
             builder.To(user.Email!)
                    .WithSubject(UserManager.MessageDescriber.ForgotPasswordMessageSubject)
                    .UsingTemplate("EmailForgotPassword")
-                   .WithData(new {
-                       UserName = User.FindDisplayName() ?? user.UserName,
+                   .WithData(new ForgotPasswordEmailModel {
+                       UserName = user.FindDisplayName() ?? user.UserName!,
                        Url = callbackUrl
                    })
         );

--- a/src/Indice.Features.Identity.UI/Pages/ForgotPassword.cs
+++ b/src/Indice.Features.Identity.UI/Pages/ForgotPassword.cs
@@ -104,13 +104,16 @@ public abstract class BaseForgotPasswordModel : BasePageModel
         }
         var maskedToken = token.Length > 4 ? string.Concat(token.AsSpan(0, 2), new string('*', token.Length - 4), token.AsSpan(token.Length - 2)) : token;
         Logger.LogDebug("{PageTitle}: Confirmation token is {Token}", "Forgot password", maskedToken);
+        var subject = UserManager.MessageDescriber.ForgotPasswordMessageSubject;
         await EmailService.SendAsync(builder =>
             builder.To(user.Email!)
-                   .WithSubject(UserManager.MessageDescriber.ForgotPasswordMessageSubject)
+                   .WithSubject(subject)
                    .UsingTemplate("EmailForgotPassword")
                    .WithData(new ForgotPasswordEmailModel {
                        DisplayName = user.FindDisplayName() ?? user.UserName,
                        User = user,
+                       Token = token,
+                       Subject = subject,
                        Url = callbackUrl
                    })
         );

--- a/src/Indice.Features.Identity.UI/Pages/ForgotPassword.cs
+++ b/src/Indice.Features.Identity.UI/Pages/ForgotPassword.cs
@@ -2,6 +2,7 @@ using Indice.AspNetCore.Features.Recaptcha;
 using Indice.AspNetCore.Filters;
 using Indice.Features.Identity.Core;
 using Indice.Features.Identity.Core.Data.Models;
+using Indice.Features.Identity.Core.Extensions;
 using Indice.Features.Identity.Core.Models;
 using Indice.Features.Identity.UI.Models;
 using Indice.Security;
@@ -99,7 +100,7 @@ public abstract class BaseForgotPasswordModel : BasePageModel
         var callbackUrl = Url.PageLink("/ForgotPasswordConfirmation", values: new { email = user.Email, token, client_id = HttpContext.GetClientIdFromReturnUrl() });
         if (string.IsNullOrWhiteSpace(callbackUrl)) {
             Logger.LogError("Failed to generate callback URL for forgot password confirmation email for user: {userId}.", user.Id);
-            return RedirectToPage("/Error");
+            return Page();
         }
         var maskedToken = token.Length > 4 ? string.Concat(token.AsSpan(0, 2), new string('*', token.Length - 4), token.AsSpan(token.Length - 2)) : token;
         Logger.LogDebug("{PageTitle}: Confirmation token is {Token}", "Forgot password", maskedToken);

--- a/src/Indice.Features.Identity.UI/Pages/ForgotPassword.cs
+++ b/src/Indice.Features.Identity.UI/Pages/ForgotPassword.cs
@@ -109,7 +109,8 @@ public abstract class BaseForgotPasswordModel : BasePageModel
                    .WithSubject(UserManager.MessageDescriber.ForgotPasswordMessageSubject)
                    .UsingTemplate("EmailForgotPassword")
                    .WithData(new ForgotPasswordEmailModel {
-                       UserName = user.FindDisplayName() ?? user.UserName!,
+                       DisplayName = user.FindDisplayName() ?? user.UserName,
+                       User = user,
                        Url = callbackUrl
                    })
         );

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/EmailForgotPassword.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/EmailForgotPassword.cshtml
@@ -1,7 +1,6 @@
 ﻿@inject IOptions<GeneralSettings> SettingsWrapper
 @inject IOptions<IdentityUIOptions> UIOptions
 @inject IdentityUILocalizer Localizer
-@model Indice.Features.Identity.Core.Models.ForgotPasswordEmailModel
 
 @{
     Layout = "_LayoutEmail.cshtml";

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/EmailForgotPassword.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/EmailForgotPassword.cshtml
@@ -8,7 +8,7 @@
 
 @{
     var Settings = SettingsWrapper.Value;
-    var subject = ViewData["Subject"];
+    var subject = @Model.Subject;
     var userName = @Model.DisplayName ?? @Model.UserName;
 }
 
@@ -21,7 +21,7 @@
 }
 
 <p style="font-family: 'Century Gothic', Arial, sans-serif ,Helvetica, Arial, sans-serif; font-size: 12px;">
-    @Localizer.Email_Body_Hi @(userName ?? string.Empty),,
+    @Localizer.Email_Body_Hi @(userName ?? string.Empty),
     <br /><br />
     <br /><br />
     @Localizer.Email_ResetPassword_RequestInfo

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/EmailForgotPassword.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/EmailForgotPassword.cshtml
@@ -10,7 +10,6 @@
 @{
     var Settings = SettingsWrapper.Value;
     var subject = ViewData["Subject"];
-    var body = ViewData["Body"];
 }
 
 @section preheader {

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/EmailForgotPassword.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/EmailForgotPassword.cshtml
@@ -9,11 +9,10 @@
 @{
     var Settings = SettingsWrapper.Value;
     var subject = @Model.Subject;
-    var userName = @Model.DisplayName ?? @Model.UserName;
 }
 
 @section preheader {
-	@Localizer.Email_Reset_Password
+    @Localizer.Email_Reset_Password
 }
 
 @section subject {
@@ -21,7 +20,7 @@
 }
 
 <p style="font-family: 'Century Gothic', Arial, sans-serif ,Helvetica, Arial, sans-serif; font-size: 12px;">
-    @Localizer.Email_Body_Hi @(userName ?? string.Empty),
+    @Localizer.Email_Body_Hi @Model.DisplayName,
     <br /><br />
     <br /><br />
     @Localizer.Email_ResetPassword_RequestInfo

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/EmailForgotPassword.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/EmailForgotPassword.cshtml
@@ -1,7 +1,7 @@
 ﻿@inject IOptions<GeneralSettings> SettingsWrapper
-@inject UserManager<User> UserManager
 @inject IOptions<IdentityUIOptions> UIOptions
 @inject IdentityUILocalizer Localizer
+@model Indice.Features.Identity.Core.Models.ForgotPasswordEmailModel
 
 @{
     Layout = "_LayoutEmail.cshtml";
@@ -9,9 +9,8 @@
 
 @{
     var Settings = SettingsWrapper.Value;
-var subject = ViewData["Subject"];
-var body = ViewData["Body"];
-var userName = Model?.UserName ?? UserManager.GetUserName(User);
+    var subject = ViewData["Subject"];
+    var body = ViewData["Body"];
 }
 
 @section preheader {
@@ -23,7 +22,7 @@ var userName = Model?.UserName ?? UserManager.GetUserName(User);
 }
 
 <p style="font-family: 'Century Gothic', Arial, sans-serif ,Helvetica, Arial, sans-serif; font-size: 12px;">
-    @Localizer.Email_Body_Hi @(userName ?? string.Empty),
+    @Localizer.Email_Body_Hi @Model.UserName,
     <br /><br />
     <br /><br />
     @Localizer.Email_ResetPassword_RequestInfo

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/EmailForgotPassword.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/EmailForgotPassword.cshtml
@@ -9,6 +9,7 @@
 @{
     var Settings = SettingsWrapper.Value;
     var subject = ViewData["Subject"];
+    var userName = @Model.DisplayName ?? @Model.UserName;
 }
 
 @section preheader {
@@ -20,7 +21,7 @@
 }
 
 <p style="font-family: 'Century Gothic', Arial, sans-serif ,Helvetica, Arial, sans-serif; font-size: 12px;">
-    @Localizer.Email_Body_Hi @Model.UserName,
+    @Localizer.Email_Body_Hi @(userName ?? string.Empty),,
     <br /><br />
     <br /><br />
     @Localizer.Email_ResetPassword_RequestInfo


### PR DESCRIPTION
[identity] Fix forgot password so it now uses the user's actual name and add ForgotPasswordEmailModel for strong typing #970. Also handle gracefully null or whitespace callback url.