### PR TITLE
[identity] add `IsMachine` extension and  `identity:users.read` claim type for read-only operation is UserApi

### DIFF
--- a/src/Indice.Common/Security/ClaimsPrincipalExtensions.cs
+++ b/src/Indice.Common/Security/ClaimsPrincipalExtensions.cs
@@ -77,6 +77,12 @@ public static class ClaimsPrincipalExtensions
         return isSystem ?? false;
     }
 
+    /// <summary>Checks if the current principal is a machine user. A machine user is a principal that is authenticated but does not have a subject id claim.</summary>
+    /// <param name="principal">The current principal.</param>
+    /// <returns></returns>
+    public static bool IsMachine(this ClaimsPrincipal principal) =>
+        principal.Identity?.IsAuthenticated is true && principal.FindSubjectId() is null;
+
     /// <summary>Checks if the current principal is a system admin.</summary>
     /// <param name="principal">The current principal.</param>
     public static bool IsAdmin(this ClaimsPrincipal principal) => FindFirstValue<bool>(principal, BasicClaimTypes.Admin) ?? principal.HasRoleClaim("Administrator");

--- a/src/Indice.Features.Identity.Server/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Indice.Features.Identity.Server/Extensions/ServiceCollectionExtensions.cs
@@ -294,7 +294,7 @@ public static class IdentityServerEndpointServiceCollectionExtensions
             authOptions.AddPolicy(IdentityEndpoints.Policies.BeUsersReader, policy => {
                 policy.AddAuthenticationSchemes(IdentityEndpoints.AuthenticationScheme)
                       .RequireAuthenticatedUser()
-                      .RequireAssertion(x => x.User.HasScope(IdentityEndpoints.SubScopes.Users) && x.User.CanReadUsers());
+                      .RequireAssertion(x => (x.User.HasScope(IdentityEndpoints.SubScopes.Users) && x.User.CanReadUsers()) || (x.User.HasScope(IdentityEndpoints.SubScopes.UsersRead) && x.User.IsMachine()));
             });
             authOptions.AddPolicy(IdentityEndpoints.Policies.BeUsersWriter, policy => {
                 policy.AddAuthenticationSchemes(IdentityEndpoints.AuthenticationScheme)
@@ -334,7 +334,7 @@ public static class IdentityServerEndpointServiceCollectionExtensions
             authOptions.AddPolicy(IdentityEndpoints.Policies.BeLogsReader, policy => {
                 policy.AddAuthenticationSchemes(IdentityEndpoints.AuthenticationScheme)
                       .RequireAuthenticatedUser()
-                      .RequireAssertion(x => x.User.HasScope(IdentityEndpoints.SubScopes.Logs) && x.User.CanReadUsers());
+                      .RequireAssertion(x => (x.User.HasScope(IdentityEndpoints.SubScopes.Logs) && x.User.CanReadUsers()) || (x.User.HasScope(IdentityEndpoints.SubScopes.Logs) && x.User.IsMachine()));
             });
             authOptions.AddPolicy(IdentityEndpoints.Policies.BeLogsWriter, policy => {
                 policy.AddAuthenticationSchemes(IdentityEndpoints.AuthenticationScheme)

--- a/src/Indice.Features.Identity.Server/Manager/IdentityEndpoints.cs
+++ b/src/Indice.Features.Identity.Server/Manager/IdentityEndpoints.cs
@@ -21,6 +21,8 @@ public static partial class IdentityEndpoints
         public const string Clients = "identity:clients";
         /// <summary>A scope that allows managing users on IdentityServer.</summary>
         public const string Users = "identity:users";
+        /// <summary>A scope that allows reading users on IdentityServer.</summary>
+        public const string UsersRead = "identity:users.read";
         /// <summary>A scope that allows using the totp endpoints on IdentityServer.</summary>
         public const string Totp = "identity:totp";
         /// <summary>A scope that allows reading the secret for a user device.</summary>

--- a/src/Indice.Features.Identity.Server/Manager/UsersApi.cs
+++ b/src/Indice.Features.Identity.Server/Manager/UsersApi.cs
@@ -22,7 +22,7 @@ public static class UsersApi
         group.WithTags("Users");
         group.WithGroupName("identity");
         // Add security requirements, all incoming requests to this API *must* be authenticated with a valid user.
-        var allowedScopes = new[] { options.ApiScope, IdentityEndpoints.SubScopes.Users }.FilterOutNulls().ToArray();
+        var allowedScopes = new[] { options.ApiScope, IdentityEndpoints.SubScopes.Users , IdentityEndpoints.SubScopes.UsersRead }.FilterOutNulls().ToArray();
         group.RequireAuthorization(policy => policy
              .RequireAuthenticatedUser()
              .AddAuthenticationSchemes(IdentityEndpoints.AuthenticationScheme)


### PR DESCRIPTION
This pull request introduces support for a new `users.read` scope, enabling machine users to access user and log reading endpoints with more granular permissions. It also updates authorization policies to recognize machine users and allows them to use the new scope. The most important changes are summarized below:

**Authorization Policy Updates:**

* Updated the `BeUsersReader` policy to allow access if a principal has the new `users.read` scope and is a machine user, in addition to the existing requirements.
* Updated the `BeLogsReader` policy to allow access if the principal has the `logs` scope and is a machine user, in addition to the existing requirements.

**Scope and API Changes:**

* Added the new `UsersRead` scope (`identity:users.read`) to the `SubScopes` class for granular user read access.
* Updated the allowed scopes for the users API to include the new `users.read` scope, enabling clients with this scope to access user management endpoints.

**ClaimsPrincipal Extension:**

* Added an `IsMachine` extension method to `ClaimsPrincipal` to identify machine users (authenticated principals without a subject id claim).