### PR TITLE
[messages] Refactor attachment cleanup and configure DB cleanup options

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -11,7 +11,7 @@
     <VersionPrefixIdentity>$(VersionPrefixBase).1</VersionPrefixIdentity>
     <VersionPrefixIdentityUI>$(VersionPrefixBase).1</VersionPrefixIdentityUI>
     <VersionPrefixCases>$(VersionPrefixBase).2</VersionPrefixCases>
-    <VersionPrefixMessages>$(VersionPrefixBase).1</VersionPrefixMessages>
+    <VersionPrefixMessages>$(VersionPrefixBase).2</VersionPrefixMessages>
     <VersionPrefixMultitenancy>$(VersionPrefixBase).1</VersionPrefixMultitenancy>
     <VersionPrefixRisk>$(VersionPrefixBase).1</VersionPrefixRisk>
     <VersionPrefixMedia>$(VersionPrefixBase).1</VersionPrefixMedia>

--- a/src/Indice.Features.Messages.Core/Services/MessagingDatabaseCleanUpService.cs
+++ b/src/Indice.Features.Messages.Core/Services/MessagingDatabaseCleanUpService.cs
@@ -24,8 +24,8 @@ public class MessagingDatabaseCleanUpService : IMessagingDatabaseCleanUpService
     /// <param name="dbContext">Database context for accessing campaign data.</param>
     /// <param name="fileServiceFactory">Factory for creating file services.</param>
     /// <param name="logger">Logger for logging events.</param>
-    public MessagingDatabaseCleanUpService(IOptions<MessagingDatabaseCleanUpOptions> options, CampaignsDbContext dbContext, IFileServiceFactory fileServiceFactory, ILogger<MessagingDatabaseCleanUpService> logger) {
-        _options = options.Value;
+    public MessagingDatabaseCleanUpService(IOptions<MessageWorkerOptions> options, CampaignsDbContext dbContext, IFileServiceFactory fileServiceFactory, ILogger<MessagingDatabaseCleanUpService> logger) {
+        _options = options.Value.DatabaseCleanUpOptions;
         DbContext = dbContext;
         FileService = fileServiceFactory.Create(KeyedServiceNames.FileServiceKey) ?? throw new ArgumentNullException(nameof(fileServiceFactory), $"Service {KeyedServiceNames.FileServiceKey} was not registered");
         _logger = logger;

--- a/src/Indice.Features.Messages.Core/Services/MessagingDatabaseCleanUpService.cs
+++ b/src/Indice.Features.Messages.Core/Services/MessagingDatabaseCleanUpService.cs
@@ -88,13 +88,14 @@ public class MessagingDatabaseCleanUpService : IMessagingDatabaseCleanUpService
                 await DbContext.DistributionLists.Where(x => x.CreatedBy!.ToLower().Trim() == "system" && deletionCampaignData.Select(c => c.DistributionListId).Contains(x.Id)).ExecuteDeleteAsync();
                 await DbContext.MessageEvents.Where(x => deletionCampaignData.Select(c => c.Id).Contains(x.CampaignId)).ExecuteDeleteAsync();
                 await transaction.CommitAsync();
-            } catch (Exception ex) {
+            } 
+            catch (Exception ex) {
                 _logger.LogError(ex, "Error occurred while deleting campaign batch.");
                 await transaction.RollbackAsync();
                 throw;
             }
         }
-        var attachmentIds = deletionCampaignData.Select(x => x.AttachmentId);
+        var attachmentIds = deletionCampaignData.Where(x => x.AttachmentId is not null).Select(x => x.AttachmentId!.Value).ToList();
         await DeleteAttachmentsAndFiles(attachmentIds);
     }
 
@@ -103,14 +104,18 @@ public class MessagingDatabaseCleanUpService : IMessagingDatabaseCleanUpService
     /// </summary>
     /// <param name="attachmentIds"></param>
     /// <returns></returns>
-    private async Task DeleteAttachmentsAndFiles(IEnumerable<Guid?> attachmentIds) {
+    private async Task DeleteAttachmentsAndFiles(List<Guid> attachmentIds) {
+        if (!attachmentIds.Any()) {
+            return;
+        }
         var dbAttachments = await DbContext.Attachments.Where(x => attachmentIds.Contains(x.Id)).ToListAsync();
         if (dbAttachments.Any()) {
             foreach (var dbAttachment in dbAttachments) {
                 var path = dbAttachment.GetPath();
                 try {
                     await FileService.DeleteAsync(path);
-                } catch (Exception ex) {
+                }
+                catch (Exception ex) {
                     _logger.LogError(ex, "Error occurred while deleting attachment file at path: {Path}", path);
                 }
             }

--- a/src/Indice.Features.Messages.Core/Services/MessagingDatabaseCleanUpService.cs
+++ b/src/Indice.Features.Messages.Core/Services/MessagingDatabaseCleanUpService.cs
@@ -95,7 +95,7 @@ public class MessagingDatabaseCleanUpService : IMessagingDatabaseCleanUpService
             }
         }
         var attachmentIds = deletionCampaignData.Select(x => x.AttachmentId);
-        await DeleteAttachments(attachmentIds);
+        await DeleteAttachmentsAndFiles(attachmentIds);
     }
 
     /// <summary>
