### PR TITLE
[platform] Add OpenApiIgnoreAttribute support for schema exclusion

### DIFF
--- a/src/Indice.AspNetCore/OpenApi/Attributes/OpenApiIgnoreAttribute.cs
+++ b/src/Indice.AspNetCore/OpenApi/Attributes/OpenApiIgnoreAttribute.cs
@@ -1,0 +1,11 @@
+﻿#if NET10_0_OR_GREATER
+namespace Indice.AspNetCore.OpenApi.Attributes;
+
+/// <summary>
+/// Add this attribute to a property to ignore it from the OpenAPI document. This is useful for properties that are used for internal purposes 
+/// and should not be exposed in the API documentation.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property)]
+public class OpenApiIgnoreAttribute : Attribute { }
+
+#endif

--- a/src/Indice.AspNetCore/OpenApi/OpenApiExtensions.cs
+++ b/src/Indice.AspNetCore/OpenApi/OpenApiExtensions.cs
@@ -63,6 +63,7 @@ public static class OpenApiExtensions
         options.AddEndpointSecurityRequirementsTransformer();
         options.AddDocumentTransformer<CanonicalDocumentTransformer>();
         options.AddExamplesTransformer();
+        options.AddOpenApiIgnoreTransformer();
         return options;
     }
 

--- a/src/Indice.AspNetCore/OpenApi/Transformers/OpenApiIgnoreTransformer.cs
+++ b/src/Indice.AspNetCore/OpenApi/Transformers/OpenApiIgnoreTransformer.cs
@@ -1,0 +1,46 @@
+﻿#if NET10_0_OR_GREATER
+using System.Reflection;
+using Indice.AspNetCore.OpenApi.Attributes;
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Provides functionality to remove properties decorated with <see cref="OpenApiIgnoreAttribute"/> from OpenAPI schema generation.
+/// </summary>
+public static class OpenApiIgnoreTransformer
+{
+    /// <summary>
+    /// Adds a schema transformer to the specified OpenAPI options that removes properties
+    /// marked with <see cref="OpenApiIgnoreAttribute"/> from the generated schema.
+    /// </summary>
+    /// <param name="options">The <see cref="OpenApiOptions"/> instance to which the transformer will be added.</param>
+    /// <returns>The <see cref="OpenApiOptions"/> instance with the ignore transformer added.</returns>
+    public static OpenApiOptions AddOpenApiIgnoreTransformer(this OpenApiOptions options) {
+        options.AddSchemaTransformer(TransformAsync);
+        return options;
+    }
+
+    private static Task TransformAsync(OpenApiSchema schema, OpenApiSchemaTransformerContext context, CancellationToken cancellationToken) {
+        if (schema.Properties?.Count == 0) {
+            return Task.CompletedTask;
+        }
+
+        // find all properties of the type that are decorated with the OpenApiIgnoreAttribute 
+        var propertiesToIgnoreFromOpenApi = context.JsonTypeInfo.Type
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(x => x.IsDefined(typeof(OpenApiIgnoreAttribute), inherit: true))
+            .Select(x => schema.Properties!.Keys.FirstOrDefault(k => k.Equals(x.Name, StringComparison.OrdinalIgnoreCase)))
+            .Where(x => x is not null)
+            .ToList();
+
+        foreach (var property in propertiesToIgnoreFromOpenApi) {
+            schema.Properties?.Remove(property!);
+            schema.Required?.Remove(property!);
+        }
+
+        return Task.CompletedTask;
+    }
+}
+#endif

--- a/src/Indice.AspNetCore/OpenApi/Transformers/OpenApiIgnoreTransformer.cs
+++ b/src/Indice.AspNetCore/OpenApi/Transformers/OpenApiIgnoreTransformer.cs
@@ -27,17 +27,16 @@ public static class OpenApiIgnoreTransformer
             return Task.CompletedTask;
         }
 
