### PR TITLE
[services] Optimize EventDispatcherAzure with Queue client caching

### DIFF
--- a/src/Indice.Services/EventDispatcherAzure.cs
+++ b/src/Indice.Services/EventDispatcherAzure.cs
@@ -65,7 +65,13 @@ public class EventDispatcherAzure : IEventDispatcher
         if (prependEnvironmentInQueueName) {
             queueName = $"{_environmentName}-{queueName}";
         }
-        var queue = await EnsureExistsAsync(queueName);
+        QueueClient queue;
+        try {
+            queue = await EnsureExistsAsync(queueName);
+        } catch (Exception ex) {
+            _logger?.LogError(ex, "Failed to get or create queue '{QueueName}' for event type '{EventType}'.", queueName, typeof(TEvent).Name);
+            throw;
+        }
         var user = actingPrincipal ?? _claimsPrincipalSelector?.Invoke();
         var payloadBytes = Array.Empty<byte>();
         // Special cases string, byte[] or stream.
@@ -102,7 +108,7 @@ public class EventDispatcherAzure : IEventDispatcher
     private async Task<QueueClient> EnsureExistsAsync(string queueName) {
         return await _queueClientCache.GetOrCreateAsync(queueName, _connectionString, _queueMessageEncoding);
     }
-    
+
 }
 
 /// <summary>Options for configuring <see cref="EventDispatcherAzure"/>.</summary>

--- a/src/Indice.Services/EventDispatcherAzure.cs
+++ b/src/Indice.Services/EventDispatcherAzure.cs
@@ -1,4 +1,5 @@
-﻿using System.IO.Compression;
+﻿using System.Collections.Concurrent;
+using System.IO.Compression;
 using System.Security.Claims;
 using System.Text;
 using System.Text.Json;
@@ -26,6 +27,7 @@ public class EventDispatcherAzure : IEventDispatcher
     private readonly Func<string?> _tenantIdSelector;
     private readonly JsonSerializerOptions _jsonSerializerOptions;
     private readonly ILogger<EventDispatcherAzure>? _logger;
+    private readonly ConcurrentDictionary<string, QueueClient> _queueClients;
 
     /// <summary>Create a new <see cref="EventDispatcherAzure"/> instance.</summary>
     /// <param name="connectionString">The connection string to the Azure Storage account. By default it searches for <see cref="CONNECTION_STRING_NAME"/> application setting inside ConnectionStrings section.</param>
@@ -46,6 +48,7 @@ public class EventDispatcherAzure : IEventDispatcher
         _tenantIdSelector = tenantIdSelector ?? new Func<string?>(() => null);
         _jsonSerializerOptions = JsonSerializerOptionDefaults.GetDefaultSettings();
         _logger = logger;
+        _queueClients = new ConcurrentDictionary<string, QueueClient>();
     }
 
     /// <inheritdoc/>
@@ -97,10 +100,14 @@ public class EventDispatcherAzure : IEventDispatcher
     }
 
     private async Task<QueueClient> EnsureExistsAsync(string queueName) {
+        if (_queueClients.TryGetValue(queueName, out var existingClient)) {
+            return existingClient;
+        }
         var queueClient = new QueueClient(_connectionString, queueName, new QueueClientOptions {
             MessageEncoding = _queueMessageEncoding
         });
         await queueClient.CreateIfNotExistsAsync();
+        _queueClients.TryAdd(queueName, queueClient);
         return queueClient;
     }
 }

--- a/src/Indice.Services/EventDispatcherAzure.cs
+++ b/src/Indice.Services/EventDispatcherAzure.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Concurrent;
-using System.IO.Compression;
+﻿using System.IO.Compression;
 using System.Security.Claims;
 using System.Text;
 using System.Text.Json;
@@ -27,7 +26,7 @@ public class EventDispatcherAzure : IEventDispatcher
     private readonly Func<string?> _tenantIdSelector;
     private readonly JsonSerializerOptions _jsonSerializerOptions;
     private readonly ILogger<EventDispatcherAzure>? _logger;
