### PR TITLE
[identity] - Add device id generation in PasswordExpired flow

### DIFF
--- a/src/Indice.Features.Identity.Core/Events/Models/DeviceEventContext.cs
+++ b/src/Indice.Features.Identity.Core/Events/Models/DeviceEventContext.cs
@@ -1,0 +1,37 @@
+﻿using Indice.Types;
+
+namespace Indice.Features.Identity.Core.Events.Models;
+
+/// <summary>Models a user agent (browser) type.</summary>
+public class DeviceEventContext
+{
+    /// <summary>The device model.</summary>
+    public string? Model { get; set; }
+    /// <summary>The device platform.</summary>
+    public DevicePlatform Platform { get; set; }
+    /// <summary>The raw value of the 'UserAgent' header.</summary>
+    public string UserAgent { get; set; } = null!;
+    /// <summary>Browser display name.</summary>
+    public string DisplayName { get; set; } = null!;
+    /// <summary>The operating system name.</summary>
+    public string? Os { get; set; }
+    /// <summary>The httpclient used to serve this request. Can be a browser app or a custom native application</summary>
+    public string UserAgentFamily { get; set; } = "Unknown";
+
+    /// <summary>
+    /// Creates a new instance of <see cref="DeviceEventContext"/> from a user agent string. 
+    /// </summary>
+    /// <param name="userAgent">The user agent string.</param>
+    /// <returns>A new instance of <see cref="DeviceEventContext"/>.</returns>
+    public static DeviceEventContext FromUserAgent(string? userAgent) {
+        userAgent = string.IsNullOrWhiteSpace(userAgent) ?  "Unknown" : userAgent;
+        var parser = new Indice.AspNetCore.UserAgent(userAgent);
+        return new DeviceEventContext {
+            UserAgent = userAgent,
+            DisplayName = parser.DisplayName,
+            Os = parser.Os,
+            Platform = parser.DevicePlatform,
+            UserAgentFamily = parser.UserAgentFamily
+        };
+    }
+}

--- a/src/Indice.Features.Identity.Core/Events/SecurityNotificationEvent.cs
+++ b/src/Indice.Features.Identity.Core/Events/SecurityNotificationEvent.cs
@@ -25,7 +25,7 @@ public class SecurityNotificationEvent : IPlatformEvent
     /// <summary>The user's email address.</summary>
     public IPAddressLocation Location { get; set; } = null!;
     /// <summary>The device metadata.</summary>
-    public DeviceEventContext Device { get; set; } = null!;
+    public DeviceEventContext Device { get; set; } = DeviceEventContext.FromUserAgent(null);
     /// <summary>The device that initiated the password change, if any.</summary>
     public UserDeviceEventContext? UserDevice { get; set; }
     /// <summary>The client that initiated the password change, if any.</summary>

--- a/src/Indice.Features.Identity.Core/Events/SecurityNotificationEvent.cs
+++ b/src/Indice.Features.Identity.Core/Events/SecurityNotificationEvent.cs
@@ -24,8 +24,10 @@ public class SecurityNotificationEvent : IPlatformEvent
     public UserEventContext User { get; set; } = null!;
     /// <summary>The user's email address.</summary>
     public IPAddressLocation Location { get; set; } = null!;
+    /// <summary>The device metadata.</summary>
+    public DeviceEventContext Device { get; set; } = null!;
     /// <summary>The device that initiated the password change, if any.</summary>
-    public UserDeviceEventContext? Device { get; set; }
+    public UserDeviceEventContext? UserDevice { get; set; }
     /// <summary>The client that initiated the password change, if any.</summary>
     public ClientEventContext? Client { get; set; }
     /// <summary>Gets or sets the timestamp indicating when the event occurred.</summary>

--- a/src/Indice.Features.Identity.Core/ExtendedSignInManager.cs
+++ b/src/Indice.Features.Identity.Core/ExtendedSignInManager.cs
@@ -176,11 +176,8 @@ public class ExtendedSignInManager<TUser> : SignInManager<TUser> where TUser : U
             userDevice.LastSignInDate = DateTimeOffset.UtcNow;
             await ExtendedUserManager.UpdateDeviceAsync(user, userDevice);
         }
