### PR TITLE
[aspnetcore] Make crypto algorithms configurable for DataProtection

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,21 +5,21 @@
     <!--<TargetFramework></TargetFramework>-->
 
     <VersionPrefixMajor>8</VersionPrefixMajor>
-    <VersionPrefixBase>$(VersionPrefixMajor).42</VersionPrefixBase>
+    <VersionPrefixBase>$(VersionPrefixMajor).43</VersionPrefixBase>
 
-    <VersionPrefixCore>$(VersionPrefixBase).1</VersionPrefixCore>
-    <VersionPrefixIdentity>$(VersionPrefixBase).1</VersionPrefixIdentity>
-    <VersionPrefixIdentityUI>$(VersionPrefixBase).1</VersionPrefixIdentityUI>
-    <VersionPrefixCases>$(VersionPrefixBase).1</VersionPrefixCases>
-    <VersionPrefixMessages>$(VersionPrefixBase).1</VersionPrefixMessages>
-    <VersionPrefixMultitenancy>$(VersionPrefixBase).1</VersionPrefixMultitenancy>
-    <VersionPrefixRisk>$(VersionPrefixBase).1</VersionPrefixRisk>
-    <VersionPrefixMedia>$(VersionPrefixBase).1</VersionPrefixMedia>
-    <VersionPrefixGeoIP>$(VersionPrefixBase).1</VersionPrefixGeoIP>
-    <VersionPrefixGovGr>$(VersionPrefixBase).1</VersionPrefixGovGr>
-    <VersionPrefixAspNet>$(VersionPrefixBase).1</VersionPrefixAspNet>
-    <VersionPrefixActivityLogs>$(VersionPrefixBase).1</VersionPrefixActivityLogs>
-    <VersionPrefix>$(VersionPrefixBase).1</VersionPrefix>
+    <VersionPrefixCore>$(VersionPrefixBase).0</VersionPrefixCore>
+    <VersionPrefixIdentity>$(VersionPrefixBase).0</VersionPrefixIdentity>
+    <VersionPrefixIdentityUI>$(VersionPrefixBase).0</VersionPrefixIdentityUI>
+    <VersionPrefixCases>$(VersionPrefixBase).0</VersionPrefixCases>
+    <VersionPrefixMessages>$(VersionPrefixBase).0</VersionPrefixMessages>
+    <VersionPrefixMultitenancy>$(VersionPrefixBase).0</VersionPrefixMultitenancy>
+    <VersionPrefixRisk>$(VersionPrefixBase).0</VersionPrefixRisk>
+    <VersionPrefixMedia>$(VersionPrefixBase).0</VersionPrefixMedia>
+    <VersionPrefixGeoIP>$(VersionPrefixBase).0</VersionPrefixGeoIP>
+    <VersionPrefixGovGr>$(VersionPrefixBase).0</VersionPrefixGovGr>
+    <VersionPrefixAspNet>$(VersionPrefixBase).0</VersionPrefixAspNet>
+    <VersionPrefixActivityLogs>$(VersionPrefixBase).0</VersionPrefixActivityLogs>
+    <VersionPrefix>$(VersionPrefixBase).0</VersionPrefix>
 
     <!--<VersionSuffix>rc02</VersionSuffix>-->
     <Authors>Constantinos Leftheris</Authors>

--- a/src/Indice.AspNetCore/Configuration/AzureDataProtectionOptions.cs
+++ b/src/Indice.AspNetCore/Configuration/AzureDataProtectionOptions.cs
@@ -25,5 +25,8 @@ public class AzureDataProtectionOptions
     /// Configures the data protection system to use the specified cryptographic algorithms by default when generating protected payloads. By default, <see cref="EncryptionAlgorithm.AES_256_GCM"/>
     /// is used for encryption and <see cref="ValidationAlgorithm.HMACSHA512"/> for validation.
     /// </summary>
-    public AuthenticatedEncryptorConfiguration CryptographicAlgorithms { get; set; } = null!;
+    public AuthenticatedEncryptorConfiguration CryptographicAlgorithms { get; set; } = new AuthenticatedEncryptorConfiguration {
+        EncryptionAlgorithm = EncryptionAlgorithm.AES_256_GCM,
+        ValidationAlgorithm = ValidationAlgorithm.HMACSHA512
+    };
 }