@@ -103,7 +103,7 @@ public class MessagingDatabaseCleanUpService : IMessagingDatabaseCleanUpService
     /// </summary>
     /// <param name="attachmentIds"></param>
     /// <returns></returns>
-    private async Task DeleteAttachments(IEnumerable<Guid?> attachmentIds) {
+    private async Task DeleteAttachmentsAndFiles(IEnumerable<Guid?> attachmentIds) {
         var dbAttachments = await DbContext.Attachments.Where(x => attachmentIds.Contains(x.Id)).ToListAsync();
         if (dbAttachments.Any()) {
             foreach (var dbAttachment in dbAttachments) {

--- a/src/Indice.Features.Messages.Worker.Azure/HostBuilderExtensions.cs
+++ b/src/Indice.Features.Messages.Worker.Azure/HostBuilderExtensions.cs
@@ -42,13 +42,10 @@ public static class HostBuilderExtensions
         });
         builder.Services.Configure<MessageWorkerOptions>(messageWorkerOptions => {
             messageWorkerOptions.ContactRetainPeriodInDays = options.ContactRetainPeriodInDays;
-        });
-
-        builder.Services.Configure<MessagingDatabaseCleanUpOptions>(dbCleanUpOptions =>  {
-            dbCleanUpOptions.RetentionDaysForOther = options.DatabaseCleanUpOptions.RetentionDaysForOther;
-            dbCleanUpOptions.RetentionDaysForInbox = options.DatabaseCleanUpOptions.RetentionDaysForInbox;
-            dbCleanUpOptions.DeletionBatchSize = options.DatabaseCleanUpOptions.DeletionBatchSize;
-            dbCleanUpOptions.Enabled = options.DatabaseCleanUpOptions.Enabled;
+            messageWorkerOptions.DatabaseCleanUpOptions.RetentionDaysForOther = options.DatabaseCleanUpOptions.RetentionDaysForOther;
+            messageWorkerOptions.DatabaseCleanUpOptions.RetentionDaysForInbox = options.DatabaseCleanUpOptions.RetentionDaysForInbox;
+            messageWorkerOptions.DatabaseCleanUpOptions.DeletionBatchSize = options.DatabaseCleanUpOptions.DeletionBatchSize;
+            messageWorkerOptions.DatabaseCleanUpOptions.Enabled = options.DatabaseCleanUpOptions.Enabled;
         });
 
         builder.Services.AddHostedService<StartupSeedHostedService>();
@@ -77,12 +74,10 @@ public static class HostBuilderExtensions
             });
             services.Configure<MessageWorkerOptions>(messageWorkerOptions => {
                 messageWorkerOptions.ContactRetainPeriodInDays = options.ContactRetainPeriodInDays;
-            });
-            services.Configure<MessagingDatabaseCleanUpOptions>(dbCleanUpOptions => {
-                dbCleanUpOptions.RetentionDaysForOther = options.DatabaseCleanUpOptions.RetentionDaysForOther;
-                dbCleanUpOptions.RetentionDaysForInbox = options.DatabaseCleanUpOptions.RetentionDaysForInbox;
-                dbCleanUpOptions.DeletionBatchSize = options.DatabaseCleanUpOptions.DeletionBatchSize;
-                dbCleanUpOptions.Enabled = options.DatabaseCleanUpOptions.Enabled;
+                messageWorkerOptions.DatabaseCleanUpOptions.RetentionDaysForOther = options.DatabaseCleanUpOptions.RetentionDaysForOther;
+                messageWorkerOptions.DatabaseCleanUpOptions.RetentionDaysForInbox = options.DatabaseCleanUpOptions.RetentionDaysForInbox;
+                messageWorkerOptions.DatabaseCleanUpOptions.DeletionBatchSize = options.DatabaseCleanUpOptions.DeletionBatchSize;
+                messageWorkerOptions.DatabaseCleanUpOptions.Enabled = options.DatabaseCleanUpOptions.Enabled;
             });
             services.AddHostedService<StartupSeedHostedService>();
             services.TryAddSingleton(options.FunctionDisablePredicate);

