### PR TITLE
[ftp] Add in-memory FTP user/password authentication support

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -19,7 +19,7 @@
     <VersionPrefixGovGr>$(VersionPrefixBase).0</VersionPrefixGovGr>
     <VersionPrefixAspNet>$(VersionPrefixBase).0</VersionPrefixAspNet>
     <VersionPrefixActivityLogs>$(VersionPrefixBase).0</VersionPrefixActivityLogs>
-    <VersionPrefixFtpServer>$(VersionPrefixBase).1</VersionPrefixFtpServer>
+    <VersionPrefixFtpServer>$(VersionPrefixBase).2</VersionPrefixFtpServer>
     <VersionPrefix>$(VersionPrefixBase).0</VersionPrefix>
 
     <!--<VersionSuffix>rc02</VersionSuffix>-->

--- a/src/Indice.Features.FtpServer/FtpServerCredentialsMembershipProvider.cs
+++ b/src/Indice.Features.FtpServer/FtpServerCredentialsMembershipProvider.cs
@@ -98,7 +98,7 @@ public record FtpSymmetricCredentials(string Username, string Password, string? 
     /// The authentication type can be specified as an optional parameter, defaulting to "custom" if not provided.
     /// </summary>
     /// <param name="authenticationType"></param>
-    /// <returns>The constructed prinipal</returns>
+    /// <returns>The constructed principal</returns>
     public ClaimsPrincipal ToClaimsPrincipal(string authenticationType = "custom") => new ClaimsPrincipal(new ClaimsIdentity(
         [
             new Claim(ClaimsIdentity.DefaultNameClaimType, Username),

--- a/src/Indice.Features.FtpServer/FtpServerCredentialsMembershipProvider.cs
+++ b/src/Indice.Features.FtpServer/FtpServerCredentialsMembershipProvider.cs
@@ -1,0 +1,108 @@
+﻿using System.Security.Claims;
+using FubarDev.FtpServer.AccountManagement;
+using Microsoft.Extensions.Options;
+
+namespace Indice.Features.FtpServer;
+
+/// <summary>
+/// An implementation of <see cref="IMembershipProviderAsync"/> that validates user credentials against a predefined list of username-password pairs specified in the <see cref="FtpServerCredentialsOptions"/>. This provider is suitable for simple scenarios where user credentials are managed in-memory and does not require integration with external authentication systems.
+/// </summary>
+public class FtpServerCredentialsMembershipProvider : IMembershipProviderAsync
+{
+    private readonly IOptions<FtpServerCredentialsOptions> _options;
+    /// <summary>
+    /// Initializes a new instance of the FtpServerCredentialsMembershipProvider class using the specified options. 
+    /// </summary>
+    /// <param name="options">The options used to configure the FTP server credentials provider. Cannot be null.</param>
+    public FtpServerCredentialsMembershipProvider(IOptions<FtpServerCredentialsOptions> options) {
+        _options = options;
+    }
+
+    /// <inheritdoc />
+    public Task LogOutAsync(ClaimsPrincipal principal, CancellationToken cancellationToken = default) {
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public async Task<MemberValidationResult> ValidateUserAsync(string username, string password, CancellationToken cancellationToken) {
+        var credential = await ValidateCredentialsAsync(username, password, cancellationToken);
+        if (credential == null) {
+            return new MemberValidationResult(MemberValidationStatus.InvalidLogin);
+        }
+        var user = credential.ToClaimsPrincipal("custom");
+
+        return new MemberValidationResult(MemberValidationStatus.AuthenticatedUser, user);
+
+    }
+
+    /// <inheritdoc />
+    public Task<MemberValidationResult> ValidateUserAsync(string username, string password) {
+        return ValidateUserAsync(username, password, default);
+    }
+
+    /// <summary>
+    /// Asynchronously validates the specified username and password against the configured credentials.
+    /// </summary>
+    /// <param name="username">The username to validate. Cannot be null.</param>
+    /// <param name="password">The password to validate. Cannot be null.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the <see cref="FtpSymmetricCredentials"/> if the
+    /// credentials are valid; otherwise, <see langword="null"/>.</returns>
+    protected virtual Task<FtpSymmetricCredentials?> ValidateCredentialsAsync(string username, string password, CancellationToken cancellationToken) {
+        var credential = _options.Value.Credentials.Values.FirstOrDefault(c => c.Username == username && c.Password == password);
+        return Task.FromResult(credential);
+    }
+}
+
+/// <summary>
+/// Represents configuration options for specifying a collection of FTP server credentials.
+/// </summary>
+/// <remarks>Use this class to provide one or more sets of credentials that can be used to authenticate with an
+/// FTP server. This is typically used when configuring FTP client or server components that require credential
+/// management.</remarks>
+public class FtpServerCredentialsOptions
+{
+    /// <summary>
+    /// Gets or sets the collection of FTP symmetric credentials, indexed by user name.
+    /// </summary>
+    /// <remarks>Each entry in the dictionary associates a user name with its corresponding FTP symmetric
+    /// credentials. Modifying this collection affects authentication for FTP operations that use these
+    /// credentials.</remarks>
+    public Dictionary<string, FtpSymmetricCredentials> Credentials { get; set; } = new();
+}
+
+/// <summary>
+/// Represents a set of symmetric credentials used for authenticating with an FTP server.
+/// </summary>
+/// <param name="Username">The user name to use when connecting to the FTP server. Cannot be null or empty.</param>
+/// <param name="Password">The password associated with the specified user name. Cannot be null or empty.</param>
+/// <param name="Roles">An optional comma-separated list of roles associated with the user. This can be used for role-based authorization when accessing FTP server resources. Can be null.</param>
+public record FtpSymmetricCredentials(string Username, string Password, string? Roles = null) {
+
+    /// <summary>
+    /// Gets the roles associated with the user as an array of strings. 
+    /// If the Roles property is null, empty, or consists only of whitespace, this method returns an array containing the username and a default "user" role. 
+    /// Otherwise, it splits the Roles string by commas and trims any whitespace from each role before returning the array of roles.
+    /// </summary>
+    /// <returns>An array of strings representing the roles associated with the user.</returns>
+    public string[] GetRoles() {
+        if (string.IsNullOrWhiteSpace(Roles)) {
+            return [Username, "user"];
+        }
+        return Roles.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+    }
+
+    /// <summary>
+    /// Converts the current instance of <see cref="FtpSymmetricCredentials"/> to a <see cref="ClaimsPrincipal"/> that can be used for authentication and authorization purposes. 
+    /// The resulting <see cref="ClaimsPrincipal"/> will contain claims for the user's name and roles based on the properties of the current instance. 
+    /// The authentication type can be specified as an optional parameter, defaulting to "custom" if not provided.
+    /// </summary>
+    /// <param name="authenticationType"></param>
+    /// <returns>The constructed prinipal</returns>
+    public ClaimsPrincipal ToClaimsPrincipal(string authenticationType = "custom") => new ClaimsPrincipal(new ClaimsIdentity(
+        [
+            new Claim(ClaimsIdentity.DefaultNameClaimType, Username),
+            .. GetRoles().Select(role => new Claim(ClaimsIdentity.DefaultRoleClaimType, role)),
+        ],
+        authenticationType));
+}

--- a/src/Indice.Features.FtpServer/FtpServerCredentialsMembershipProvider.cs
+++ b/src/Indice.Features.FtpServer/FtpServerCredentialsMembershipProvider.cs
@@ -1,4 +1,6 @@
 ﻿using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
 using FubarDev.FtpServer.AccountManagement;
 using Microsoft.Extensions.Options;
 
@@ -49,8 +51,10 @@ public class FtpServerCredentialsMembershipProvider : IMembershipProviderAsync
     /// <returns>A task that represents the asynchronous operation. The task result contains the <see cref="FtpSymmetricCredentials"/> if the
     /// credentials are valid; otherwise, <see langword="null"/>.</returns>
     protected virtual Task<FtpSymmetricCredentials?> ValidateCredentialsAsync(string username, string password, CancellationToken cancellationToken) {
-        var credential = _options.Value.Credentials.Values.FirstOrDefault(c => c.Username == username && c.Password == password);
-        return Task.FromResult(credential);
+        if (_options.Value.Credentials.TryGetValue(username, out var credential) && credential.VerifyPassword(password)) {
+            return Task.FromResult<FtpSymmetricCredentials?>(credential);
+        }
+        return Task.FromResult<FtpSymmetricCredentials?>(null);
     }
 }
 
@@ -78,6 +82,12 @@ public class FtpServerCredentialsOptions
 /// <param name="Password">The password associated with the specified user name. Cannot be null or empty.</param>
 /// <param name="Roles">An optional comma-separated list of roles associated with the user. This can be used for role-based authorization when accessing FTP server resources. Can be null.</param>
 public record FtpSymmetricCredentials(string Username, string Password, string? Roles = null) {
+    /// <summary>
+    /// Gets or initializes an optional password hash in the format:
+    /// <c>PBKDF2$&lt;iterations&gt;$&lt;saltBase64&gt;$&lt;hashBase64&gt;</c>.
+    /// If set, this hash is used for validation instead of <see cref="Password"/>.
+    /// </summary>
+    public string? PasswordHash { get; init; }
 
     /// <summary>
     /// Gets the roles associated with the user as an array of strings. 
@@ -93,16 +103,52 @@ public record FtpSymmetricCredentials(string Username, string Password, string? 
     }
 
     /// <summary>
+    /// Validates the provided clear-text password against this credential.
+    /// </summary>
+    /// <param name="password">The clear-text password to validate.</param>
+    /// <returns><see langword="true"/> when the password matches; otherwise, <see langword="false"/>.</returns>
+    public bool VerifyPassword(string password) {
+        return PasswordHash switch {
+            null or "" => FixedTimeEquals(Password, password),
+            _ => VerifyPbkdf2Password(password)
+        };
+    }
+
+    /// <summary>
     /// Converts the current instance of <see cref="FtpSymmetricCredentials"/> to a <see cref="ClaimsPrincipal"/> that can be used for authentication and authorization purposes. 
     /// The resulting <see cref="ClaimsPrincipal"/> will contain claims for the user's name and roles based on the properties of the current instance. 
     /// The authentication type can be specified as an optional parameter, defaulting to "custom" if not provided.
     /// </summary>
-    /// <param name="authenticationType"></param>
-    /// <returns>The constructed principal</returns>
+    /// <param name="authenticationType">The authentication type to assign to the resulting <see cref="ClaimsIdentity"/>.</param>
+    /// <returns>The constructed principal.</returns>
     public ClaimsPrincipal ToClaimsPrincipal(string authenticationType = "custom") => new ClaimsPrincipal(new ClaimsIdentity(
         [
             new Claim(ClaimsIdentity.DefaultNameClaimType, Username),
             .. GetRoles().Select(role => new Claim(ClaimsIdentity.DefaultRoleClaimType, role)),
         ],
         authenticationType));
+
+    private bool VerifyPbkdf2Password(string password) {
+        var parts = PasswordHash!.Split('$', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (parts.Length != 4 || !parts[0].Equals("PBKDF2", StringComparison.OrdinalIgnoreCase)) {
+            return false;
+        }
+        if (!int.TryParse(parts[1], out var iterations) || iterations <= 0) {
+            return false;
+        }
+        try {
+            var salt = Convert.FromBase64String(parts[2]);
+            var expectedHash = Convert.FromBase64String(parts[3]);
+            var actualHash = Rfc2898DeriveBytes.Pbkdf2(password, salt, iterations, HashAlgorithmName.SHA256, expectedHash.Length);
+            return CryptographicOperations.FixedTimeEquals(expectedHash, actualHash);
+        } catch (FormatException) {
+            return false;
+        }
+    }
+
+    private static bool FixedTimeEquals(string left, string right) {
+        var leftBytes = Encoding.UTF8.GetBytes(left);
+        var rightBytes = Encoding.UTF8.GetBytes(right);
+        return CryptographicOperations.FixedTimeEquals(leftBytes, rightBytes);
+    }
 }

--- a/src/Indice.Features.FtpServer/FtpServerCredentialsMembershipProvider.cs
+++ b/src/Indice.Features.FtpServer/FtpServerCredentialsMembershipProvider.cs
@@ -9,6 +9,9 @@ namespace Indice.Features.FtpServer;
 /// <summary>
 /// An implementation of <see cref="IMembershipProviderAsync"/> that validates user credentials against a predefined list of username-password pairs specified in the <see cref="FtpServerCredentialsOptions"/>. This provider is suitable for simple scenarios where user credentials are managed in-memory and does not require integration with external authentication systems.
 /// </summary>
+/// <summary>
+/// An implementation of <see cref="IMembershipProviderAsync"/> that validates user credentials against a predefined list of username-password pairs specified in the <see cref="FtpServerCredentialsOptions"/>. This provider is suitable for simple scenarios where user credentials are managed in-memory and does not require integration with external authentication systems.
+/// </summary>
 public class FtpServerCredentialsMembershipProvider : IMembershipProviderAsync
 {
     private readonly IOptions<FtpServerCredentialsOptions> _options;
@@ -51,7 +54,7 @@ public class FtpServerCredentialsMembershipProvider : IMembershipProviderAsync
     /// <returns>A task that represents the asynchronous operation. The task result contains the <see cref="FtpSymmetricCredentials"/> if the
     /// credentials are valid; otherwise, <see langword="null"/>.</returns>
     protected virtual Task<FtpSymmetricCredentials?> ValidateCredentialsAsync(string username, string password, CancellationToken cancellationToken) {
-        if (_options.Value.Credentials.TryGetValue(username, out var credential) && credential.VerifyPassword(password)) {
+        if (_options.Value.Credentials.Values.FirstOrDefault(c => c.Username == username) is FtpSymmetricCredentials credential && credential.VerifyPassword(password)) {
             return Task.FromResult<FtpSymmetricCredentials?>(credential);
         }
         return Task.FromResult<FtpSymmetricCredentials?>(null);
@@ -67,9 +70,9 @@ public class FtpServerCredentialsMembershipProvider : IMembershipProviderAsync
 public class FtpServerCredentialsOptions
 {
     /// <summary>
-    /// Gets or sets the collection of FTP symmetric credentials, indexed by user name.
+    /// Gets or sets the collection of FTP symmetric credentials, indexed by a description/label.
     /// </summary>
-    /// <remarks>Each entry in the dictionary associates a user name with its corresponding FTP symmetric
+    /// <remarks>Each entry in the dictionary associates a description/label with its corresponding FTP symmetric
     /// credentials. Modifying this collection affects authentication for FTP operations that use these
     /// credentials.</remarks>
     public Dictionary<string, FtpSymmetricCredentials> Credentials { get; set; } = new();

--- a/src/Indice.Features.FtpServer/FtpServerCredentialsMembershipProvider.cs
+++ b/src/Indice.Features.FtpServer/FtpServerCredentialsMembershipProvider.cs
@@ -129,11 +129,11 @@ public record FtpSymmetricCredentials(string Username, string Password, string? 
         authenticationType));
 
     private bool VerifyPbkdf2Password(string password) {
-        var parts = PasswordHash!.Split('$', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        var parts = PasswordHash!.Split('$', StringSplitOptions.RemoveEmptyEntries);
         if (parts.Length != 4 || !parts[0].Equals("PBKDF2", StringComparison.OrdinalIgnoreCase)) {
             return false;
         }
-        if (!int.TryParse(parts[1], out var iterations) || iterations <= 0) {
+        if (!int.TryParse(parts[1], out var iterations) || iterations < 10_000) {
             return false;
         }
         try {
@@ -147,8 +147,8 @@ public record FtpSymmetricCredentials(string Username, string Password, string? 
     }
 
     private static bool FixedTimeEquals(string left, string right) {
-        var leftBytes = Encoding.UTF8.GetBytes(left);
-        var rightBytes = Encoding.UTF8.GetBytes(right);
-        return CryptographicOperations.FixedTimeEquals(leftBytes, rightBytes);
+        var leftHash = SHA256.HashData(Encoding.UTF8.GetBytes(left));
+        var rightHash = SHA256.HashData(Encoding.UTF8.GetBytes(right));
+        return CryptographicOperations.FixedTimeEquals(leftHash, rightHash);
     }
 }

--- a/src/Indice.Features.FtpServer/FtpServerFeatureExtensions.cs
+++ b/src/Indice.Features.FtpServer/FtpServerFeatureExtensions.cs
@@ -86,7 +86,7 @@ public static class FtpServerFeatureExtensions
         return builder;
     }
 
-    private static IFtpServerBuilder EnableAnonymousAuthenticationInternal(this IFtpServerBuilder builder) {
+    private static IFtpServerBuilder EnableNormalAuthenticationInternal(this IFtpServerBuilder builder) {
         builder.Services.AddSingleton<IMembershipProviderAsync, FtpServerCredentialsMembershipProvider>();
         builder.Services.AddSingleton<IMembershipProvider, FtpServerCredentialsMembershipProvider>();
         return builder;

--- a/src/Indice.Features.FtpServer/FtpServerFeatureExtensions.cs
+++ b/src/Indice.Features.FtpServer/FtpServerFeatureExtensions.cs
@@ -1,8 +1,10 @@
 ﻿using System.Net;
 using FubarDev.FtpServer;
+using FubarDev.FtpServer.AccountManagement;
 using FubarDev.FtpServer.AccountManagement.Anonymous;
 using FubarDev.FtpServer.FileSystem.DotNet;
 using Indice.Features.FtpServer;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.DependencyInjection;
@@ -56,6 +58,37 @@ public static class FtpServerFeatureExtensions
             builder.Services.AddSingleton<IAnonymousPasswordValidator, NotEmptyPasswordValidation>(sp => new NotEmptyPasswordValidation(options.MinimumPasswordLength));
         }
         builder.EnableAnonymousAuthentication();
+        return builder;
+    }
+
+    /// <summary>
+    /// Enables normal authentication for the FTP server using a custom membership provider that validates user credentials against a predefined list of username-password pairs specified in the <see cref="FtpServerCredentialsOptions"/>. This method allows you to easily set up basic authentication for your FTP server without needing to implement a custom membership provider. Use the <paramref name="configureAction"/> parameter to specify the credentials that should be accepted by the server.
+    /// </summary>
+    /// <param name="builder">The FTP server builder to configure. Cannot be null.</param>
+    /// <param name="configureAction">An action to configure the FTP server credentials options. 
+    /// This action is invoked to specify the username-password pairs that will be accepted for authentication. Cannot be null.</param>
+    /// <returns>The same instance of <see cref="IFtpServerBuilder"/> to allow for method chaining.</returns>
+    public static IFtpServerBuilder EnableNormalAuthentication(this IFtpServerBuilder builder, Action<FtpServerCredentialsOptions> configureAction) {
+        builder.Services.Configure(configureAction);
+        builder.EnableAnonymousAuthenticationInternal();
+        return builder;
+    }
+
+    /// <summary>
+    /// Enables normal authentication for the FTP server using a custom membership provider that validates user credentials against a predefined list of username-password pairs specified in the <see cref="FtpServerCredentialsOptions"/>. This method allows you to easily set up basic authentication for your FTP server without needing to implement a custom membership provider. Use the <paramref name="configuration"/> parameter to specify the credentials that should be accepted by the server.
+    /// </summary>
+    /// <param name="builder">The FTP server builder to configure. Cannot be null.</param>
+    /// <param name="configuration">The configuration instance to configure the FTP server credentials options. Cannot be null.</param>
+    /// <returns>The same instance of <see cref="IFtpServerBuilder"/> to allow for method chaining.</returns>
+    public static IFtpServerBuilder EnableNormalAuthentication(this IFtpServerBuilder builder, IConfiguration configuration) {
+        builder.Services.Configure<FtpServerCredentialsOptions>(configuration);
+        builder.EnableAnonymousAuthenticationInternal();
+        return builder;
+    }
+
+    private static IFtpServerBuilder EnableAnonymousAuthenticationInternal(this IFtpServerBuilder builder) {
+        builder.Services.AddSingleton<IMembershipProviderAsync, FtpServerCredentialsMembershipProvider>();
+        builder.Services.AddSingleton<IMembershipProvider, FtpServerCredentialsMembershipProvider>();
         return builder;
     }
 

--- a/src/Indice.Features.FtpServer/FtpServerFeatureExtensions.cs
+++ b/src/Indice.Features.FtpServer/FtpServerFeatureExtensions.cs
@@ -70,7 +70,7 @@ public static class FtpServerFeatureExtensions
     /// <returns>The same instance of <see cref="IFtpServerBuilder"/> to allow for method chaining.</returns>
     public static IFtpServerBuilder EnableNormalAuthentication(this IFtpServerBuilder builder, Action<FtpServerCredentialsOptions> configureAction) {
         builder.Services.Configure(configureAction);
-        builder.EnableAnonymousAuthenticationInternal();
+        builder.EnableNormalAuthenticationInternal();
         return builder;
     }
 
@@ -82,7 +82,7 @@ public static class FtpServerFeatureExtensions
     /// <returns>The same instance of <see cref="IFtpServerBuilder"/> to allow for method chaining.</returns>
     public static IFtpServerBuilder EnableNormalAuthentication(this IFtpServerBuilder builder, IConfiguration configuration) {
         builder.Services.Configure<FtpServerCredentialsOptions>(configuration);
-        builder.EnableAnonymousAuthenticationInternal();
+        builder.EnableNormalAuthenticationInternal();
         return builder;
     }
 


### PR DESCRIPTION
Added extension methods to enable normal authentication for the FTP server using a custom membership provider. Introduced FtpServerCredentialsMembershipProvider and related options for managing username/password pairs in-memory. Incremented FtpServer package version to .2.