-        // find all properties of the type that are decorated with the OpenApiIgnoreAttribute 
-        var propertiesToIgnoreFromOpenApi = context.JsonTypeInfo.Type
-            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
-            .Where(x => x.IsDefined(typeof(OpenApiIgnoreAttribute), inherit: true))
-            .Select(x => schema.Properties!.Keys.FirstOrDefault(k => k.Equals(x.Name, StringComparison.OrdinalIgnoreCase)))
-            .Where(x => x is not null)
+        // Find all JSON properties whose underlying member is decorated with OpenApiIgnoreAttribute.
+        // Use the JSON property name so renamed properties (for example via JsonPropertyName) are removed correctly.
+        var propertiesToIgnoreFromOpenApi = context.JsonTypeInfo.Properties
+            .Where(x => x.AttributeProvider?.IsDefined(typeof(OpenApiIgnoreAttribute), inherit: true) == true)
+            .Select(x => x.Name)
             .ToList();
 
         foreach (var property in propertiesToIgnoreFromOpenApi) {
-            schema.Properties?.Remove(property!);
-            schema.Required?.Remove(property!);
+            schema.Properties?.Remove(property);
+            schema.Required?.Remove(property);
         }
 
         return Task.CompletedTask;

--- a/src/Indice.AspNetCore/OpenApi/Transformers/OpenApiIgnoreTransformer.cs
+++ b/src/Indice.AspNetCore/OpenApi/Transformers/OpenApiIgnoreTransformer.cs
@@ -23,7 +23,7 @@ public static class OpenApiIgnoreTransformer
     }
 
     private static Task TransformAsync(OpenApiSchema schema, OpenApiSchemaTransformerContext context, CancellationToken cancellationToken) {
-        if (schema.Properties?.Count == 0) {
+        if (schema.Properties is null || schema.Properties.Count == 0) {
             return Task.CompletedTask;
         }
 

--- a/test/Indice.AspNetCore.Tests/OpenApiTests.cs
+++ b/test/Indice.AspNetCore.Tests/OpenApiTests.cs
@@ -58,9 +58,10 @@ public class OpenApiTests : IAsyncLifetime
                     services.AddRouting();
                     services.ConfigureHttpJsonOptions(options => {
                         ConfigureIndiceHttpJsonOptions(options.SerializerOptions);
-                     });
+                    });
                     services.AddOpenApi("tests", options => options.AddDocumentInfo().ControllerActionAsOperationId());
                     services.AddOpenApi("nullables", options => options.AddDocumentInfo().ControllerActionAsOperationId());
+                    services.AddOpenApi("ignore-openapi", options => options.AddDocumentInfo().ControllerActionAsOperationId());
                     services.AddEndpointsApiExplorer();
                     services.AddControllers().ConfigureApplicationPartManager(m => m.FeatureProviders.Add(new OpenApiTestFeatureProvider()));
                 });
@@ -69,6 +70,7 @@ public class OpenApiTests : IAsyncLifetime
                     app.UseEndpoints(e => {
                         e.MapTestEndpoints();
                         e.MapNullableTestEndpoints();
+                        e.MapIgnoreAttributeEndpoints();
                         e.MapControllers();
                         e.MapOpenApi();
                     });
@@ -206,12 +208,24 @@ public class OpenApiTests : IAsyncLifetime
         var expectedEnumSchema = "{\"enum\":[0,1,2,3],\"type\":\"integer\",\"x-enum-varnames\":[\"Valid\",\"Invalid\",\"Draft\",\"Deleted\"]}";
         Assert.Equal(expectedEnumSchema, actualEnumSchema!.ToJsonString());
     }
