### PR TITLE
[openapi] Improve support for long-based enums in OpenAPI schema

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,19 +7,19 @@
     <VersionPrefixMajor>8</VersionPrefixMajor>
     <VersionPrefixBase>$(VersionPrefixMajor).43</VersionPrefixBase>
 
-    <VersionPrefixCore>$(VersionPrefixBase).0</VersionPrefixCore>
-    <VersionPrefixIdentity>$(VersionPrefixBase).0</VersionPrefixIdentity>
-    <VersionPrefixIdentityUI>$(VersionPrefixBase).0</VersionPrefixIdentityUI>
-    <VersionPrefixCases>$(VersionPrefixBase).1</VersionPrefixCases>
-    <VersionPrefixMessages>$(VersionPrefixBase).0</VersionPrefixMessages>
-    <VersionPrefixMultitenancy>$(VersionPrefixBase).0</VersionPrefixMultitenancy>
-    <VersionPrefixRisk>$(VersionPrefixBase).0</VersionPrefixRisk>
-    <VersionPrefixMedia>$(VersionPrefixBase).0</VersionPrefixMedia>
-    <VersionPrefixGeoIP>$(VersionPrefixBase).0</VersionPrefixGeoIP>
-    <VersionPrefixGovGr>$(VersionPrefixBase).0</VersionPrefixGovGr>
-    <VersionPrefixAspNet>$(VersionPrefixBase).0</VersionPrefixAspNet>
-    <VersionPrefixActivityLogs>$(VersionPrefixBase).0</VersionPrefixActivityLogs>
-    <VersionPrefix>$(VersionPrefixBase).0</VersionPrefix>
+    <VersionPrefixCore>$(VersionPrefixBase).1</VersionPrefixCore>
+    <VersionPrefixIdentity>$(VersionPrefixBase).1</VersionPrefixIdentity>
+    <VersionPrefixIdentityUI>$(VersionPrefixBase).1</VersionPrefixIdentityUI>
+    <VersionPrefixCases>$(VersionPrefixBase).2</VersionPrefixCases>
+    <VersionPrefixMessages>$(VersionPrefixBase).1</VersionPrefixMessages>
+    <VersionPrefixMultitenancy>$(VersionPrefixBase).1</VersionPrefixMultitenancy>
+    <VersionPrefixRisk>$(VersionPrefixBase).1</VersionPrefixRisk>
+    <VersionPrefixMedia>$(VersionPrefixBase).1</VersionPrefixMedia>
+    <VersionPrefixGeoIP>$(VersionPrefixBase).1</VersionPrefixGeoIP>
+    <VersionPrefixGovGr>$(VersionPrefixBase).1</VersionPrefixGovGr>
+    <VersionPrefixAspNet>$(VersionPrefixBase).1</VersionPrefixAspNet>
+    <VersionPrefixActivityLogs>$(VersionPrefixBase).1</VersionPrefixActivityLogs>
+    <VersionPrefix>$(VersionPrefixBase).1</VersionPrefix>
 
     <!--<VersionSuffix>rc02</VersionSuffix>-->
     <Authors>Constantinos Leftheris</Authors>

--- a/src/Indice.AspNetCore/OpenApi/Transformers/EnumTransformer.cs
+++ b/src/Indice.AspNetCore/OpenApi/Transformers/EnumTransformer.cs
@@ -71,23 +71,33 @@ public static class EnumTransformer
         var isString = schema.Enum?.FirstOrDefault()?.ToJsonString().StartsWith('"') ??
                        schema.Type?.HasFlag(JsonSchemaType.String) ?? 
                        context.JsonTypeInfo.Options.Converters.OfType<JsonStringEnumConverter>().Any();
+        var underlyingType = Enum.GetUnderlyingType(enumType);
+        var isLong = underlyingType.Name.ToLowerInvariant().Equals("int64");
         if (!schema.Type.HasValue) {
             schema.Type = isString ? JsonSchemaType.String : JsonSchemaType.Integer;
         }
