### PR TITLE
[angular] Bump ng-components version to 0.5.1 with debounce support for ListComponent 

### DIFF
--- a/src/Indice.Features.Cases.App/package.json
+++ b/src/Indice.Features.Cases.App/package.json
@@ -22,7 +22,7 @@
     "@angular/platform-browser-dynamic": "20.3.18",
     "@angular/router": "20.3.18",
     "@indice/ng-auth": "0.5.1",
-    "@indice/ng-components": "0.5.0",
+    "@indice/ng-components": "0.5.1",
     "@ngx-translate/core": "^15.0.0",
     "@ngx-translate/http-loader": "^8.0.0",
     "chart.js": "4.5.1",

--- a/src/Indice.Features.Messages.App/package.json
+++ b/src/Indice.Features.Messages.App/package.json
@@ -26,7 +26,7 @@
     "@angular/cdk": "20.2.14",
     "@codemirror/language-data": "^6.5.1",
     "@indice/ng-auth": "0.5.1",
-    "@indice/ng-components": "0.5.0",
+    "@indice/ng-components": "0.5.1",
     "@types/chart.js": "^2.9.41",
     "chart.js": "^4.4.1",
     "@ngx-translate/core": "^17.0.0",

--- a/src/Indice.Features.Risk.App/package.json
+++ b/src/Indice.Features.Risk.App/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser-dynamic": "20.3.18",
     "@angular/router": "20.3.18",
     "@indice/ng-auth": "0.5.1",
-    "@indice/ng-components": "0.5.0",
+    "@indice/ng-components": "0.5.1",
     "f": "^1.4.0",
     "file-saver": "^2.0.5",
     "lodash": "^4.17.21",


### PR DESCRIPTION
Bump ng-components version which adds search debounce and minimum search characters functionality for BaseListComponent. Both properties (searchDebounceTime, minimumSearchCharacters) can be customized by the integrator.