+
+    [Fact]
+    public async Task OpenApiHandleOpenApiIgnoreAttribute() {
+        var openApi = await _httpClient.GetStringAsync("openapi/ignore-openapi.json");
+        Assert.NotEmpty(openApi);
+
+        var json = JsonNode.Parse(openApi);
+        var schema = json!["components"]!["schemas"]!["IgnoreAttributeResponse"];
+        var expectedSchema = "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":[\"null\",\"string\"]},\"nest\":{\"oneOf\":[{\"type\":\"null\"},{\"$ref\":\"#/components/schemas/IgnoreAttrubuteNest\"}]}},\"additionalProperties\":false}";
+
+        Assert.Equal(expectedSchema, schema!.ToJsonString());
+    }
 }
 #endif
 
 public class OpenApiTestsModels
 {
-    public class MenuItem 
+    public class MenuItem
     {
         public string Name { get; set; } = string.Empty;
         public string Description { get; set; } = string.Empty;
@@ -263,7 +277,8 @@ public class OpenApiTestsModels
         public Dictionary<string, string> Mappings { get; set; } = [];
     }
 
-    public class NullableEnumsTestRequest { 
+    public class NullableEnumsTestRequest
+    {
         public NullableEnumsType? NullableType { get; set; }
     }
     public enum NullableEnumsType
@@ -365,6 +380,34 @@ public class OpenApiTestsModels
         AJ = 1L << 35,  // 34359738368
         AK = 1L << 36   // 68719476736
     }
+
+    public class IgnoreAttributeResponse
+    {
+        public string? Id { get; set; }
+
+#if NET10_0_OR_GREATER
+        [OpenApi.Attributes.OpenApiIgnore]
+#endif
+        public int MyProperty { get; set; }
+
+#if NET10_0_OR_GREATER
+        [OpenApi.Attributes.OpenApiIgnore]
+#endif
+        public required string IgnoredRequiredProperty { get; set; }
+
+        public IgnoreAttrubuteNest? Nest { get; set; }
+    }
+
+    public class IgnoreAttrubuteNest
+    {
+        public string NestedId { get; set; } = null!;
+
+#if NET10_0_OR_GREATER
+        [OpenApi.Attributes.OpenApiIgnore]
+#endif
+        public bool NestedAndIngored { get; set; }
+    }
+
 }
 
 [ApiController]
