### PR TITLE
[identity] fix tailwind template with MFA onboarding missing icons in…

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,8 +8,8 @@
     <VersionPrefixBase>$(VersionPrefixMajor).46</VersionPrefixBase>
 
     <VersionPrefixCore>$(VersionPrefixBase).0</VersionPrefixCore>
-    <VersionPrefixIdentity>$(VersionPrefixBase).1</VersionPrefixIdentity>
-    <VersionPrefixIdentityUI>$(VersionPrefixBase).1</VersionPrefixIdentityUI>
+    <VersionPrefixIdentity>$(VersionPrefixBase).2</VersionPrefixIdentity>
+    <VersionPrefixIdentityUI>$(VersionPrefixBase).2</VersionPrefixIdentityUI>
     <VersionPrefixCases>$(VersionPrefixBase).0</VersionPrefixCases>
     <VersionPrefixMessages>$(VersionPrefixBase).0</VersionPrefixMessages>
     <VersionPrefixMultitenancy>$(VersionPrefixBase).0</VersionPrefixMultitenancy>

--- a/src/Indice.Features.Identity.UI/Pages/Tailwind/MfaOnboarding.cshtml
+++ b/src/Indice.Features.Identity.UI/Pages/Tailwind/MfaOnboarding.cshtml
@@ -1,4 +1,5 @@
 ﻿@page "/login/mfa/onboarding"
+@using Indice.Features.Identity.Core.Models
 
 @model BaseMfaOnboardingModel
 
@@ -9,6 +10,22 @@
     ViewData["Title"] = @Localizer.MfaOnBoarding_PageTitle;
     var lang = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
     var langSuffix = (lang == "el") ? ".el" : string.Empty;
+}
+@functions {
+    public string GetIconFromAuthenticationMethod(AuthenticationMethod method)
+    {
+        return method.Code.ToLowerInvariant() switch
+        {
+            "viber" => "fa-brands fa-viber",
+            "sms" => "fa-regular fa-message",
+            "email" => "fa-regular fa-envelope",
+            "authenticatorapp" => "fa-solid fa-shield-halved",
+            "trusteddevice" => "fa-solid fa-mobile-screen",
+            "fido2" => "fa-solid fa-fingerprint",
+            "code" => "fa-solid fa-square-binary",
+            _ => "fa-regular fa-message"
+        };
+    }
 }
 <div class="content-wrapper">
     <div class="card-wrapper">
@@ -70,8 +87,9 @@
     <script type="text/javascript" src="~/js/mfa-onboarding.js" csp-nonce></script>
     <script type="text/javascript" csp-nonce>
         var viewModelParameters = {
-            authenticationMethods: @Html.Raw(JsonSerializer.Serialize(Model.View.AuthenticationMethods, JsonSerializerOptionDefaults.GetDefaultSettings()))
-                };
+           authenticationMethods: @Html.Raw(JsonSerializer.Serialize(Model.View.AuthenticationMethods, JsonSerializerOptionDefaults.GetDefaultSettings())),
+           icons: @Html.Raw(JsonSerializer.Serialize(Model.View.AuthenticationMethods.ToDictionary(x => x.Code, x => GetIconFromAuthenticationMethod(x)), JsonSerializerOptionDefaults.GetDefaultSettings()))
+        };
         var viewModel = new indice.MfaOnboardingViewModelFactory(viewModelParameters);
         viewModel.init();
         ko.bindingProvider.instance = new ko.secureBindingsProvider();


### PR DESCRIPTION
… knockoutjs and bump identity version

Incremented VersionPrefixIdentity and VersionPrefixIdentityUI to .2. Added a helper in MfaOnboarding.cshtml to map authentication methods to FontAwesome icons and exposed these mappings to the JavaScript view model.