### PR TITLE
[identity-ui] - Make production environments configurable in Identity UI

### DIFF
--- a/src/Indice.Features.Identity.UI/IdentityBuilderUIExtensions.cs
+++ b/src/Indice.Features.Identity.UI/IdentityBuilderUIExtensions.cs
@@ -18,6 +18,7 @@ using Microsoft.AspNetCore.Mvc.Razor.Compilation;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
 
 
 #if NET9_0_OR_GREATER
@@ -66,6 +67,7 @@ public static class IdentityBuilderUIExtensions
             foreach (var url in configuredOptions.ValidReturnUrls) {
                 options.ValidReturnUrls.Add(url);
             }
+            options.ProductionEnvironments = new StringValues(options.ProductionEnvironments.Concat(configuredOptions.ProductionEnvironments).ToArray());
         });
 #if NET9_0_OR_GREATER
         services.AddSingleton<IConfigureOptions<IdentityServerOptions>, IdentityServerOptionsConfigure>();

--- a/src/Indice.Features.Identity.UI/IdentityBuilderUIExtensions.cs
+++ b/src/Indice.Features.Identity.UI/IdentityBuilderUIExtensions.cs
@@ -67,7 +67,8 @@ public static class IdentityBuilderUIExtensions
             foreach (var url in configuredOptions.ValidReturnUrls) {
                 options.ValidReturnUrls.Add(url);
             }
-            options.ProductionEnvironments = new StringValues(options.ProductionEnvironments.Concat(configuredOptions.ProductionEnvironments).ToArray());
+            options.ProductionEnvironments = new StringValues(options.ProductionEnvironments.Concat(configuredOptions.ProductionEnvironments)
+                                                                                            .Distinct(StringComparer.OrdinalIgnoreCase).ToArray());
         });
 #if NET9_0_OR_GREATER
         services.AddSingleton<IConfigureOptions<IdentityServerOptions>, IdentityServerOptionsConfigure>();

--- a/src/Indice.Features.Identity.UI/IdentityUIOptions.cs
+++ b/src/Indice.Features.Identity.UI/IdentityUIOptions.cs
@@ -96,7 +96,7 @@ public class IdentityUIOptions
     /// <summary>
     /// A collection of production environment names. Used to determine whether the environment is production and exclude the ribbon in the UI.
     /// </summary>
-    public StringValues ProductionEnvironments { get; set; } = new StringValues(new[] { "prod", "production", "live" });
+    public StringValues ProductionEnvironments { get; set; } = new StringValues([ "prod", "Production", "live" ]);
 
     /// <summary>Services shown in the homepage.</summary>
     public List<HomePageLink> HomepageLinks { get; } = new List<HomePageLink>() {

--- a/src/Indice.Features.Identity.UI/IdentityUIOptions.cs
+++ b/src/Indice.Features.Identity.UI/IdentityUIOptions.cs
@@ -2,6 +2,7 @@
 using Indice.Features.Identity.Core.Data.Models;
 using Indice.Security;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
 
 namespace Indice.Features.Identity.UI;
 
@@ -91,6 +92,11 @@ public class IdentityUIOptions
     /// Used with <see cref="Indice.Globalization.PhoneNumber"/> instances to convert to predictable string for storage.
     /// </summary>
     public string PhoneNumberStoreFormat => EnablePhoneNumberCallingCodes ? "G" : "N";
+
+    /// <summary>
+    /// A collection of production environment names. Used to determine whether the environment is production and exclude the ribbon in the UI.
+    /// </summary>
+    public StringValues ProductionEnvironments { get; set; } = new StringValues(new[] { "prod", "production", "live" });
 
     /// <summary>Services shown in the homepage.</summary>
     public List<HomePageLink> HomepageLinks { get; } = new List<HomePageLink>() {

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/_IdentityLayout.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/_IdentityLayout.cshtml
@@ -42,7 +42,7 @@
     <partial name="_Styles" />
     @RenderSection("css", required: false)
     <partial name="_Header" />
-    <environment exclude="Production">
+    <environment exclude="@UiOptions.Value.ProductionEnvironments">
         <div class="ribbon @Environment.EnvironmentName.ToLower()">
             <span>@Environment.EnvironmentName</span>
         </div>

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/_IdentityMasterLayout.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/_IdentityMasterLayout.cshtml
@@ -41,7 +41,7 @@
     <partial name="_Styles" />
     @RenderSection("css", required: false)
     @RenderSection("aside", required: false)
-    <environment exclude="Production">
+    <environment exclude="@UiOptions.Value.ProductionEnvironments">
         <div class="ribbon @Environment.EnvironmentName.ToLower()">
             <span>@Environment.EnvironmentName</span>
         </div>

--- a/src/Indice.Features.Identity.UI/wwwroot/css/bootstrap.scss
+++ b/src/Indice.Features.Identity.UI/wwwroot/css/bootstrap.scss
@@ -48,4 +48,7 @@ $h6-font-size: $font-size-base;
 $link-decoration: none;
 $link-hover-decoration: underline;
 
+$list-group-active-color: #000;
+$list-group-active-bg: transparent;
+
 @import 'bootstrap/scss/bootstrap';


### PR DESCRIPTION
- Added ProductionEnvironments option to IdentityUIOptions, allowing customization of which environment names are treated as production (defaulting to "prod", "production", "live"). 
- Updated layout files to use this configurable list for ribbon exclusion. Enabled merging of environment names from configuration.
- Also added minor list group style tweaks in bootstrap.scss.