--- a/src/Indice.Features.Messages.Worker.Azure/HostBuilderExtensions.cs
+++ b/src/Indice.Features.Messages.Worker.Azure/HostBuilderExtensions.cs
@@ -43,6 +43,14 @@ public static class HostBuilderExtensions
         builder.Services.Configure<MessageWorkerOptions>(messageWorkerOptions => {
             messageWorkerOptions.ContactRetainPeriodInDays = options.ContactRetainPeriodInDays;
         });
+
+        builder.Services.Configure<MessagingDatabaseCleanUpOptions>(dbCleanUpOptions =>  {
+            dbCleanUpOptions.RetentionDaysForOther = options.DatabaseCleanUpOptions.RetentionDaysForOther;
+            dbCleanUpOptions.RetentionDaysForInbox = options.DatabaseCleanUpOptions.RetentionDaysForInbox;
+            dbCleanUpOptions.DeletionBatchSize = options.DatabaseCleanUpOptions.DeletionBatchSize;
+            dbCleanUpOptions.Enabled = options.DatabaseCleanUpOptions.Enabled;
+        });
+
         builder.Services.AddHostedService<StartupSeedHostedService>();
         builder.Services.TryAddSingleton(options.FunctionDisablePredicate);
         builder.Services.AddDecorator<IFunctionMetadataProvider, ExtendedFunctionMetadataProvider>();

--- a/src/Indice.Features.Messages.Worker/WorkerHostBuilderExtensions.cs
+++ b/src/Indice.Features.Messages.Worker/WorkerHostBuilderExtensions.cs
@@ -45,13 +45,12 @@ public static class WorkerHostBuilderExtensions
         });
         workerHostBuilder.Services.Configure<MessageWorkerOptions>(messageWorkerOptions => {
             messageWorkerOptions.ContactRetainPeriodInDays = options.ContactRetainPeriodInDays;
+            messageWorkerOptions.DatabaseCleanUpOptions.RetentionDaysForOther = options.DatabaseCleanUpOptions.RetentionDaysForOther;
+            messageWorkerOptions.DatabaseCleanUpOptions.RetentionDaysForInbox = options.DatabaseCleanUpOptions.RetentionDaysForInbox;
+            messageWorkerOptions.DatabaseCleanUpOptions.DeletionBatchSize = options.DatabaseCleanUpOptions.DeletionBatchSize;
+            messageWorkerOptions.DatabaseCleanUpOptions.Enabled = options.DatabaseCleanUpOptions.Enabled;
         });
-        workerHostBuilder.Services.Configure<MessagingDatabaseCleanUpOptions>(dbCleanUpOptions => {
-            dbCleanUpOptions.RetentionDaysForOther = options.DatabaseCleanUpOptions.RetentionDaysForOther;
-            dbCleanUpOptions.RetentionDaysForInbox = options.DatabaseCleanUpOptions.RetentionDaysForInbox;
-            dbCleanUpOptions.DeletionBatchSize = options.DatabaseCleanUpOptions.DeletionBatchSize;
-            dbCleanUpOptions.Enabled = options.DatabaseCleanUpOptions.Enabled;
-        });
+
         workerHostBuilder.Services.AddHostedService<StartupSeedHostedService>();
         return workerHostBuilder;
     }

