### PR TITLE
[cases] Bugfix on cases menu when user$ was firing multiple times

### DIFF
--- a/src/Indice.Features.Cases.App/src/app/app.links.ts
+++ b/src/Indice.Features.Cases.App/src/app/app.links.ts
@@ -22,37 +22,32 @@ export class AppLinks implements IAppLinks {
         this.authService.user$.pipe(
             filter(user => !!user),
             take(1),
-            switchMap(user => {
-                if (user) {
-                    return this._caseTypeService.getCaseTypeMenuItems().pipe(
-                        map(caseTypeMenuItems => {
-                            for (const item of caseTypeMenuItems) {
-                                if (item.title) {
-                                    const queryParams: Params = {
-                                        view: 'table',
-                                        page: '1',
-                                        pagesize: '20',
-                                        search: '',
-                                        sort: 'createdByWhen',
-                                        dir: 'desc',
-                                        filter: `caseTypeCodes::eq::${item.code}`
-                                    };
-                                    this.headerMenu.push(new NavLink(item.title, `/case/by-type/${item.code}`, true, undefined, Icons.MenuItem, undefined, queryParams));
-                                }
-                            }
-                            if (this.authService.isAdmin()) {
-                                this.headerMenu.push(new NavLink('Διαχείριση Υποθέσεων', '/case-types', true, undefined, Icons.CaseTypes));
-                            }
-                            if (this.authService.isAdmin() || this.authService.hasRole('CasesManager') || this.authService.hasRole('CasesAdministrator')) {
-                                this.headerMenu.push(new NavLink('Ειδοποιήσεις', '/notifications', true, undefined, Icons.Notifications));
-                            }
+            switchMap(() => this._caseTypeService.getCaseTypeMenuItems().pipe(
+                map(caseTypeMenuItems => {
+                    for (const item of caseTypeMenuItems) {
+                        if (item.title) {
+                            const queryParams: Params = {
+                                view: 'table',
+                                page: '1',
+                                pagesize: '20',
+                                search: '',
+                                sort: 'createdByWhen',
+                                dir: 'desc',
+                                filter: `caseTypeCodes::eq::${item.code}`
+                            };
+                            this.headerMenu.push(new NavLink(item.title, `/case/by-type/${item.code}`, true, undefined, Icons.MenuItem, undefined, queryParams));
+                        }
+                    }
+                    if (this.authService.isAdmin()) {
+                        this.headerMenu.push(new NavLink('Διαχείριση Υποθέσεων', '/case-types', true, undefined, Icons.CaseTypes));
+                    }
+                    if (this.authService.isAdmin() || this.authService.hasRole('CasesManager') || this.authService.hasRole('CasesAdministrator')) {
+                        this.headerMenu.push(new NavLink('Ειδοποιήσεις', '/notifications', true, undefined, Icons.Notifications));
+                    }
 
-                            return this.headerMenu;
-                        })
-                    );
-                }
-                return of(this.headerMenu);
-            })
+                    return this.headerMenu;
+                })
+            ))
         ).subscribe(navLinks => this._main.next(navLinks));
     }
 

--- a/src/Indice.Features.Cases.App/src/app/app.links.ts
+++ b/src/Indice.Features.Cases.App/src/app/app.links.ts
@@ -1,4 +1,4 @@
-import { map, switchMap } from 'rxjs/operators';
+import { map, switchMap, take, filter } from 'rxjs/operators';
 import { AuthService } from '@indice/ng-auth';
 import { IAppLinks, NavLink } from '@indice/ng-components';
 import { Observable, of, ReplaySubject } from 'rxjs';
@@ -19,6 +19,8 @@ export class AppLinks implements IAppLinks {
         private _caseTypeService: CaseTypeService
     ) {
         this.authService.user$.pipe(
+            filter(user => !!user),
+            take(1),
             switchMap(user => {
                 if (user) {
                     return this._caseTypeService.getCaseTypeMenuItems().pipe(
@@ -48,6 +50,7 @@ export class AppLinks implements IAppLinks {
                         })
                     );
                 }
+                
                 return of(this.headerMenu);
             })
         ).subscribe(navLinks => this._main.next(navLinks));

--- a/src/Indice.Features.Cases.App/src/app/app.links.ts
+++ b/src/Indice.Features.Cases.App/src/app/app.links.ts
@@ -18,6 +18,7 @@ export class AppLinks implements IAppLinks {
         private authService: AuthService,
         private _caseTypeService: CaseTypeService
     ) {
+        this._main.next(this.headerMenu);
         this.authService.user$.pipe(
             filter(user => !!user),
             take(1),
@@ -50,7 +51,6 @@ export class AppLinks implements IAppLinks {
                         })
                     );
                 }
-                
                 return of(this.headerMenu);
             })
         ).subscribe(navLinks => this._main.next(navLinks));


### PR DESCRIPTION
This pull request updates the `AppLinks` class to improve how user authentication is handled before loading case type menu items. The changes ensure that the menu items are only fetched once a valid user is present, preventing unnecessary or premature API calls.

**Improvements to authentication flow:**

* Added `filter` and `take` operators to the user observable pipeline in `app.links.ts` to ensure that menu items are only loaded for authenticated users and only once per session. [[1]](diffhunk://#diff-756fc243895d95b0a3c378b739477df7b22be5dd82e11c25ce822fc39ed32e78L1-R1) [[2]](diffhunk://#diff-756fc243895d95b0a3c378b739477df7b22be5dd82e11c25ce822fc39ed32e78R22-R23)

**Code quality:**

* Improved code clarity and reliability by preventing multiple or redundant subscriptions to the user observable.

No other significant changes were made.