-    private readonly ConcurrentDictionary<string, Lazy<Task<QueueClient>>> _queueClients;
+    private readonly IQueueClientCache _queueClientCache;  // instead of ConcurrentDictionary
 
     /// <summary>Create a new <see cref="EventDispatcherAzure"/> instance.</summary>
     /// <param name="connectionString">The connection string to the Azure Storage account. By default it searches for <see cref="CONNECTION_STRING_NAME"/> application setting inside ConnectionStrings section.</param>
@@ -37,8 +36,9 @@ public class EventDispatcherAzure : IEventDispatcher
     /// <param name="queueMessageEncoding">Determines how <see cref="Azure.Storage.Queues.Models.QueueMessage.Body"/> is represented in HTTP requests and responses.</param>
     /// <param name="claimsPrincipalSelector">Provides a way to access the current <see cref="ClaimsPrincipal"/> inside a service.</param>
     /// <param name="tenantIdSelector">Provides a way to access the current tenant id if any.</param>
-    /// <param name="logger">Logger instance for logging warnings and errors.</param>
-    public EventDispatcherAzure(string connectionString, string environmentName, bool enabled, bool useCompression, QueueMessageEncoding queueMessageEncoding, Func<ClaimsPrincipal?>? claimsPrincipalSelector, Func<string>? tenantIdSelector, ILogger<EventDispatcherAzure>? logger = null) {
+    /// <param name="queueClientCache">Cache for QueueClient instances to avoid repeated instantiation.</param> 
+    /// <param name="logger">Logger instance for logging warnings and errors.</param>   
+    public EventDispatcherAzure(string connectionString, string environmentName, bool enabled, bool useCompression, QueueMessageEncoding queueMessageEncoding, Func<ClaimsPrincipal?>? claimsPrincipalSelector, Func<string>? tenantIdSelector, IQueueClientCache queueClientCache, ILogger<EventDispatcherAzure>? logger = null) {
         _connectionString = connectionString ?? throw new ArgumentNullException(nameof(connectionString));
         _environmentName = Regex.Replace(environmentName ?? "Development", @"\s+", "-").ToLowerInvariant();
         _enabled = enabled;
@@ -47,8 +47,8 @@ public class EventDispatcherAzure : IEventDispatcher
         _claimsPrincipalSelector = claimsPrincipalSelector ?? throw new ArgumentNullException(nameof(claimsPrincipalSelector));
         _tenantIdSelector = tenantIdSelector ?? new Func<string?>(() => null);
         _jsonSerializerOptions = JsonSerializerOptionDefaults.GetDefaultSettings();
+        _queueClientCache = queueClientCache ?? throw new ArgumentNullException(nameof(queueClientCache));
         _logger = logger;
-        _queueClients = new ConcurrentDictionary<string, Lazy<Task<QueueClient>>>();
     }
 
     /// <inheritdoc/>
@@ -100,16 +100,9 @@ public class EventDispatcherAzure : IEventDispatcher
     }
 
     private async Task<QueueClient> EnsureExistsAsync(string queueName) {
-        var lazyClient = _queueClients.GetOrAdd(queueName, key => new Lazy<Task<QueueClient>>(async () => {
-            var queueClient = new QueueClient(_connectionString, key, new QueueClientOptions {
-                MessageEncoding = _queueMessageEncoding
-            });
-            await queueClient.CreateIfNotExistsAsync();
-            return queueClient;
-        }));
-
-        return await lazyClient.Value;
+        return await _queueClientCache.GetOrCreateAsync(queueName, _connectionString, _queueMessageEncoding);
     }
+    
 }
 
 /// <summary>Options for configuring <see cref="EventDispatcherAzure"/>.</summary>

--- a/src/Indice.Services/EventDispatcherAzure.cs
+++ b/src/Indice.Services/EventDispatcherAzure.cs
@@ -27,7 +27,7 @@ public class EventDispatcherAzure : IEventDispatcher
     private readonly Func<string?> _tenantIdSelector;
     private readonly JsonSerializerOptions _jsonSerializerOptions;
     private readonly ILogger<EventDispatcherAzure>? _logger;