--- a/test/Indice.Features.Messages.Tests/CampaignDatabaseCleanUpTests.cs
+++ b/test/Indice.Features.Messages.Tests/CampaignDatabaseCleanUpTests.cs
@@ -17,6 +17,10 @@ namespace Indice.Features.Messages.Tests;
 
 public class CampaignDatabaseCleanUpTests : IAsyncLifetime
 {
+    // Retention days from MessagingDatabaseCleanUpOptions defaults
+    private const int RetentionDaysForInbox = 180;
+    private const int RetentionDaysForOther = 120;
+
     public ServiceProvider ServiceProvider { get; }
 
     public CampaignDatabaseCleanUpTests() {
@@ -42,8 +46,8 @@ public class CampaignDatabaseCleanUpTests : IAsyncLifetime
             .AddTransient<UserNameAccessorAggregate>()
             .AddSingleton<IFileServiceFactory, DefaultFileServiceFactory>()
             .AddKeyedSingleton<IFileService, FileServiceInMemory>("Messages:FileServiceKey")
-            .Configure<MessagingDatabaseCleanUpOptions>(options => {
-                options.Enabled = true;
+            .Configure<MessageWorkerOptions>(options => {
+                options.DatabaseCleanUpOptions.Enabled = true;
             })
             .AddTransient<IMessagingDatabaseCleanUpService, MessagingDatabaseCleanUpService>()
             .AddOptions()
@@ -80,12 +84,12 @@ public class CampaignDatabaseCleanUpTests : IAsyncLifetime
         }
         db.DistributionLists.AddRange(distributionLists);
 
-        var oldCampaign1 = CreateCampaign(MessageChannelKind.Inbox, 185, true, distributionLists[0].Id);
-        var oldCampaign2 = CreateCampaign(MessageChannelKind.Inbox, 190, true, distributionLists[1].Id);
-        var oldCampaign3 = CreateCampaign(MessageChannelKind.Inbox | MessageChannelKind.Email, 200, true, distributionLists[2].Id);
+        var oldCampaign1 = CreateCampaign(MessageChannelKind.Inbox, RetentionDaysForInbox + 5, true, distributionLists[0].Id);
+        var oldCampaign2 = CreateCampaign(MessageChannelKind.Inbox, RetentionDaysForInbox + 10, true, distributionLists[1].Id);
+        var oldCampaign3 = CreateCampaign(MessageChannelKind.Inbox | MessageChannelKind.Email, RetentionDaysForInbox + 20, true, distributionLists[2].Id);
 
-        var recentCampaign = CreateCampaign(MessageChannelKind.Inbox, 10, true, distributionLists[3].Id);
-        var unpublishedCampaign = CreateCampaign(MessageChannelKind.Inbox, 200, false, distributionLists[4].Id);
+        var recentCampaign = CreateCampaign(MessageChannelKind.Inbox, RetentionDaysForInbox - 170, true, distributionLists[3].Id);
+        var unpublishedCampaign = CreateCampaign(MessageChannelKind.Inbox, RetentionDaysForInbox + 20, false, distributionLists[4].Id);
 
         db.Campaigns.AddRange(oldCampaign1, oldCampaign2, oldCampaign3, recentCampaign, unpublishedCampaign);
 
@@ -130,12 +134,12 @@ public class CampaignDatabaseCleanUpTests : IAsyncLifetime
         }
         db.DistributionLists.AddRange(distributionLists);
 
-        var oldCampaign1 = CreateCampaign(MessageChannelKind.Email, 124, true, distributionLists[0].Id);
-        var oldCampaign2 = CreateCampaign(MessageChannelKind.Email, 170, true, distributionLists[1].Id);
-        var oldCampaign3 = CreateCampaign(MessageChannelKind.Email, 129, true, distributionLists[2].Id);
+        var oldCampaign1 = CreateCampaign(MessageChannelKind.Email, RetentionDaysForOther + 4, true, distributionLists[0].Id);
+        var oldCampaign2 = CreateCampaign(MessageChannelKind.Email, RetentionDaysForOther + 50, true, distributionLists[1].Id);
+        var oldCampaign3 = CreateCampaign(MessageChannelKind.Email, RetentionDaysForOther + 9, true, distributionLists[2].Id);
 
-        var recentCampaign = CreateCampaign(MessageChannelKind.Email, 10, true, distributionLists[3].Id);
-        var unpublishedCampaign = CreateCampaign(MessageChannelKind.Email, 135, false, distributionLists[4].Id);
+        var recentCampaign = CreateCampaign(MessageChannelKind.Email, RetentionDaysForOther - 110, true, distributionLists[3].Id);
+        var unpublishedCampaign = CreateCampaign(MessageChannelKind.Email, RetentionDaysForOther + 15, false, distributionLists[4].Id);
 
         db.Campaigns.AddRange(oldCampaign1, oldCampaign2, oldCampaign3, recentCampaign, unpublishedCampaign);
 
@@ -184,7 +188,7 @@ public class CampaignDatabaseCleanUpTests : IAsyncLifetime
         };
         db.DistributionLists.Add(distributionList);
 
-        var campaignWithActivePeriod = CreateCampaign(MessageChannelKind.Email, 135, true, distributionList.Id);
+        var campaignWithActivePeriod = CreateCampaign(MessageChannelKind.Email, RetentionDaysForOther + 15, true, distributionList.Id);
         campaignWithActivePeriod.ActivePeriod = new Types.Period {
             From = DateTimeOffset.UtcNow.AddDays(-10), // Active period started 10 days ago
             To = DateTimeOffset.UtcNow.AddDays(10)


### PR DESCRIPTION
Renamed DeleteAttachments to DeleteAttachmentsAndFiles in MessagingDatabaseCleanUpService to clarify that both files and DB records are deleted. Added explicit configuration for MessagingDatabaseCleanUpOptions in HostBuilderExtensions to ensure proper setup of retention periods, batch size, and enablement.