-        if (RememberExpirationType == MfaExpirationType.Sliding) {
-            var authenticateResult = await Context.AuthenticateAsync(IdentityConstants.TwoFactorRememberMeScheme);
-            if (authenticateResult.Succeeded && authenticateResult.Principal is not null) {
-                await RememberTwoFactorClientAsync(user);
-            }
+        if (RememberExpirationType == MfaExpirationType.Sliding && await IsTwoFactorClientRememberedAsync(user)) {
+            await RememberTwoFactorClientAsync(user);
         }
 
         List<string> authenticationMethods = [loginProvider ?? "pwd"];
@@ -358,11 +355,19 @@ public class ExtendedSignInManager<TUser> : SignInManager<TUser> where TUser : U
     /// <param name="user"></param>
     /// <returns>The device identifier</returns>
     public async Task<MfaDeviceIdentifier> GetMfaDeviceIdentifierAsync(TUser user) {
+        if (Context.Items.TryGetValue(BasicClaimTypes.DeviceId, out var deviceItBoxed) 
+            && deviceItBoxed is MfaDeviceIdentifier deviceId) {
+            return deviceId;
+        }
         var result = await Context.AuthenticateAsync(IdentityConstants.TwoFactorRememberMeScheme);
         if (!result.Succeeded || result.Principal?.FindSubjectId() != user.Id) {
+            deviceId = Context.ResolveDeviceId();
+            Context.Items.Add(BasicClaimTypes.DeviceId, deviceId);
             return Context.ResolveDeviceId();
         }
-        return new MfaDeviceIdentifier(result.Principal.FindFirstValue(BasicClaimTypes.DeviceId));
+        deviceId = new MfaDeviceIdentifier(result.Principal.FindFirstValue(BasicClaimTypes.DeviceId));
+        Context.Items.Add(BasicClaimTypes.DeviceId, deviceId);
+        return deviceId;
     }
     #endregion
 

--- a/src/Indice.Features.Identity.Core/Models/SecurityNotificationModel.cs
+++ b/src/Indice.Features.Identity.Core/Models/SecurityNotificationModel.cs
@@ -11,15 +11,15 @@ public class SecurityNotificationModel
 {
     /// <summary>The user instance.</summary>
     public UserEventContext User { get; set; } = null!;
+    /// <summary>The device metadata.</summary>
+    public DeviceEventContext Device { get; set; } = null!;
     /// <summary>The device that initiated the password change, if any.</summary>
-    public UserDeviceEventContext? Device { get; set; }
+    public UserDeviceEventContext? UserDevice { get; set; }
     /// <summary>The client that initiated the password change, if any.</summary>
     public ClientEventContext? Client { get; set; }
     /// <summary>The user's email address.</summary>
     public IPAddressLocation Location { get; set; } = null!;
-    /// <summary>
-    /// Gets or sets the timestamp indicating when the event occurred.
-    /// </summary>
+    /// <summary>Gets or sets the timestamp indicating when the event occurred.</summary>
     public DateTimeOffset TimeStamp { get; set; } = DateTimeOffset.UtcNow;
     /// <summary>The username</summary>
     public string? UserName => User?.UserName;

--- a/src/Indice.Features.Identity.SignInLogs/EventHandlers/AccountLockedEventHandler.cs
+++ b/src/Indice.Features.Identity.SignInLogs/EventHandlers/AccountLockedEventHandler.cs
@@ -61,15 +61,14 @@ public sealed class AccountLockedEventHandler : IPlatformEventHandler<AccountLoc
         var claims = await userManager.GetClaimsAsync(user!);
         var userLocale = claims.FirstOrDefault(c => c.Type == BasicClaimTypes.Locale)?.Value;
 
-        UserDevice? device = null;
+        UserDevice? userDevice = null;
+        var userAgentHeader = _httpContextAccessor?.HttpContext?.Request.Headers[HeaderNames.UserAgent];
+
         if (!deviceId.IsEmpty) {
             // If the device id is available populate data.
-            device = await userManager.GetDeviceByIdAsync(user!, deviceId.Value!);
-        }
-        if (device is null) {
-            var userAgentHeader = _httpContextAccessor?.HttpContext?.Request.Headers[HeaderNames.UserAgent];
-            if (!string.IsNullOrWhiteSpace(userAgentHeader)) {
-                device = UserDevice.FromUserAgent(userAgentHeader!, deviceId, @event.User.Id, 0);
+            userDevice = await userManager.GetDeviceByIdAsync(user!, deviceId.Value!);
+            if (userDevice is null && !string.IsNullOrWhiteSpace(userAgentHeader)) {
+                userDevice = UserDevice.FromUserAgent(userAgentHeader!, deviceId, @event.User.Id, 0);
             }
         }
         Client? client = null;
@@ -77,7 +76,8 @@ public sealed class AccountLockedEventHandler : IPlatformEventHandler<AccountLoc
             client = await _clientStore.FindClientByIdAsync(clientId);
         }
         await _platformEvents.Publish(new SecurityNotificationEvent(nameof(AccountLockedEvent), UserEventContext.InitializeFromUser(user!), ipLocation) {
-            Device = device is not null ? UserDeviceEventContext.InitializeFromUserDevice(device) : null,
+            UserDevice = userDevice is not null ? UserDeviceEventContext.InitializeFromUserDevice(userDevice) : null,
+            Device = DeviceEventContext.FromUserAgent(userAgentHeader),
             Client = client is not null ? ClientEventContext.InitializeFromClient(client) : null,
             TimeStamp = DateTimeOffset.UtcNow,
             Locale = userLocale

--- a/src/Indice.Features.Identity.SignInLogs/EventHandlers/UserPasswordChangedEventHandler.cs
+++ b/src/Indice.Features.Identity.SignInLogs/EventHandlers/UserPasswordChangedEventHandler.cs
@@ -61,23 +61,24 @@ public sealed class UserPasswordChangedEventHandler : IPlatformEventHandler<Pass
         var claims = await userManager.GetClaimsAsync(user!);
         var userLocale = claims.FirstOrDefault(c => c.Type == BasicClaimTypes.Locale)?.Value;
 
-        UserDevice? device = null;
+        UserDevice? userDevice = null;
+        var userAgentHeader = _httpContextAccessor?.HttpContext?.Request.Headers[HeaderNames.UserAgent];
+
         if (!deviceId.IsEmpty) {
             // If the device id is available populate data.
-            device = await userManager.GetDeviceByIdAsync(user!, deviceId.Value!);
-        }
-        if (device is null) {
-            var userAgentHeader = _httpContextAccessor?.HttpContext?.Request.Headers[HeaderNames.UserAgent];
-            if (!string.IsNullOrWhiteSpace(userAgentHeader)) {
-                device = UserDevice.FromUserAgent(userAgentHeader!, deviceId, @event.User.Id, 0);
+            userDevice = await userManager.GetDeviceByIdAsync(user!, deviceId.Value!);
+            if (userDevice is null && !string.IsNullOrWhiteSpace(userAgentHeader)) {
+                userDevice = UserDevice.FromUserAgent(userAgentHeader!, deviceId, @event.User.Id, 0);
             }
         }
+
         Client? client = null;
         if (!string.IsNullOrWhiteSpace(clientId)) {
             client = await _clientStore.FindClientByIdAsync(clientId);
         }
         await _platformEvents.Publish(new SecurityNotificationEvent(nameof(PasswordChangedEvent), UserEventContext.InitializeFromUser(user!), ipLocation) {
-            Device = device is not null ? UserDeviceEventContext.InitializeFromUserDevice(device) : null,
+            UserDevice = userDevice is not null ? UserDeviceEventContext.InitializeFromUserDevice(userDevice) : null,
+            Device = DeviceEventContext.FromUserAgent(userAgentHeader),
             Client = client is not null ? ClientEventContext.InitializeFromClient(client) : null,
             TimeStamp = DateTimeOffset.UtcNow,
             Locale = userLocale

--- a/src/Indice.Features.Identity.UI/EventHandlers/SecurityNotificationEventHandler.cs
+++ b/src/Indice.Features.Identity.UI/EventHandlers/SecurityNotificationEventHandler.cs
@@ -1,5 +1,6 @@
 ﻿using Indice.Events;
 using Indice.Features.Identity.Core;
+using Indice.Features.Identity.Core.Events.Models;
 using Indice.Features.Identity.Core.Models;
 using Indice.Features.Identity.SignInLogs.Events;
 using Indice.Localization;
@@ -47,7 +48,7 @@ public class SecurityNotificationEventHandler : IPlatformEventHandler<SecurityNo
                         Location = @event.Location,
                         TimeStamp = @event.LocalTimeStamp,
                         Client = @event.Client,
-                        Device = @event.Device,
+                        Device = @event.Device ?? DeviceEventContext.FromUserAgent(null),
                         UserDevice = @event.UserDevice,
                         DisplayName = @event.User.UserName,
                         Subject = subject,

--- a/src/Indice.Features.Identity.UI/EventHandlers/SecurityNotificationEventHandler.cs
+++ b/src/Indice.Features.Identity.UI/EventHandlers/SecurityNotificationEventHandler.cs
@@ -48,13 +48,13 @@ public class SecurityNotificationEventHandler : IPlatformEventHandler<SecurityNo
                         TimeStamp = @event.LocalTimeStamp,
                         Client = @event.Client,
                         Device = @event.Device,
+                        UserDevice = @event.UserDevice,
                         DisplayName = @event.User.UserName,
                         Subject = subject,
                         Description = description,
                     })
                     .UsingTemplate("EmailSecurityNotification");
             });
-
         }
     }
 }