-    private readonly ConcurrentDictionary<string, QueueClient> _queueClients;
+    private readonly ConcurrentDictionary<string, Lazy<Task<QueueClient>>> _queueClients;
 
     /// <summary>Create a new <see cref="EventDispatcherAzure"/> instance.</summary>
     /// <param name="connectionString">The connection string to the Azure Storage account. By default it searches for <see cref="CONNECTION_STRING_NAME"/> application setting inside ConnectionStrings section.</param>
@@ -48,7 +48,7 @@ public class EventDispatcherAzure : IEventDispatcher
         _tenantIdSelector = tenantIdSelector ?? new Func<string?>(() => null);
         _jsonSerializerOptions = JsonSerializerOptionDefaults.GetDefaultSettings();
         _logger = logger;
-        _queueClients = new ConcurrentDictionary<string, QueueClient>();
+        _queueClients = new ConcurrentDictionary<string, Lazy<Task<QueueClient>>>();
     }
 
     /// <inheritdoc/>
@@ -100,15 +100,15 @@ public class EventDispatcherAzure : IEventDispatcher
     }
 
     private async Task<QueueClient> EnsureExistsAsync(string queueName) {
-        if (_queueClients.TryGetValue(queueName, out var existingClient)) {
-            return existingClient;
-        }
-        var queueClient = new QueueClient(_connectionString, queueName, new QueueClientOptions {
-            MessageEncoding = _queueMessageEncoding
-        });
-        await queueClient.CreateIfNotExistsAsync();
-        _queueClients.TryAdd(queueName, queueClient);
-        return queueClient;
+        var lazyClient = _queueClients.GetOrAdd(queueName, key => new Lazy<Task<QueueClient>>(async () => {
+            var queueClient = new QueueClient(_connectionString, key, new QueueClientOptions {
+                MessageEncoding = _queueMessageEncoding
+            });
+            await queueClient.CreateIfNotExistsAsync();
+            return queueClient;
+        }));
+
+        return await lazyClient.Value;
     }
 }
 

--- a/src/Indice.Services/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Indice.Services/Extensions/IServiceCollectionExtensions.cs
@@ -382,7 +382,7 @@ public static class IndiceServicesServiceCollectionExtensions
     /// <param name="configure">Configure the available options. Null to use defaults.</param>
     public static IServiceCollection AddEventDispatcherAzure(this IServiceCollection services, Action<IServiceProvider, EventDispatcherAzureOptions>? configure = null) {
         services.TryAddTransient<IEventDispatcherFactory, DefaultEventDispatcherFactory>();
-        return services.AddTransient<IEventDispatcher, EventDispatcherAzure>(serviceProvider => GetEventDispatcherAzure(serviceProvider, configure));
+        return services.AddSingleton<IEventDispatcher, EventDispatcherAzure>(serviceProvider => GetEventDispatcherAzure(serviceProvider, configure));
     }
 
     /// <summary>Adds <see cref="IEventDispatcher"/> using Azure Storage as a queuing mechanism.</summary>
@@ -391,7 +391,7 @@ public static class IndiceServicesServiceCollectionExtensions
     /// <param name="configure">Configure the available options. Null to use defaults.</param>
     public static IServiceCollection AddEventDispatcherAzure(this IServiceCollection services, string name, Action<IServiceProvider, EventDispatcherAzureOptions>? configure = null) {
         services.TryAddTransient<IEventDispatcherFactory, DefaultEventDispatcherFactory>();
-        return services.AddKeyedTransient<IEventDispatcher, EventDispatcherAzure>(serviceKey: name, implementationFactory: (serviceProvider, serviceKey) => GetEventDispatcherAzure(serviceProvider, configure));
+        return services.AddKeyedSingleton<IEventDispatcher, EventDispatcherAzure>(serviceKey: name, implementationFactory: (serviceProvider, serviceKey) => GetEventDispatcherAzure(serviceProvider, configure));
     }
 
     /// <summary>The factory that creates the default instance and configuration for <see cref="EventDispatcherAzure"/>.</summary>

--- a/src/Indice.Services/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Indice.Services/Extensions/IServiceCollectionExtensions.cs
@@ -373,6 +373,7 @@ public static class IndiceServicesServiceCollectionExtensions
             options.QueueMessageEncoding,
             options.ClaimsPrincipalSelector,
             options.TenantIdSelector!,
