### PR TITLE
[aspnetcore] Add guards for invalid default schemas in transformer

### DIFF
--- a/src/Indice.AspNetCore/OpenApi/Transformers/JsonConverterSchemaTransformer.cs
+++ b/src/Indice.AspNetCore/OpenApi/Transformers/JsonConverterSchemaTransformer.cs
@@ -76,6 +76,14 @@ public static class JsonConverterSchemaTransformer
     private static void TransformSchemaPrimitive(OpenApiSchema schema, JsonSerializerOptions runtimeJsonOptions, Type type) {
         _WebDefalts ??= StripCustomConverters(runtimeJsonOptions);
         var defaultSchema = _WebDefalts.GetJsonSchemaAsNode(type);
+        // Guard: if the schema is not a JsonObject (e.g. bare 'true'/'false' schema), bail out.
+        if (defaultSchema is not System.Text.Json.Nodes.JsonObject) {
+            return;
+        }
+        // Guard: if the schema has no "type" property (e.g. unsupported .NET type), bail out.
+        if (defaultSchema["type"] is null) {
+            return;
+        }
         var isArrayOfTypes = defaultSchema["type"]!.GetValueKind() == JsonValueKind.Array;
         var defaultTypes = isArrayOfTypes ? string.Join(',', defaultSchema["type"]!.AsArray().Select(x => x!.ToString())) : defaultSchema["type"]!.ToString();
         schema.Pattern = defaultSchema["pattern"]?.ToString();

--- a/src/Indice.AspNetCore/OpenApi/Transformers/JsonConverterSchemaTransformer.cs
+++ b/src/Indice.AspNetCore/OpenApi/Transformers/JsonConverterSchemaTransformer.cs
@@ -80,12 +80,8 @@ public static class JsonConverterSchemaTransformer
         if (defaultSchema is not System.Text.Json.Nodes.JsonObject) {
             return;
         }
-        // Guard: if the schema has no "type" property (e.g. unsupported .NET type), bail out.
-        if (defaultSchema["type"] is null) {
-            return;
-        }
-        var isArrayOfTypes = defaultSchema["type"]!.GetValueKind() == JsonValueKind.Array;
-        var defaultTypes = isArrayOfTypes ? string.Join(',', defaultSchema["type"]!.AsArray().Select(x => x!.ToString())) : defaultSchema["type"]!.ToString();
+        var isArrayOfTypes = defaultSchema["type"]?.GetValueKind() == JsonValueKind.Array;
+        var defaultTypes = isArrayOfTypes ? string.Join(',', defaultSchema["type"]!.AsArray().Select(x => x!.ToString())) : defaultSchema["type"]?.ToString();
         schema.Pattern = defaultSchema["pattern"]?.ToString();
         schema.Format = defaultSchema["format"]?.ToString();
         if (Enum.TryParse<JsonSchemaType>(defaultTypes, ignoreCase: true, out var defaultSchemaType)) {


### PR DESCRIPTION
Added early returns in TransformSchemaPrimitive to skip processing when the default schema is not a JsonObject or lacks a "type" property, ensuring unsupported or malformed schemas are safely ignored.