### PR TITLE
[fix] Enhance security for XSRF cookie and redirect handling

### DIFF
--- a/src/Indice.AspNetCore.EmbeddedUI/SpaUIMiddleware.cs
+++ b/src/Indice.AspNetCore.EmbeddedUI/SpaUIMiddleware.cs
@@ -73,6 +73,6 @@ public class SpaUIMiddleware<TOptions> where TOptions : SpaUIOptions, new()
     private void GenerateAntiforgeryCookie(HttpContext httpContext) {
         var antiforgery = httpContext.RequestServices.GetRequiredService<IAntiforgery>();
         var tokenSet = antiforgery.GetAndStoreTokens(httpContext);
-        httpContext.Response.Cookies.Append("XSRF-TOKEN", tokenSet.RequestToken!, new CookieOptions { HttpOnly = false });
+        httpContext.Response.Cookies.Append("XSRF-TOKEN", tokenSet.RequestToken!, new CookieOptions { HttpOnly = false, Secure = httpContext.Request.IsHttps });
     }
 }

--- a/src/Indice.Features.Identity.UI/wwwroot/js/signin-redirect.js
+++ b/src/Indice.Features.Identity.UI/wwwroot/js/signin-redirect.js
@@ -1,1 +1,10 @@
-window.location.href = document.querySelector("meta[http-equiv=refresh]").getAttribute("data-url");
+const refreshMeta = document.querySelector("meta[http-equiv=refresh]");
+const rawUrl = refreshMeta ? refreshMeta.getAttribute("data-url") : null;
+if (rawUrl) {
+    try {
+        const parsedUrl = new URL(rawUrl, window.location.origin);
+        window.location.href = parsedUrl.href;
+    } catch (e) {
+        // Ignore invalid redirect URL.
+    }
+}


### PR DESCRIPTION
- Set the XSRF-TOKEN cookie with the Secure flag when using HTTPS.
- Improve signin-redirect.js to robustly handle missing or invalid redirect URLs, using the URL API and error handling to prevent faulty redirects.