-        
+        if (!isString && isLong) {
+            schema.Format = "int64";
+            isLong = true;
+        }
+
         schema.Format = null;
         var fields = enumType.GetFields(BindingFlags.Public | BindingFlags.Static).ToDictionary(x => x.Name, x => new {
             Name = x.GetCustomAttribute<JsonStringEnumMemberNameAttribute>()?.Name ?? x.GetCustomAttribute<EnumMemberAttribute>()?.Value ?? x.Name,
             x.GetCustomAttribute<DescriptionAttribute>()?.Description
         });
         var enumNames = Enum.GetNames(enumType);
-        var enumValues = Enum.GetValuesAsUnderlyingType(enumType).Cast<object>().Select(Convert.ToInt32).ToArray();
+        var enumValues = isLong ? Enum.GetValuesAsUnderlyingType(enumType)! : Enum.GetValuesAsUnderlyingType(enumType).Cast<object>().Select(Convert.ToInt32).ToArray()!;
         var openApiValueArray = new List<JsonNode>();
         var openApiNameArray = new List<JsonNode>();
         var openApiDescArray = new List<JsonNode>();
         bool writeDescriptions = false;
         for (int i = 0; i < enumValues.Length; i++) {
-            openApiValueArray.Add(isString ? (JsonNode)fields[enumNames[i]].Name! : (JsonNode)enumValues[i]);
+
+
+            openApiValueArray.Add(isString ? (JsonNode)fields[enumNames[i]].Name! :
+                                  isLong ? (JsonNode)((long[])enumValues)[i] :
+                                           (JsonNode)((int[])enumValues)[i]);
             openApiNameArray.Add(enumNames[i]);
             openApiDescArray.Add(fields[enumNames[i]].Description!);
             writeDescriptions |= !string.IsNullOrWhiteSpace(fields[enumNames[i]].Description);

--- a/src/Indice.AspNetCore/OpenApi/Transformers/EnumTransformer.cs
+++ b/src/Indice.AspNetCore/OpenApi/Transformers/EnumTransformer.cs
@@ -72,16 +72,14 @@ public static class EnumTransformer
                        schema.Type?.HasFlag(JsonSchemaType.String) ?? 
                        context.JsonTypeInfo.Options.Converters.OfType<JsonStringEnumConverter>().Any();
         var underlyingType = Enum.GetUnderlyingType(enumType);
-        var isLong = underlyingType.Name.ToLowerInvariant().Equals("int64");
+        var isLong = underlyingType == typeof(long);
         if (!schema.Type.HasValue) {
             schema.Type = isString ? JsonSchemaType.String : JsonSchemaType.Integer;
         }
+        schema.Format = null;
         if (!isString && isLong) {
             schema.Format = "int64";
-            isLong = true;
         }
-
-        schema.Format = null;
         var fields = enumType.GetFields(BindingFlags.Public | BindingFlags.Static).ToDictionary(x => x.Name, x => new {
             Name = x.GetCustomAttribute<JsonStringEnumMemberNameAttribute>()?.Name ?? x.GetCustomAttribute<EnumMemberAttribute>()?.Value ?? x.Name,
             x.GetCustomAttribute<DescriptionAttribute>()?.Description

--- a/src/Indice.AspNetCore/OpenApi/Transformers/EnumTransformer.net9.cs
+++ b/src/Indice.AspNetCore/OpenApi/Transformers/EnumTransformer.net9.cs
@@ -85,7 +85,7 @@ public static class EnumTransformer
         }
         var isString = context.JsonTypeInfo.Options.Converters.OfType<JsonStringEnumConverter>().Any();
         var underlyingType = Enum.GetUnderlyingType(enumType);
-        var isLong = underlyingType.Name.ToLowerInvariant().Equals("int64");
+        var isLong = underlyingType == typeof(long);
         schema.Type = isString ? "string" : "integer";
         schema.Format = null;
         if (!isString && isLong) { 

--- a/src/Indice.AspNetCore/OpenApi/Transformers/EnumTransformer.net9.cs
+++ b/src/Indice.AspNetCore/OpenApi/Transformers/EnumTransformer.net9.cs
@@ -84,21 +84,27 @@ public static class EnumTransformer
             return false;
         }
         var isString = context.JsonTypeInfo.Options.Converters.OfType<JsonStringEnumConverter>().Any();
-
+        var underlyingType = Enum.GetUnderlyingType(enumType);
+        var isLong = underlyingType.Name.ToLowerInvariant().Equals("int64");
         schema.Type = isString ? "string" : "integer";
         schema.Format = null;
+        if (!isString && isLong) { 
+            schema.Format = "int64";
+        }
         var fields = enumType.GetFields(BindingFlags.Public | BindingFlags.Static).ToDictionary(x => x.Name, x => new {
             Name = x.GetCustomAttribute<JsonStringEnumMemberNameAttribute>()?.Name ?? x.GetCustomAttribute<EnumMemberAttribute>()?.Value ?? x.Name,
             x.GetCustomAttribute<DescriptionAttribute>()?.Description
         });
         var enumNames = Enum.GetNames(enumType);
-        var enumValues = Enum.GetValuesAsUnderlyingType(enumType).Cast<object>().Select(Convert.ToInt32).ToArray();
+        var enumValues = isLong ? Enum.GetValuesAsUnderlyingType(enumType)! : Enum.GetValuesAsUnderlyingType(enumType).Cast<object>().Select(Convert.ToInt32).ToArray()!;
         var openApiValueArray = new OpenApiArray();
         var openApiNameArray = new OpenApiArray();
         var openApiDescArray = new OpenApiArray();
         bool writeDescriptions = false;
         for (int i = 0; i < enumValues.Length; i++) {
-            openApiValueArray.Add(isString ? new OpenApiString(fields[enumNames[i]].Name) : new OpenApiInteger(enumValues[i]));
+            openApiValueArray.Add(isString ? new OpenApiString(fields[enumNames[i]].Name) :
+                                  isLong ? new OpenApiLong(((long[])enumValues)[i]) : 
+                                           new OpenApiInteger(((int[])enumValues)[i]));
             openApiNameArray.Add(new OpenApiString(enumNames[i]));
             openApiDescArray.Add(new OpenApiString(fields[enumNames[i]].Description));
             writeDescriptions |= !string.IsNullOrWhiteSpace(fields[enumNames[i]].Description);

--- a/test/Indice.AspNetCore.Tests/OpenApiTests.cs
+++ b/test/Indice.AspNetCore.Tests/OpenApiTests.cs
@@ -126,6 +126,12 @@ public class OpenApiTests : IAsyncLifetime
         var parameterEnumSchema = json!["paths"]!["/mvc/menu"]!["get"]!["parameters"]![0]!["schema"];
         var expectedSampleEnumSchema = "{\"enum\":[1,2,3],\"type\":\"integer\",\"x-enum-varnames\":[\"Value1\",\"Value2\",\"Value3\"]}";
         Assert.Equal(expectedSampleEnumSchema, parameterEnumSchema!.ToJsonString());
+
+
+        var longListTypeSchema = json!["components"]!["schemas"]!["LongListType"];
+        Assert.NotNull(longListTypeSchema);
+        var longListTypeAsStringSchema = json!["components"]!["schemas"]!["LongListTypeAsString"];
+        Assert.NotNull(longListTypeAsStringSchema);
     }
 }
 #else
@@ -165,6 +171,11 @@ public class OpenApiTests : IAsyncLifetime
 
         var parameterEnumSchema = json!["paths"]!["/mvc/menu"]!["get"]!["parameters"]![0]!["schema"];
         Assert.Equal("{\"$ref\":\"#/components/schemas/SampleEnum\"}", parameterEnumSchema!.ToJsonString());
+
+        var longListTypeSchema = json!["components"]!["schemas"]!["LongListType"];
+        Assert.NotNull(longListTypeSchema);
+        var longListTypeAsStringSchema = json!["components"]!["schemas"]!["LongListTypeAsString"];
+        Assert.NotNull(longListTypeAsStringSchema);
     }
 }
 #endif
