### PR TITLE
[codeql] Prefix filter cache keys with '$' in FilterCachingService

### DIFF
--- a/src/Indice.Features.Cases.App/src/app/core/services/filter-caching.service.ts
+++ b/src/Indice.Features.Cases.App/src/app/core/services/filter-caching.service.ts
@@ -1,14 +1,14 @@
 import { Injectable } from '@angular/core';
 
 type Dictionary = {
-    [key: string]: object;
+    [key: string]: object | undefined;
 };
 
 @Injectable({
   providedIn: 'root'
 })
 export class FilterCachingService {
-  private filterParams: Dictionary = {};
+  private filterParams: Dictionary = Object.create(null);
   private readonly keyPrefix = '$';
   constructor() { }
 
@@ -16,13 +16,13 @@ export class FilterCachingService {
    * Stores params.
    */
   setParams(key: string, filterParams: object) {
-      this.filterParams[this.keyPrefix + key] = filterParams;
+    this.filterParams[this.keyPrefix + key] = filterParams;
   }
 
   /**
    * Gets Stored params.
    */
-  getParams(key: string): object {
+  getParams(key: string): object | undefined {
     return this.filterParams[this.keyPrefix + key];
   }
 

--- a/src/Indice.Features.Cases.App/src/app/core/services/filter-caching.service.ts
+++ b/src/Indice.Features.Cases.App/src/app/core/services/filter-caching.service.ts
@@ -9,27 +9,27 @@ type Dictionary = {
 })
 export class FilterCachingService {
   private filterParams: Dictionary = {};
-
+  private readonly keyPrefix = '$';
   constructor() { }
 
   /**
    * Stores params.
    */
   setParams(key: string, filterParams: object) {
-    this.filterParams[key] = filterParams;
+      this.filterParams[this.keyPrefix + key] = filterParams;
   }
 
   /**
    * Gets Stored params.
    */
   getParams(key: string): object {
-    return this.filterParams[key];
+    return this.filterParams[this.keyPrefix + key];
   }
 
   /**
    * Clears Stored params.
    */
   resetParams(key: string) {
-    delete this.filterParams[key];
+    delete this.filterParams[this.keyPrefix + key];
   }
 }

--- a/src/Indice.Features.Cases.App/src/app/core/services/filter-caching.service.ts
+++ b/src/Indice.Features.Cases.App/src/app/core/services/filter-caching.service.ts
@@ -9,27 +9,29 @@ type Dictionary = {
 })
 export class FilterCachingService {
   private filterParams: Dictionary = Object.create(null);
-  private readonly keyPrefix = '$';
   constructor() { }
 
   /**
    * Stores params.
    */
   setParams(key: string, filterParams: object) {
-    this.filterParams[this.keyPrefix + key] = filterParams;
+    let internalKey = '$' + key;
+    this.filterParams[internalKey] = filterParams;
   }
 
   /**
    * Gets Stored params.
    */
   getParams(key: string): object | undefined {
-    return this.filterParams[this.keyPrefix + key];
+    let internalKey = '$' + key;
+    return this.filterParams[internalKey];
   }
 
   /**
    * Clears Stored params.
    */
   resetParams(key: string) {
-    delete this.filterParams[this.keyPrefix + key];
+    let internalKey = '$' + key;
+    delete this.filterParams[internalKey];
   }
 }


### PR DESCRIPTION
All filter parameter keys are now stored with a '$' prefix to avoid object injection as well as potential key collisions. Updated setParams, getParams, and resetParams methods to use this prefix consistently.