### PR TITLE
[aspnetcore] Fix array item schema initialization in transformer

### DIFF
--- a/src/Indice.AspNetCore/OpenApi/Transformers/MappedTypeTransformer.net9.cs
+++ b/src/Indice.AspNetCore/OpenApi/Transformers/MappedTypeTransformer.net9.cs
@@ -99,7 +99,7 @@ public static class MappedTypeTransformer
                     continue;
                 }
                 if (property.Type == "array" && jsonProperty.PropertyType.TryGetAnyElementType(out var elementType) && transforms.ContainsKey(elementType!)) {
-                    schema.Items ??= new OpenApiSchema();
+                    property.Items ??= new OpenApiSchema();
                     TransformSchema(property.Items, elementType!, nullable: null);
                     continue;
                 }


### PR DESCRIPTION
Replaced schema.Items with property.Items when handling array types to ensure the correct OpenApiSchema instance is initialized and transformed. This prevents potential issues with referencing the wrong schema variable during transformation.