@@ -223,6 +234,98 @@ public class OpenApiTestsModels
         public List<DateTime> Schedule { get; set; } = [];
         public Dictionary<string, string> Mappings { get; set; } = [];
     }
+
+    public class LongListRequest
+    {
+        public LongListType LongList { get; set; } = LongListType.None;
+        public LongListTypeAsString LongListText { get; set; } = LongListTypeAsString.None;
+    }
+    [Flags]
+    public enum LongListType : long
+    {
+        None = 0,
+        A = 1L << 0,    // 1
+        B = 1L << 1,    // 2
+        C = 1L << 2,    // 4
+        D = 1L << 3,    // 8
+        E = 1L << 4,    // 16
+        F = 1L << 5,    // 32
+        G = 1L << 6,    // 64
+        H = 1L << 7,    // 128
+        I = 1L << 8,    // 256
+        J = 1L << 9,    // 512
+        K = 1L << 10,   // 1024
+        L = 1L << 11,   // 2048
+        M = 1L << 12,   // 4096
+        N = 1L << 13,   // 8192
+        O = 1L << 14,   // 16384
+        P = 1L << 15,   // 32768
+        Q = 1L << 16,   // 65536
+        R = 1L << 17,   // 131072
+        S = 1L << 18,   // 262144
+        T = 1L << 19,   // 524288
+        U = 1L << 20,   // 1048576
+        V = 1L << 21,   // 2097152
+        W = 1L << 22,   // 4194304
+        X = 1L << 23,   // 8388608
+        Y = 1L << 24,   // 16777216
+        Z = 1L << 25,   // 33554432
+        AA = 1L << 26,  // 67108864
+        AB = 1L << 27,  // 134217728
+        AC = 1L << 28,  // 268435456
+        AD = 1L << 29,  // 536870912
+        AE = 1L << 30,  // 1073741824
+        AF = 1L << 31,  // 2147483648
+        AG = 1L << 32,  // 4294967296
+        AH = 1L << 33,  // 8589934592
+        AI = 1L << 34,  // 17179869184
+        AJ = 1L << 35,  // 34359738368
+        AK = 1L << 36   // 68719476736
+    }
+
+
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum LongListTypeAsString : long
+    {
+        None = 0,
+        A = 1L << 0,    // 1
+        B = 1L << 1,    // 2
+        C = 1L << 2,    // 4
+        D = 1L << 3,    // 8
+        E = 1L << 4,    // 16
+        F = 1L << 5,    // 32
+        G = 1L << 6,    // 64
+        H = 1L << 7,    // 128
+        I = 1L << 8,    // 256
+        J = 1L << 9,    // 512
+        K = 1L << 10,   // 1024
+        L = 1L << 11,   // 2048
+        M = 1L << 12,   // 4096
+        N = 1L << 13,   // 8192
+        O = 1L << 14,   // 16384
+        P = 1L << 15,   // 32768
+        Q = 1L << 16,   // 65536
+        R = 1L << 17,   // 131072
+        S = 1L << 18,   // 262144
+        T = 1L << 19,   // 524288
+        U = 1L << 20,   // 1048576
+        V = 1L << 21,   // 2097152
+        W = 1L << 22,   // 4194304
+        X = 1L << 23,   // 8388608
+        Y = 1L << 24,   // 16777216
+        Z = 1L << 25,   // 33554432
+        AA = 1L << 26,  // 67108864
+        AB = 1L << 27,  // 134217728
+        AC = 1L << 28,  // 268435456
+        AD = 1L << 29,  // 536870912
+        AE = 1L << 30,  // 1073741824
+        AF = 1L << 31,  // 2147483648
+        AG = 1L << 32,  // 4294967296
+        AH = 1L << 33,  // 8589934592
+        AI = 1L << 34,  // 17179869184
+        AJ = 1L << 35,  // 34359738368
+        AK = 1L << 36   // 68719476736
+    }
 }
 
 [ApiController]
@@ -276,6 +379,8 @@ public static class OpenApiTestsEndpoints
              .Accepts<UploadFileRequest>(MediaTypeNames.Multipart.FormData);
         group.MapPost("converters", UpdateWithConverters)
              .WithName(nameof(UpdateWithConverters));
+        group.MapPost("long-enum", UpdateLongTypeEnum)
+             .WithName(nameof(UpdateLongTypeEnum));
 
 
         return routes;
@@ -302,6 +407,9 @@ public static class OpenApiTestsEndpoints
         return TypedResults.Ok(items);
     }
     public static NoContent UpdateWithConverters(PrimitivesTestRequest request) {
+        return TypedResults.NoContent();
+    }
+    public static NoContent UpdateLongTypeEnum(LongListRequest request) {
         return TypedResults.NoContent();
     }
 


### PR DESCRIPTION
Detect enums with Int64 underlying type and set schema format to "int64". Process enum values as long instead of int to ensure correct representation of large enum values. Updates applied to both EnumTransformer.cs and EnumTransformer.net9.cs.