### PR TITLE
[cases] Update Elsa packages to 2.16.1 and bump Cases version fixes #986

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -10,7 +10,7 @@
     <VersionPrefixCore>$(VersionPrefixBase).0</VersionPrefixCore>
     <VersionPrefixIdentity>$(VersionPrefixBase).0</VersionPrefixIdentity>
     <VersionPrefixIdentityUI>$(VersionPrefixBase).0</VersionPrefixIdentityUI>
-    <VersionPrefixCases>$(VersionPrefixBase).0</VersionPrefixCases>
+    <VersionPrefixCases>$(VersionPrefixBase).1</VersionPrefixCases>
     <VersionPrefixMessages>$(VersionPrefixBase).0</VersionPrefixMessages>
     <VersionPrefixMultitenancy>$(VersionPrefixBase).0</VersionPrefixMultitenancy>
     <VersionPrefixRisk>$(VersionPrefixBase).0</VersionPrefixRisk>

--- a/src/Indice.Features.Cases.Workflows/Indice.Features.Cases.Workflows.csproj
+++ b/src/Indice.Features.Cases.Workflows/Indice.Features.Cases.Workflows.csproj
@@ -9,15 +9,15 @@
 
   <ItemGroup>
     <PackageReference Include="Duende.AccessTokenManagement" Version="4.1.2" />
-    <PackageReference Include="Elsa" Version="2.16.0" />
-    <PackageReference Include="Elsa.Activities.Email" Version="2.16.0" />
-    <PackageReference Include="Elsa.Activities.Http" Version="2.16.0" />
-    <PackageReference Include="Elsa.Activities.Temporal.Quartz" Version="2.16.0" />
-    <PackageReference Include="Elsa.Activities.UserTask" Version="2.16.0" />
-    <PackageReference Include="Elsa.Designer.Components.Web" Version="2.16.0" />
-    <PackageReference Include="Elsa.Persistence.EntityFramework.SqlServer" Version="2.16.0" />
-    <PackageReference Include="Elsa.Retention" Version="2.16.0" />
-    <PackageReference Include="Elsa.Server.Api" Version="2.16.0" />
+    <PackageReference Include="Elsa" Version="2.16.1" />
+    <PackageReference Include="Elsa.Activities.Email" Version="2.16.1" />
+    <PackageReference Include="Elsa.Activities.Http" Version="2.16.1" />
+    <PackageReference Include="Elsa.Activities.Temporal.Quartz" Version="2.16.1" />
+    <PackageReference Include="Elsa.Activities.UserTask" Version="2.16.1" />
+    <PackageReference Include="Elsa.Designer.Components.Web" Version="2.16.1" />
+    <PackageReference Include="Elsa.Persistence.EntityFramework.SqlServer" Version="2.16.1" />
+    <PackageReference Include="Elsa.Retention" Version="2.16.1" />
+    <PackageReference Include="Elsa.Server.Api" Version="2.16.1" />
     <PackageReference Include="JsonSchema.Net" Version="8.0.5" />
     <PackageReference Include="Indice.AspNetCore" Version="$(VersionPrefixCore)-*" />
   </ItemGroup>


### PR DESCRIPTION
Upgraded all Elsa workflow-related NuGet packages in Indice.Features.Cases.Workflows.csproj from 2.16.0 to 2.16.1. Incremented <VersionPrefixCases> in Directory.Build.props to $(VersionPrefixBase).1 to reflect the new Cases component version.