+            serviceProvider.GetRequiredService<IQueueClientCache>(),
             serviceProvider.GetService<ILogger<EventDispatcherAzure>>() ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<EventDispatcherAzure>.Instance
         );
     };
@@ -381,8 +382,9 @@ public static class IndiceServicesServiceCollectionExtensions
     /// <param name="services">Specifies the contract for a collection of service descriptors.</param>
     /// <param name="configure">Configure the available options. Null to use defaults.</param>
     public static IServiceCollection AddEventDispatcherAzure(this IServiceCollection services, Action<IServiceProvider, EventDispatcherAzureOptions>? configure = null) {
+        services.TryAddSingleton<IQueueClientCache, QueueClientCache>();
         services.TryAddTransient<IEventDispatcherFactory, DefaultEventDispatcherFactory>();
-        return services.AddSingleton<IEventDispatcher, EventDispatcherAzure>(serviceProvider => GetEventDispatcherAzure(serviceProvider, configure));
+        return services.AddTransient<IEventDispatcher, EventDispatcherAzure>(serviceProvider => GetEventDispatcherAzure(serviceProvider, configure));
     }
 
     /// <summary>Adds <see cref="IEventDispatcher"/> using Azure Storage as a queuing mechanism.</summary>
@@ -390,8 +392,9 @@ public static class IndiceServicesServiceCollectionExtensions
     /// <param name="name">The key under which the specified implementation is registered.</param>
     /// <param name="configure">Configure the available options. Null to use defaults.</param>
     public static IServiceCollection AddEventDispatcherAzure(this IServiceCollection services, string name, Action<IServiceProvider, EventDispatcherAzureOptions>? configure = null) {
+        services.TryAddSingleton<IQueueClientCache, QueueClientCache>();
         services.TryAddTransient<IEventDispatcherFactory, DefaultEventDispatcherFactory>();
-        return services.AddKeyedSingleton<IEventDispatcher, EventDispatcherAzure>(serviceKey: name, implementationFactory: (serviceProvider, serviceKey) => GetEventDispatcherAzure(serviceProvider, configure));
+        return services.AddKeyedTransient<IEventDispatcher, EventDispatcherAzure>(serviceKey: name, implementationFactory: (serviceProvider, serviceKey) => GetEventDispatcherAzure(serviceProvider, configure));
     }
 
     /// <summary>The factory that creates the default instance and configuration for <see cref="EventDispatcherAzure"/>.</summary>

--- a/src/Indice.Services/QueueClientCache.cs
+++ b/src/Indice.Services/QueueClientCache.cs
@@ -31,6 +31,13 @@ public sealed class QueueClientCache : IQueueClientCache
             return queueClient;
         }));
 
-        return await lazyClient.Value;
+        try {
+            return await lazyClient.Value;
+        }
+        catch {
+            // Remove the faulted task from cache so the next call can retry
+            _queueClients.TryRemove(cacheKey, out _);
+            throw;
+        }
     }
 }

--- a/src/Indice.Services/QueueClientCache.cs
+++ b/src/Indice.Services/QueueClientCache.cs
@@ -1,0 +1,36 @@
+using System.Collections.Concurrent;
+using Azure.Storage.Queues;
+
+namespace Indice.Services;
+
+/// <summary>Thread-safe cache for Azure Storage Queue clients to avoid repeated instantiation and CreateIfNotExists calls.</summary>
+public interface IQueueClientCache
+{
+    /// <summary>Gets or creates a QueueClient for the specified queue name and connection string.</summary>
+    /// <param name="queueName">The name of the queue.</param>
+    /// <param name="connectionString">The Azure Storage connection string.</param>
+    /// <param name="messageEncoding">The message encoding to use.</param>
+    /// <returns>A cached or newly created QueueClient.</returns>
+    Task<QueueClient> GetOrCreateAsync(string queueName, string connectionString, QueueMessageEncoding messageEncoding);
+}
+
+/// <inheritdoc/>
+public sealed class QueueClientCache : IQueueClientCache
+{
+    private readonly ConcurrentDictionary<string, Lazy<Task<QueueClient>>> _queueClients = new();
+
+    /// <inheritdoc/>
+    public async Task<QueueClient> GetOrCreateAsync(string queueName, string connectionString, QueueMessageEncoding messageEncoding) {
+        var cacheKey = $"{connectionString}::{queueName}::{messageEncoding}";
+
+        var lazyClient = _queueClients.GetOrAdd(cacheKey, key => new Lazy<Task<QueueClient>>(async () => {
+            var queueClient = new QueueClient(connectionString, queueName, new QueueClientOptions {
+                MessageEncoding = messageEncoding
+            });
+            await queueClient.CreateIfNotExistsAsync();
+            return queueClient;
+        }));
+
+        return await lazyClient.Value;
+    }
+}

