### PR TITLE
[identity] fix Client Store Cache Invalidation

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,7 +8,7 @@
     <VersionPrefixBase>$(VersionPrefixMajor).43</VersionPrefixBase>
 
     <VersionPrefixCore>$(VersionPrefixBase).1</VersionPrefixCore>
-    <VersionPrefixIdentity>$(VersionPrefixBase).1</VersionPrefixIdentity>
+    <VersionPrefixIdentity>$(VersionPrefixBase).2</VersionPrefixIdentity>
     <VersionPrefixIdentityUI>$(VersionPrefixBase).1</VersionPrefixIdentityUI>
     <VersionPrefixCases>$(VersionPrefixBase).3</VersionPrefixCases>
     <VersionPrefixMessages>$(VersionPrefixBase).2</VersionPrefixMessages>

--- a/src/Indice.Features.Identity.Server/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Indice.Features.Identity.Server/Extensions/ServiceCollectionExtensions.cs
@@ -178,10 +178,10 @@ public static class IdentityServerEndpointServiceCollectionExtensions
         // Add store decorators for caching after calling AddDotnet7CompatibleStores.
         .AddInMemoryCaching()
         .AddClientStoreCache<IndiceStores.ClientStore>()
-        .AddClientStoreCacheInvalidation()
         .AddResourceStoreCache<IndiceStores.ResourceStore>()
         .AddCorsPolicyCache<CorsPolicyService>()
 #endif
+        .AddClientStoreCacheInvalidation()
         ;
         if (webHostEnvironment.IsDevelopment()) {
             IdentityModelEventSource.ShowPII = true;


### PR DESCRIPTION
Reordered service registration to call AddClientStoreCacheInvalidation in IdentityServer endpoint setup.