### PR TITLE
[core] Update Azure packages due to Microsoft.Azure.Functions.Worker.Grpc incompatibility

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,13 +5,13 @@
     <!--<TargetFramework></TargetFramework>-->
 
     <VersionPrefixMajor>8</VersionPrefixMajor>
-    <VersionPrefixBase>$(VersionPrefixMajor).44</VersionPrefixBase>
+    <VersionPrefixBase>$(VersionPrefixMajor).45</VersionPrefixBase>
 
     <VersionPrefixCore>$(VersionPrefixBase).0</VersionPrefixCore>
     <VersionPrefixIdentity>$(VersionPrefixBase).0</VersionPrefixIdentity>
-    <VersionPrefixIdentityUI>$(VersionPrefixBase).1</VersionPrefixIdentityUI>
+    <VersionPrefixIdentityUI>$(VersionPrefixBase).0</VersionPrefixIdentityUI>
     <VersionPrefixCases>$(VersionPrefixBase).0</VersionPrefixCases>
-    <VersionPrefixMessages>$(VersionPrefixBase).1</VersionPrefixMessages>
+    <VersionPrefixMessages>$(VersionPrefixBase).0</VersionPrefixMessages>
     <VersionPrefixMultitenancy>$(VersionPrefixBase).0</VersionPrefixMultitenancy>
     <VersionPrefixRisk>$(VersionPrefixBase).0</VersionPrefixRisk>
     <VersionPrefixMedia>$(VersionPrefixBase).0</VersionPrefixMedia>

--- a/src/Indice.Features.Messages.Worker.Azure/Indice.Features.Messages.Worker.Azure.csproj
+++ b/src/Indice.Features.Messages.Worker.Azure/Indice.Features.Messages.Worker.Azure.csproj
@@ -8,9 +8,9 @@
     <PackageReference Include="Indice.Features.Messages.Core" Version="$(VersionPrefixMessages)-*" />
     <PackageReference Include="Indice.Features.Multitenancy.Worker.Azure" Version="$(VersionPrefixMultitenancy)-*" />
     <PackageReference Include="Indice.Services" Version="$(VersionPrefixCore)-*" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues" Version="5.5.3" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues" Version="5.5.4" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.24.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="2.51.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="2.52.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">

--- a/src/Indice.Features.Multitenancy.Worker.Azure/Indice.Features.Multitenancy.Worker.Azure.csproj
+++ b/src/Indice.Features.Multitenancy.Worker.Azure/Indice.Features.Multitenancy.Worker.Azure.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Indice.Features.Multitenancy.Core" Version="$(VersionPrefixMultitenancy)-*" />
     <PackageReference Include="Indice.Services" Version="$(VersionPrefixCore)-*" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.51.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Indice.Features.Multitenancy.Core\Indice.Features.Multitenancy.Core.csproj" />

--- a/src/Indice.Functions.Builder/Indice.Functions.Builder.csproj
+++ b/src/Indice.Functions.Builder/Indice.Functions.Builder.csproj
@@ -5,7 +5,7 @@
     <VersionPrefix>$(VersionPrefixAspNet)</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.51.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
     <!--Open Telemetry Packages-->


### PR DESCRIPTION
…ns.Worker.Grpc version mismatch inside Azure Functions

Updated Microsoft.Azure.Functions.Worker and related packages to latest patch versions across multiple projects. Incremented version base to 45 in Directory.Build.props and set IdentityUI/Messages VersionPrefix to .0.