--- a/src/Indice.Services/QueueClientCache.cs
+++ b/src/Indice.Services/QueueClientCache.cs
@@ -17,11 +17,13 @@ public interface IQueueClientCache
 /// <inheritdoc/>
 public sealed class QueueClientCache : IQueueClientCache
 {
-    private readonly ConcurrentDictionary<string, Lazy<Task<QueueClient>>> _queueClients = new();
+    private readonly record struct QueueClientCacheKey(string ConnectionString, string QueueName, QueueMessageEncoding MessageEncoding);
+
+    private readonly ConcurrentDictionary<QueueClientCacheKey, Lazy<Task<QueueClient>>> _queueClients = new();
 
     /// <inheritdoc/>
     public async Task<QueueClient> GetOrCreateAsync(string queueName, string connectionString, QueueMessageEncoding messageEncoding) {
-        var cacheKey = $"{connectionString}::{queueName}::{messageEncoding}";
+        var cacheKey = new QueueClientCacheKey(connectionString, queueName, messageEncoding);
 
         var lazyClient = _queueClients.GetOrAdd(cacheKey, key => new Lazy<Task<QueueClient>>(async () => {
             var queueClient = new QueueClient(connectionString, queueName, new QueueClientOptions {

--- a/test/Indice.Services.Tests/EventDispatcherAzureTests.cs
+++ b/test/Indice.Services.Tests/EventDispatcherAzureTests.cs
@@ -2,6 +2,7 @@
 using System.Security.Claims;
 using System.Text.Json;
 using Azure.Storage.Queues;
+using Moq;
 using Xunit;
 
 namespace Indice.Services.Tests;
@@ -11,7 +12,16 @@ public class EventDispatcherAzureTests
     private const string CONNECTION_STRING = "UseDevelopmentStorage=true;";
 
     public EventDispatcherAzureTests() {
-        EventDispatcher = new EventDispatcherAzure(CONNECTION_STRING, "Development", enabled: true, useCompression: true, QueueMessageEncoding.Base64, () => ClaimsPrincipal.Current!, null);
+        var mockCache = new Mock<IQueueClientCache>();
+        mockCache.Setup(x => x.GetOrCreateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<QueueMessageEncoding>()))
+                 .ReturnsAsync((string queueName, string connectionString, QueueMessageEncoding encoding) => {
+                     var queueClient = new QueueClient(connectionString, queueName, new QueueClientOptions {
+                         MessageEncoding = encoding
+                     });
+                     queueClient.CreateIfNotExists();
+                     return queueClient;
+                 });
+        EventDispatcher = new EventDispatcherAzure(CONNECTION_STRING, "Development", enabled: true, useCompression: true, QueueMessageEncoding.Base64, () => ClaimsPrincipal.Current!, null, mockCache.Object);
     }
 
     public EventDispatcherAzure EventDispatcher { get; set; }


### PR DESCRIPTION
This PR introduces thread-safe caching for Azure Queue Storage clients to eliminate redundant instantiation and CreateIfNotExistsAsync calls, significantly improving performance in high-throughput event dispatching scenarios. 

Key Changes:
• New IQueueClientCache singleton service with ConcurrentDictionary<string, Lazy<Task<QueueClient>>> for thread-safe caching
• Performance boost: Eliminates redundant QueueClient instantiation and Azure Storage API calls