--- a/src/Indice.Features.Identity.UI/Models/PasswordExpiredInputModel.cs
+++ b/src/Indice.Features.Identity.UI/Models/PasswordExpiredInputModel.cs
@@ -9,4 +9,6 @@ public class PasswordExpiredInputModel
     public string? NewPasswordConfirmation { get; set; }
     /// <summary>The return URL.</summary>
     public string? ReturnUrl { get; set; }
+    /// <summary>Device Id.</summary>
+    public string? DeviceId { get; set; }
 }

--- a/src/Indice.Features.Identity.UI/Models/PasswordExpiredViewModel.cs
+++ b/src/Indice.Features.Identity.UI/Models/PasswordExpiredViewModel.cs
@@ -1,0 +1,8 @@
+﻿namespace Indice.Features.Identity.UI.Models;
+
+/// <summary> View model for the password expired page. </summary>
+public class PasswordExpiredViewModel
+{
+    /// <summary>Indicates whether to generate a device ID.</summary>
+    public bool GenerateDeviceId { get; set; } = true;
+}

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/PasswordExpired.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/PasswordExpired.cshtml
@@ -64,8 +64,8 @@
     <script type="text/javascript" src="~/js/reveal-password.js" csp-nonce="true"></script>
     @if (Model.View.GenerateDeviceId)
     {
-        <script type="text/javascript" src="/lib/@@fingerprintjs/fingerprintjs/dist/fp.min.js" csp-nonce></script>
-        <script type="text/javascript" src="/js/mfa.js" csp-nonce></script>
+        <script type="text/javascript" src="~/lib/@@fingerprintjs/fingerprintjs/dist/fp.min.js" csp-nonce></script>
+        <script type="text/javascript" src="~/js/mfa.js" csp-nonce></script>
         <script type="text/javascript" csp-nonce>
             $(document).ready(function () {
                 var viewModelParameters = {

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/PasswordExpired.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/PasswordExpired.cshtml
@@ -15,6 +15,7 @@
     <partial name="_Alert" model="tempData?.Alert" />
     <form asp-route-returnUrl="@Model.Input.ReturnUrl" method="post" data-sbind="event: { change: formChanged }" data-token="@Base64Id.Parse(User.FindSubjectId()!)" data-userName="@(User.FindFirstValue(JwtClaimTypes.Name) ?? string.Empty)">
         <input type="hidden" asp-for="Input.ReturnUrl" />
+        <input asp-for="Input.DeviceId" type="hidden" />
         <div class="mb-3" indice-if="@(tempData?.DisableForm != true)">
             <label asp-for="Input.NewPassword" class="form-label visually-hidden">@Localizer.PasswordExpired_New_Password</label>
             <div class="password-control">
@@ -61,4 +62,20 @@
     <script type="text/javascript" src="~/js/utilities.js" csp-nonce="true"></script>
     <script type="text/javascript" src="~/js/password-rules.js" csp-nonce="true"></script>
     <script type="text/javascript" src="~/js/reveal-password.js" csp-nonce="true"></script>
+    @if (Model.View.GenerateDeviceId)
+    {
+        <script type="text/javascript" src="/lib/@@fingerprintjs/fingerprintjs/dist/fp.min.js" csp-nonce></script>
+        <script type="text/javascript" src="/js/mfa.js" csp-nonce></script>
+        <script type="text/javascript" csp-nonce>
+            $(document).ready(function () {
+                var viewModelParameters = {
+                    $deviceIdInput: $('#Input_DeviceId'),
+                    browserFamily: '@Request.GetBrowserName()'
+                };
+                var viewModel = new indice.mfaViewModelFactory(viewModelParameters);
+                viewModel.init();
+                viewModel.calculateDeviceId();
+            });
+        </script>
+    }
 }

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/EmailSecurityNotification.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/EmailSecurityNotification.cshtml
@@ -35,9 +35,13 @@
         <li>@Localizer.EmailSecurity_Body_EventTime: @Model.TimeStamp.ToString()</li>
         <li>@Localizer.EmailSecurity_Body_Username: @Model.UserName</li>
         <li>@Localizer.EmailSecurity_Body_Email: @Model.User?.Email</li>
-        @if (Model.Device != null)
+        @if (Model.UserDevice != null)
         {
-            <li>@Localizer.EmailSecurity_Body_Device: @Model.Device.Name (@Model.Device.ClientType)</li>
+            <li>@Localizer.EmailSecurity_Body_Device: @Model.UserDevice.Name (@Model.UserDevice.ClientType)</li>
+        }
+        else
+        {
+            <li>@Localizer.EmailSecurity_Body_Device: @Model.Device.DisplayName</li>
         }
         @if (Model.Client != null)
         {

--- a/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/EmailSecurityNotification.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Bootstrap5/Shared/EmailSecurityNotification.cshtml
@@ -41,7 +41,7 @@
         }
         else
         {
-            <li>@Localizer.EmailSecurity_Body_Device: @Model.Device.DisplayName</li>
+            <li>@Localizer.EmailSecurity_Body_Device: @(Model.Device?.DisplayName ?? "Unknown")</li>
         }
         @if (Model.Client != null)
         {

--- a/src/Indice.Features.Identity.UI/Pages/Mfa.cs
+++ b/src/Indice.Features.Identity.UI/Pages/Mfa.cs
@@ -100,7 +100,8 @@ public abstract class BaseMfaModel : BasePageModel
             }
             return Page();
         }
-        var signInResult = await SignInManager.TwoFactorSignInAsync(View.AuthenticationMethod?.GetTokenProvider()!, Input.OtpCode!, Input.RememberMe, Input.RememberClient);
+        var rememberMfaClient = View.IsExistingBrowser || Input.RememberClient;
+        var signInResult = await SignInManager.TwoFactorSignInAsync(View.AuthenticationMethod?.GetTokenProvider()!, Input.OtpCode!, Input.RememberMe, rememberMfaClient);
         if (signInResult.Succeeded) {
             if (string.IsNullOrEmpty(Input.ReturnUrl)) {
                 return Redirect("/");

--- a/src/Indice.Features.Identity.UI/Pages/PasswordExpired.cs
+++ b/src/Indice.Features.Identity.UI/Pages/PasswordExpired.cs
@@ -39,7 +39,7 @@ public abstract class BasePasswordExpiredModel : BasePageModel
     [BindProperty]
     public PasswordExpiredInputModel Input { get; set; } = new PasswordExpiredInputModel();
 
-    /// <summary>View model for forgot password confirmation model.</summary>
+    /// <summary>View model for the password-expired page.</summary>
     public PasswordExpiredViewModel View { get; set; } = new PasswordExpiredViewModel();
 
     /// <summary>Key used for setting and retrieving temp data.</summary>

--- a/src/Indice.Features.Identity.UI/Pages/PasswordExpired.cs
+++ b/src/Indice.Features.Identity.UI/Pages/PasswordExpired.cs
@@ -39,6 +39,9 @@ public abstract class BasePasswordExpiredModel : BasePageModel
     [BindProperty]
     public PasswordExpiredInputModel Input { get; set; } = new PasswordExpiredInputModel();
 
+    /// <summary>View model for forgot password confirmation model.</summary>
+    public PasswordExpiredViewModel View { get; set; } = new PasswordExpiredViewModel();
+
     /// <summary>Key used for setting and retrieving temp data.</summary>
     public static string TempDataKey => "info_message";
 

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/PasswordExpired.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/PasswordExpired.cshtml
@@ -16,6 +16,7 @@
         <partial name="_ValidationSummary" />
         <partial name="_Alert" model="alert" />
         <form asp-route-returnUrl="@Model.Input.ReturnUrl" method="post" data-sbind="event: { change: formChanged }" novalidate>
+            <input asp-for="Input.DeviceId" type="hidden" />
             <div indice-if="@(tempData?.DisableForm != true)" class="input-group-w-full group password-control">
                 <input class="peer password" type="password" placeholder="@Localizer.PasswordExpired_New_Password" asp-for="Input.NewPassword" disabled="@(tempData?.DisableForm == true)" autocomplete="new-password" data-sbind="event: { keyup: passwordChanged }" />
                 <label asp-for="Input.NewPassword" class="peer-focus:-translate-y-[6px] peer-focus:visible absolute">@Localizer.PasswordExpired_New_Password</label>
@@ -57,4 +58,20 @@
     <script type="text/javascript" src="~/js/utilities.js" csp-nonce="true"></script>
     <script type="text/javascript" src="~/js/password-rules.js" csp-nonce="true"></script>
     <script type="text/javascript" src="~/js/reveal-password.js" csp-nonce="true"></script>
+    @if (Model.View.GenerateDeviceId)
+    {
+        <script type="text/javascript" src="~/lib/@@fingerprintjs/fingerprintjs/dist/fp.min.js" csp-nonce></script>
+        <script type="text/javascript" src="~/js/mfa.js" csp-nonce></script>
+        <script type="text/javascript" csp-nonce>
+            $(document).ready(function () {
+                var viewModelParameters = {
+                    $deviceIdInput: $('#Input_DeviceId'),
+                    browserFamily: '@Request.GetBrowserName()'
+                };
+                var viewModel = new indice.mfaViewModelFactory(viewModelParameters);
+                viewModel.init();
+                viewModel.calculateDeviceId();
+            });
+        </script>
+    }
 }

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/EmailSecurityNotification.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/EmailSecurityNotification.cshtml
@@ -25,9 +25,13 @@
         <li>@Localizer.EmailSecurity_Body_EventTime: @Model.TimeStamp.ToString()</li>
         <li>@Localizer.EmailSecurity_Body_Username: @Model.UserName</li>
         <li>@Localizer.Email: @Model.User?.Email</li>
-        @if (Model.Device != null)
+        @if (Model.UserDevice != null)
         {
-            <li>@Localizer.EmailSecurity_Body_Device: @Model.Device.Name (@Model.Device.ClientType)</li>
+            <li>@Localizer.EmailSecurity_Body_Device: @Model.UserDevice.Name (@Model.UserDevice.ClientType)</li>
+        }
+        else
+        {
+            <li>@Localizer.EmailSecurity_Body_Device: @Model.Device.DisplayName</li>
         }
         @if (Model.Client != null)
         {

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/EmailSecurityNotification.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/Shared/EmailSecurityNotification.cshtml
@@ -31,7 +31,7 @@
         }
         else
         {
-            <li>@Localizer.EmailSecurity_Body_Device: @Model.Device.DisplayName</li>
+            <li>@Localizer.EmailSecurity_Body_Device: @(Model.Device?.DisplayName ?? "Unknown")</li>
         }
         @if (Model.Client != null)
         {


### PR DESCRIPTION
- Add device Id generation in PasswordExpired flow for both bootstrap and tailwind.
- Make password changed event handler more defensive in regards to device Id.
- Add defensive handling in UserPasswordChangedEventHandler.
- Rename DeviceEventContext  to UserDeviceEventContext in Security Notification Events.
- Introduce fallback DeviceEventContext in Security Notification Events.