--- a/src/Indice.AspNetCore/Configuration/AzureDataProtectionOptions.cs
+++ b/src/Indice.AspNetCore/Configuration/AzureDataProtectionOptions.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption;
+using Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Indice.Configuration;
 
@@ -19,4 +21,9 @@ public class AzureDataProtectionOptions
     public string ApplicationName { get; set; } = null!;
     /// <summary>Controls the lifetime (in days) of the private key. Defaults to 90 days. It gets rolled automatically, except if option <see cref="DisableAutomaticKeyGeneration"/> is set to true.</summary>
     public int KeyLifetime { get; set; }
+    /// <summary>
+    /// Configures the data protection system to use the specified cryptographic algorithms by default when generating protected payloads. By default, <see cref="EncryptionAlgorithm.AES_256_GCM"/>
+    /// is used for encryption and <see cref="ValidationAlgorithm.HMACSHA512"/> for validation.
+    /// </summary>
+    public AuthenticatedEncryptorConfiguration CryptographicAlgorithms { get; set; } = null!;
 }

--- a/src/Indice.AspNetCore/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Indice.AspNetCore/Extensions/IServiceCollectionExtensions.cs
@@ -111,8 +111,8 @@ public static class ServiceCollectionExtensions
         container.CreateIfNotExists();
         // Enables data protection services to the specified IServiceCollection.
         var dataProtectionBuilder = services.AddDataProtection()
-                                            // Configures the data protection system to use the specified cryptographic algorithms by default when generating protected payloads.
-                                            // The algorithms selected below are the default and they are added just for completeness.
+                                            // Configures the data protection system to use the cryptographic algorithms from options.CryptographicAlgorithms
+                                            // when generating protected payloads. Default values are initialized above and may be overridden by configure.
                                             .UseCryptographicAlgorithms(options.CryptographicAlgorithms)
                                             .PersistKeysToAzureBlobStorage(options.StorageConnectionString, options.ContainerName, "keys.xml")
                                             // Configure the system to use a key lifetime. Default is 90 days.

--- a/src/Indice.AspNetCore/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Indice.AspNetCore/Extensions/IServiceCollectionExtensions.cs
@@ -96,6 +96,10 @@ public static class ServiceCollectionExtensions
             ContainerName = environmentName,
             ApplicationName = hostingEnvironment.ApplicationName,
             KeyLifetime = defaultKeyLifetime,
+            CryptographicAlgorithms = new AuthenticatedEncryptorConfiguration {
+                EncryptionAlgorithm = EncryptionAlgorithm.AES_256_GCM,
+                ValidationAlgorithm = ValidationAlgorithm.HMACSHA512
+            },
             Services = services
         };
         configure?.Invoke(options);
@@ -109,10 +113,7 @@ public static class ServiceCollectionExtensions
         var dataProtectionBuilder = services.AddDataProtection()
                                             // Configures the data protection system to use the specified cryptographic algorithms by default when generating protected payloads.
                                             // The algorithms selected below are the default and they are added just for completeness.
-                                            .UseCryptographicAlgorithms(new AuthenticatedEncryptorConfiguration {
-                                                EncryptionAlgorithm = EncryptionAlgorithm.AES_256_GCM,
-                                                ValidationAlgorithm = ValidationAlgorithm.HMACSHA512
-                                            })
+                                            .UseCryptographicAlgorithms(options.CryptographicAlgorithms)
                                             .PersistKeysToAzureBlobStorage(options.StorageConnectionString, options.ContainerName, "keys.xml")
                                             // Configure the system to use a key lifetime. Default is 90 days.
                                             .SetDefaultKeyLifetime(TimeSpan.FromDays(options.KeyLifetime))


### PR DESCRIPTION
Added CryptographicAlgorithms property to AzureDataProtectionOptions, allowing selection of encryption and validation algorithms (defaulting to AES_256_GCM and HMACSHA512). Updated ServiceCollectionExtensions to use this property. Bumped version to 8.43.0. Centralizes and increases flexibility of cryptographic configuration.