@@ -372,7 +415,7 @@ public class OpenApiTestsModels
 public class OpenApiTestsController
 {
     [HttpGet("/mvc/menu")]
-    public IActionResult GetMenuItems([FromQuery]SampleFilterRequest filter) {
+    public IActionResult GetMenuItems([FromQuery] SampleFilterRequest filter) {
         var items = new List<MenuItem>
         {
                 new()
@@ -423,7 +466,6 @@ public static class OpenApiTestsEndpoints
         group.MapPost("long-enum", UpdateLongTypeEnum)
              .WithName(nameof(UpdateLongTypeEnum));
 
-
         return routes;
     }
     public static IEndpointRouteBuilder MapNullableTestEndpoints(this IEndpointRouteBuilder routes) {
@@ -433,6 +475,15 @@ public static class OpenApiTestsEndpoints
         group.MapPost("nullable-enum/{parentId}", PostNullableEnum)
              .WithName(nameof(PostNullableEnum));
 
+        return routes;
+    }
+
+    public static IEndpointRouteBuilder MapIgnoreAttributeEndpoints(this IEndpointRouteBuilder routes) {
+        var group = routes.MapGroup("ignore-openapi");
+        group.WithGroupName("ignore-openapi");
+        group.WithTags("Ignore OpenApi");
+        group.MapGet("ignore-open-api/sample", GetIgnoreAttributeResponse)
+                   .WithName(nameof(GetIgnoreAttributeResponse));
 
         return routes;
     }
@@ -470,6 +521,18 @@ public static class OpenApiTestsEndpoints
     public static Ok<AttachmentLink> UploadAttachment(UploadFileRequest uploadFileRequest) {
         return TypedResults.Ok(new AttachmentLink {
             AttachmentId = Guid.Parse("1b62a5f3-f2d2-43be-81f9-572e97862b60")
+        });
+    }
+
+    public static Ok<IgnoreAttributeResponse> GetIgnoreAttributeResponse() {
+        return TypedResults.Ok(new IgnoreAttributeResponse {
+            Id = "123",
+            MyProperty = 456,
+            IgnoredRequiredProperty = "This should be ignored in the OpenAPI schema",
+            Nest = new IgnoreAttrubuteNest {
+                NestedId = "Nested123",
+                NestedAndIngored = true
+            }
         });
     }
 }

--- a/test/Indice.AspNetCore.Tests/OpenApiTests.cs
+++ b/test/Indice.AspNetCore.Tests/OpenApiTests.cs
@@ -210,15 +210,18 @@ public class OpenApiTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task OpenApiHandleOpenApiIgnoreAttribute() {
+    public async Task OpenApiHandlesOpenApiIgnoreAttribute() {
         var openApi = await _httpClient.GetStringAsync("openapi/ignore-openapi.json");
         Assert.NotEmpty(openApi);
 
         var json = JsonNode.Parse(openApi);
         var schema = json!["components"]!["schemas"]!["IgnoreAttributeResponse"];
         var expectedSchema = "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":[\"null\",\"string\"]},\"nest\":{\"oneOf\":[{\"type\":\"null\"},{\"$ref\":\"#/components/schemas/IgnoreAttrubuteNest\"}]}},\"additionalProperties\":false}";
+        var nestedSchema = json!["components"]!["schemas"]!["IgnoreAttrubuteNest"];
+        var expectedNestedSchema = "{\"type\":\"object\",\"properties\":{},\"additionalProperties\":false}";
 
         Assert.Equal(expectedSchema, schema!.ToJsonString());
+        Assert.Equal(expectedNestedSchema, nestedSchema!.ToJsonString());
     }
 }
 #endif
@@ -395,17 +398,17 @@ public class OpenApiTestsModels
 #endif
         public required string IgnoredRequiredProperty { get; set; }
 
-        public IgnoreAttrubuteNest? Nest { get; set; }
+        public IgnoreAttributeNest? Nest { get; set; }
     }
 
-    public class IgnoreAttrubuteNest
+    public class IgnoreAttributeNest
     {
         public string NestedId { get; set; } = null!;
 
 #if NET10_0_OR_GREATER
         [OpenApi.Attributes.OpenApiIgnore]
 #endif
-        public bool NestedAndIngored { get; set; }
+        public bool NestedAndIgnored { get; set; }
     }
 
 }

--- a/test/Indice.AspNetCore.Tests/OpenApiTests.cs
+++ b/test/Indice.AspNetCore.Tests/OpenApiTests.cs
@@ -216,9 +216,9 @@ public class OpenApiTests : IAsyncLifetime
 
         var json = JsonNode.Parse(openApi);
         var schema = json!["components"]!["schemas"]!["IgnoreAttributeResponse"];
-        var expectedSchema = "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":[\"null\",\"string\"]},\"nest\":{\"oneOf\":[{\"type\":\"null\"},{\"$ref\":\"#/components/schemas/IgnoreAttrubuteNest\"}]}},\"additionalProperties\":false}";
-        var nestedSchema = json!["components"]!["schemas"]!["IgnoreAttrubuteNest"];
-        var expectedNestedSchema = "{\"type\":\"object\",\"properties\":{},\"additionalProperties\":false}";
+        var expectedSchema = "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":[\"null\",\"string\"]},\"nest\":{\"oneOf\":[{\"type\":\"null\"},{\"$ref\":\"#/components/schemas/IgnoreAttributeNest\"}]}},\"additionalProperties\":false}";
+        var nestedSchema = json!["components"]!["schemas"]!["IgnoreAttributeNest"];
+        var expectedNestedSchema = "{\"type\":\"object\",\"properties\":{\"nestedId\":{\"type\":\"string\"}},\"additionalProperties\":false}";
 
         Assert.Equal(expectedSchema, schema!.ToJsonString());
         Assert.Equal(expectedNestedSchema, nestedSchema!.ToJsonString());
@@ -532,9 +532,9 @@ public static class OpenApiTestsEndpoints
             Id = "123",
             MyProperty = 456,
             IgnoredRequiredProperty = "This should be ignored in the OpenAPI schema",
-            Nest = new IgnoreAttrubuteNest {
+            Nest = new IgnoreAttributeNest {
                 NestedId = "Nested123",
-                NestedAndIngored = true
+                NestedAndIgnored = true
             }
         });
     }


### PR DESCRIPTION
This pull request introduces support for an `OpenApiIgnoreAttribute` that allows properties to be excluded from the generated OpenAPI schema when targeting .NET 10.0 or greater. The implementation includes the new attribute, a schema transformer to remove ignored properties, and corresponding tests to ensure correct behavior.
