### PR TITLE
[messaging] Add MergeContacts event and related handlers

### DIFF
--- a/src/Indice.Features.Messages.AspNetCore/Endpoints/CampaignsApi.cs
+++ b/src/Indice.Features.Messages.AspNetCore/Endpoints/CampaignsApi.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using OfficeOpenXml.FormulaParsing.Excel.Functions.DateTime;
 
 namespace Microsoft.AspNetCore.Routing;
 

--- a/src/Indice.Features.Messages.Core/Constants.cs
+++ b/src/Indice.Features.Messages.Core/Constants.cs
@@ -42,6 +42,8 @@ public static class EventNames
     public const string MarkAllAsRead = "my-messages-mark-all-read";
     /// <summary>Name for the event that is raised when user trigger mark all as unread.</summary>
     public const string MarkAllAsUnread = "my-messages-mark-all-unread";
+    /// <summary>Name for the event that is raised when contacts are merged.</summary>
+    public const string MergeContacts = "contacts-merge";
 }
 
 /// <summary>Placeholder for prefixing Messages API endpoints.</summary>

--- a/src/Indice.Features.Messages.Core/Events/MergeContactsEvent.cs
+++ b/src/Indice.Features.Messages.Core/Events/MergeContactsEvent.cs
@@ -6,5 +6,5 @@ public class MergeContactsEvent
     /// <summary>The Database Id of the primary contact.</summary>
     public Guid PrimaryContactId { get; set; }
     /// <summary>The list of duplicate contact IDs to merge with the primary contact.</summary>
-    public List<Guid> DuplicateContactsIds { get; set; } = null!;
+    public List<Guid> DuplicateContactsIds { get; set; } = [];
 }

--- a/src/Indice.Features.Messages.Core/Events/MergeContactsEvent.cs
+++ b/src/Indice.Features.Messages.Core/Events/MergeContactsEvent.cs
@@ -1,0 +1,10 @@
+﻿namespace Indice.Features.Messages.Core.Events;
+
+/// <summary>The event model used to merge contacts.</summary>
+public class MergeContactsEvent
+{
+    /// <summary>The Database Id of the primary contact.</summary>
+    public Guid PrimaryContactId { get; set; }
+    /// <summary>The list of duplicate contact IDs to merge with the primary contact.</summary>
+    public List<Guid> DuplicateContactsIds { get; set; } = null!;
+}

--- a/src/Indice.Features.Messages.Core/Handlers/MergeContactsEventHandler.cs
+++ b/src/Indice.Features.Messages.Core/Handlers/MergeContactsEventHandler.cs
@@ -1,0 +1,44 @@
+﻿using Indice.Features.Messages.Core.Events;
+using Indice.Features.Messages.Core.Services.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace Indice.Features.Messages.Core.Handlers;
+
+/// <summary>Job handler for <see cref="MergeContactsEvent"/>.</summary>
+public class MergeContactsEventHandler : ICampaignJobHandler<MergeContactsEvent>
+{
+    /// <summary>Creates a new instance of <see cref="MergeContactsEventHandler"/>.</summary>
+    /// <param name="contactService">Contacts management service</param>
+    /// <param name="logger">Logging service</param>
+    /// <exception cref="ArgumentNullException"></exception>
+    public MergeContactsEventHandler(IContactService contactService, ILogger<MergeContactsEventHandler> logger) {
+        _contactService = contactService ?? throw new ArgumentNullException(nameof(contactService));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    private readonly IContactService _contactService;
+    private readonly ILogger<MergeContactsEventHandler> _logger;
+
+    /// <summary>Merges duplicate contacts into a primary contact.</summary>
+    /// <param name="event">The event model used when merging contacts.</param>
+    public async Task Process(MergeContactsEvent @event) {
+        var mainContact = await _contactService.GetById(@event.PrimaryContactId);
+        if (mainContact is null) {
+            _logger.LogError("No Contact was found with the given Id: {PrimaryContactId}", @event.PrimaryContactId);
+            return;
+        }
+        if (string.IsNullOrWhiteSpace(mainContact.RecipientId)) {
+            _logger.LogError("The main contact does not have a recipient Id: {PrimaryContactId}", @event.PrimaryContactId);
+            return;
+        }
+        if (@event.DuplicateContactsIds is null || @event.DuplicateContactsIds.Count == 0) {
+            _logger.LogError("Duplicates list cannot be empty for primary contact Id: {PrimaryContactId}", @event.PrimaryContactId);
+            return;
+        }
+        if (@event.DuplicateContactsIds.Contains(@event.PrimaryContactId)) {
+            _logger.LogError("Duplicates list should not contain main contact Id: {PrimaryContactId}", @event.PrimaryContactId);
+            return;
+        }
+        await _contactService.MergeContacts(mainContact, @event.DuplicateContactsIds);
+    }
+}

--- a/src/Indice.Features.Messages.Core/Services/ContactService.cs
+++ b/src/Indice.Features.Messages.Core/Services/ContactService.cs
@@ -17,13 +17,10 @@ public class ContactService : IContactService
 {
     /// <summary>Creates a new instance of <see cref="ContactService"/>.</summary>
     /// <param name="dbContext">The <see cref="Microsoft.EntityFrameworkCore.DbContext"/> for Campaigns API feature.</param>
-    /// <param name="eventDispatcherFactory">The <see cref="IEventDispatcherFactory"/> for dispatching events.</param>
     /// <exception cref="ArgumentNullException"></exception>
-    public ContactService(CampaignsDbContext dbContext, IEventDispatcherFactory eventDispatcherFactory) {
+    public ContactService(CampaignsDbContext dbContext) {
         DbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
-        EventDispatcherFactory = eventDispatcherFactory ?? throw new ArgumentNullException(nameof(eventDispatcherFactory));
     }
-    private IEventDispatcherFactory EventDispatcherFactory { get; }
     private CampaignsDbContext DbContext { get; }
     /// <inheritdoc />
     public async Task AddToDistributionList(Guid id, CreateDistributionListContactRequest request) {
@@ -323,22 +320,7 @@ public class ContactService : IContactService
                                     .ToList()
                             }
                         });
-        try {
-            return await query.SingleOrDefaultAsync();
-        } catch (InvalidOperationException) {
-            // More than one matching record was found
-            var duplicateContacts = await query.ToListAsync();
-            var primaryRecord = duplicateContacts.OrderByDescending(r => r.UpdatedAt).First();
-            var eventDispatcher = EventDispatcherFactory.Create(Core.KeyedServiceNames.EventDispatcherServiceKey);
-            await eventDispatcher.RaiseEventAsync(
-                new MergeContactsEvent() {
-                    PrimaryContactId = primaryRecord.Id!.Value,
-                    DuplicateContactsIds = [.. duplicateContacts.Where(r => r.Id != primaryRecord.Id).Select(r => r.Id!.Value)]
-                },
-                builder => builder.WrapInEnvelope().WithQueueName(EventNames.MergeContacts)
-            );
-            return primaryRecord;
-        }
+        return await query.SingleOrDefaultAsync();
     }
 
 

--- a/src/Indice.Features.Messages.Core/Services/ContactService.cs
+++ b/src/Indice.Features.Messages.Core/Services/ContactService.cs
@@ -1,10 +1,12 @@
 ﻿using System.Data.Common;
 using Indice.Features.Messages.Core.Data;
 using Indice.Features.Messages.Core.Data.Models;
+using Indice.Features.Messages.Core.Events;
 using Indice.Features.Messages.Core.Exceptions;
 using Indice.Features.Messages.Core.Models;
 using Indice.Features.Messages.Core.Models.Requests;
 using Indice.Features.Messages.Core.Services.Abstractions;
+using Indice.Services;
 using Indice.Types;
 using Microsoft.EntityFrameworkCore;
 
@@ -15,11 +17,13 @@ public class ContactService : IContactService
 {
     /// <summary>Creates a new instance of <see cref="ContactService"/>.</summary>
     /// <param name="dbContext">The <see cref="Microsoft.EntityFrameworkCore.DbContext"/> for Campaigns API feature.</param>
+    /// <param name="eventDispatcherFactory">The <see cref="IEventDispatcherFactory"/> for dispatching events.</param>
     /// <exception cref="ArgumentNullException"></exception>
-    public ContactService(CampaignsDbContext dbContext) {
+    public ContactService(CampaignsDbContext dbContext, IEventDispatcherFactory eventDispatcherFactory) {
         DbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        EventDispatcherFactory = eventDispatcherFactory ?? throw new ArgumentNullException(nameof(eventDispatcherFactory));
     }
-
+    private IEventDispatcherFactory EventDispatcherFactory { get; }
     private CampaignsDbContext DbContext { get; }
     /// <inheritdoc />
     public async Task AddToDistributionList(Guid id, CreateDistributionListContactRequest request) {
@@ -319,7 +323,22 @@ public class ContactService : IContactService
                                     .ToList()
                             }
                         });
-        return await query.SingleOrDefaultAsync();
+        try {
+            return await query.SingleOrDefaultAsync();
+        } catch (InvalidOperationException) {
+            // More than one matching record was found
+            var duplicateContacts = await query.ToListAsync();
+            var primaryRecord = duplicateContacts.OrderByDescending(r => r.UpdatedAt).First();
+            var eventDispatcher = EventDispatcherFactory.Create(Core.KeyedServiceNames.EventDispatcherServiceKey);
+            await eventDispatcher.RaiseEventAsync(
+                new MergeContactsEvent() {
+                    PrimaryContactId = primaryRecord.Id!.Value,
+                    DuplicateContactsIds = [.. duplicateContacts.Where(r => r.Id != primaryRecord.Id).Select(r => r.Id!.Value)]
+                },
+                builder => builder.WrapInEnvelope().WithQueueName(EventNames.MergeContacts)
+            );
+            return primaryRecord;
+        }
     }
 
 
@@ -398,8 +417,7 @@ public class ContactService : IContactService
                 await DbContext.ContactPreferences.AddAsync(recipientPreferences);
                 await DbContext.SaveChangesAsync();
                 return;
-            } 
-            catch (DbUpdateException ex) when (IsDuplicateKeyViolation(ex)) {
+            } catch (DbUpdateException ex) when (IsDuplicateKeyViolation(ex)) {
                 DbContext.ChangeTracker.Clear();
                 recipientPreferences = await DbContext.ContactPreferences
                                            .Include(x => x.CommunicationOptions)
@@ -447,8 +465,7 @@ public class ContactService : IContactService
                 await DbContext.ContactPreferences.AddAsync(recipientPreferences);
                 await DbContext.SaveChangesAsync();
                 return;
-            } 
-            catch (DbUpdateException ex) when(IsDuplicateKeyViolation(ex)) {
+            } catch (DbUpdateException ex) when (IsDuplicateKeyViolation(ex)) {
                 DbContext.ChangeTracker.Clear();
                 recipientPreferences = await DbContext.ContactPreferences
                                              .Include(x => x.CommunicationOptions)

--- a/src/Indice.Features.Messages.Core/Services/MessageService.cs
+++ b/src/Indice.Features.Messages.Core/Services/MessageService.cs
@@ -24,7 +24,7 @@ public class MessageService : IMessageService
     /// <param name="dbContext">The <see cref="Microsoft.EntityFrameworkCore.DbContext"/> for Campaigns API feature.</param>
     /// <param name="campaignInboxOptions">Options used to configure the Campaigns inbox API feature.</param>
     /// <param name="contactResolver">Contact resolver service</param>
-    /// <param name="contactService"></param>
+    /// <param name="contactService">Contacts management service</param>
     /// <param name="messageEventQueue">Event queue</param>
     /// <param name="partialTemplateResolverFactory">Partial template resolver factory</param>
     /// <exception cref="ArgumentNullException"></exception>

--- a/src/Indice.Features.Messages.Worker.Azure/HostBuilderExtensions.cs
+++ b/src/Indice.Features.Messages.Worker.Azure/HostBuilderExtensions.cs
@@ -129,6 +129,7 @@ public static class HostBuilderExtensions
         services.TryAddTransient<ICampaignJobHandler<SendSmsEvent>, SendSmsHandler>();
         services.TryAddTransient<ICampaignJobHandler<MarkMessagesReadEvent>, MarkReadEventHandler>();
         services.TryAddTransient<ICampaignJobHandler<MarkMessagesUnreadEvent>, MarkUnreadEventHandler>();
+        services.TryAddTransient<ICampaignJobHandler<MergeContactsEvent>, MergeContactsEventHandler>();
         services.TryAddTransient<ICampaignJobHandler<MessagingDatabaseCleanUpTimerEvent>, MessagingDatabaseCleanUpHandler>();
         services.AddTransient<MessageJobHandlerFactory>();
         return services;

--- a/src/Indice.Features.Messages.Worker.Azure/HostBuilderExtensions.cs
+++ b/src/Indice.Features.Messages.Worker.Azure/HostBuilderExtensions.cs
@@ -349,7 +349,8 @@ public static class HostBuilderExtensions
                                                             EventNames.SendPushNotification,
                                                             EventNames.SendSms,
                                                             EventNames.MarkAllAsRead,
-                                                            EventNames.MarkAllAsUnread
+                                                            EventNames.MarkAllAsUnread,
+                                                            EventNames.MergeContacts
                                                             );
 
     internal static readonly ExtendedFunctionMetadataProviderDisablePredicate ExcludeServiceBusTriggers =
@@ -359,8 +360,8 @@ public static class HostBuilderExtensions
                                                             $"{ServiceBusTriggers.ServiceBusTriggerPrefix}{EventNames.SendPushNotification}",
                                                             $"{ServiceBusTriggers.ServiceBusTriggerPrefix}{EventNames.SendSms}",
                                                             $"{ServiceBusTriggers.ServiceBusTriggerPrefix}{EventNames.MarkAllAsRead}",
-                                                            $"{ServiceBusTriggers.ServiceBusTriggerPrefix}{EventNames.MarkAllAsUnread}");
-
+                                                            $"{ServiceBusTriggers.ServiceBusTriggerPrefix}{EventNames.MarkAllAsUnread}",
+                                                            $"{ServiceBusTriggers.ServiceBusTriggerPrefix}{EventNames.MergeContacts}");
     internal static ExtendedFunctionMetadataProviderDisablePredicate ExcludeFunctions(params string[] functionNames) {
         return (fn, Configuration) => functionNames.Any(x => x.Equals(fn.Name, StringComparison.OrdinalIgnoreCase));
     }

--- a/src/Indice.Features.Messages.Worker.Azure/QueueTriggers.cs
+++ b/src/Indice.Features.Messages.Worker.Azure/QueueTriggers.cs
@@ -128,7 +128,7 @@ internal class QueueTriggers
 
     [Function(EventNames.MergeContacts)]
     public async Task MergeContactsHandler(
-        [QueueTrigger("%ENVIRONMENT%-" + EventNames.MergeContacts, Connection = "ServiceBusConnection")] byte[] message,
+        [QueueTrigger("%ENVIRONMENT%-" + EventNames.MergeContacts, Connection = "StorageConnection" )] byte[] message,
         FunctionContext functionContext
     ) {
         LogExecution(functionContext, EventNames.MergeContacts);

--- a/src/Indice.Features.Messages.Worker.Azure/QueueTriggers.cs
+++ b/src/Indice.Features.Messages.Worker.Azure/QueueTriggers.cs
@@ -126,6 +126,18 @@ internal class QueueTriggers
         await CampaignJobHandlerFactory.CreateFor<MarkMessagesUnreadEvent>().Process(payload!);
     }
 
+    [Function(EventNames.MergeContacts)]
+    public async Task MergeContactsHandler(
+        [QueueTrigger("%ENVIRONMENT%-" + EventNames.MergeContacts, Connection = "ServiceBusConnection")] byte[] message,
+        FunctionContext functionContext
+    ) {
+        LogExecution(functionContext, EventNames.MergeContacts);
+        var originalMessage = await CompressionUtils.Decompress(message);
+        var envelope = JsonSerializer.Deserialize<Envelope<MergeContactsEvent>>(originalMessage, JsonSerializerOptions)!;
+        var payload = envelope.Payload;
+        await CampaignJobHandlerFactory.CreateFor<MergeContactsEvent>().Process(payload!);
+    }
+
     private static void LogExecution(FunctionContext functionContext, string eventName) {
         var logger = functionContext.GetLogger(eventName);
         logger.LogInformation("Function '{FunctionName}' was triggered.", eventName);

--- a/src/Indice.Features.Messages.Worker.Azure/ServiceBusTriggers.cs
+++ b/src/Indice.Features.Messages.Worker.Azure/ServiceBusTriggers.cs
@@ -115,6 +115,17 @@ internal class ServiceBusTriggers
         await CampaignJobHandlerFactory.CreateFor<MarkMessagesUnreadEvent>().Process(payload!);
     }
 
+    [Function(ServiceBusTriggerPrefix + EventNames.MergeContacts)]
+    public async Task MergeContactsHandler(
+        [QueueTrigger("%ENVIRONMENT%-" + EventNames.MergeContacts, Connection = "ServiceBusConnection")] byte[] message,
+        FunctionContext functionContext
+    ) {
+        LogExecution(functionContext, EventNames.MergeContacts);
+        var envelope = JsonSerializer.Deserialize<Envelope<MergeContactsEvent>>(await ReadMessageAsync(message), JsonSerializerOptions)!;
+        var payload = envelope.Payload;
+        await CampaignJobHandlerFactory.CreateFor<MergeContactsEvent>().Process(payload!);
+    }
+
     private async Task<byte[]> ReadMessageAsync(byte[] message) {
         if (_options.UseCompression) {
             return await CompressionUtils.Decompress(message);

--- a/src/Indice.Features.Messages.Worker.Azure/ServiceBusTriggers.cs
+++ b/src/Indice.Features.Messages.Worker.Azure/ServiceBusTriggers.cs
@@ -117,7 +117,7 @@ internal class ServiceBusTriggers
 
     [Function(ServiceBusTriggerPrefix + EventNames.MergeContacts)]
     public async Task MergeContactsHandler(
-        [QueueTrigger("%ENVIRONMENT%-" + EventNames.MergeContacts, Connection = "ServiceBusConnection")] byte[] message,
+        [ServiceBusTrigger("%ENVIRONMENT%-" + EventNames.MergeContacts, Connection = "ServiceBusConnection")] byte[] message,
         FunctionContext functionContext
     ) {
         LogExecution(functionContext, EventNames.MergeContacts);

--- a/src/Indice.Features.Messages.Worker/Handlers/MarkAllAsReadHandler.cs
+++ b/src/Indice.Features.Messages.Worker/Handlers/MarkAllAsReadHandler.cs
@@ -1,0 +1,24 @@
+﻿using Indice.Features.Messages.Core.Events;
+using Indice.Features.Messages.Core.Handlers;
+using Microsoft.Extensions.Logging;
+
+namespace Indice.Features.Messages.Worker.Handlers;
+
+internal class MarkAllAsReadHandler
+{
+    public MarkAllAsReadHandler(
+        ILogger<MarkAllAsReadHandler> logger,
+        MessageJobHandlerFactory messageJobHandlerFactory
+    ) {
+        Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        MessageJobHandlerFactory = messageJobHandlerFactory ?? throw new ArgumentNullException(nameof(messageJobHandlerFactory));
+    }
+
+    public ILogger<MarkAllAsReadHandler> Logger { get; }
+    public MessageJobHandlerFactory MessageJobHandlerFactory { get; }
+
+    public async Task Process(MarkMessagesReadEvent @event) {
+        var handler = MessageJobHandlerFactory.CreateFor<MarkMessagesReadEvent>();
+        await handler.Process(@event);
+    }
+}

--- a/src/Indice.Features.Messages.Worker/Handlers/MarkAllAsUnreadHandler.cs
+++ b/src/Indice.Features.Messages.Worker/Handlers/MarkAllAsUnreadHandler.cs
@@ -1,0 +1,24 @@
+﻿using Indice.Features.Messages.Core.Events;
+using Indice.Features.Messages.Core.Handlers;
+using Microsoft.Extensions.Logging;
+
+namespace Indice.Features.Messages.Worker.Handlers;
+
+internal class MarkAllAsUnreadHandler
+{
+    public MarkAllAsUnreadHandler(
+        ILogger<MarkAllAsUnreadHandler> logger,
+        MessageJobHandlerFactory messageJobHandlerFactory
+    ) {
+        Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        MessageJobHandlerFactory = messageJobHandlerFactory ?? throw new ArgumentNullException(nameof(messageJobHandlerFactory));
+    }
+
+    public ILogger<MarkAllAsUnreadHandler> Logger { get; }
+    public MessageJobHandlerFactory MessageJobHandlerFactory { get; }
+
+    public async Task Process(MarkMessagesUnreadEvent @event) {
+        var handler = MessageJobHandlerFactory.CreateFor<MarkMessagesUnreadEvent>();
+        await handler.Process(@event);
+    }
+}

--- a/src/Indice.Features.Messages.Worker/Handlers/MergeContactsHandler.cs
+++ b/src/Indice.Features.Messages.Worker/Handlers/MergeContactsHandler.cs
@@ -1,0 +1,24 @@
+﻿using Indice.Features.Messages.Core.Events;
+using Indice.Features.Messages.Core.Handlers;
+using Microsoft.Extensions.Logging;
+
+namespace Indice.Features.Messages.Worker.Handlers;
+
+internal class MergeContactsHandler
+{
+    public MergeContactsHandler(
+        ILogger<MergeContactsHandler> logger,
+        MessageJobHandlerFactory messageJobHandlerFactory
+    ) {
+        Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        MessageJobHandlerFactory = messageJobHandlerFactory ?? throw new ArgumentNullException(nameof(messageJobHandlerFactory));
+    }
+
+    public ILogger<MergeContactsHandler> Logger { get; }
+    public MessageJobHandlerFactory MessageJobHandlerFactory { get; }
+
+    public async Task Process(MergeContactsEvent @event) {
+        var handler = MessageJobHandlerFactory.CreateFor<MergeContactsEvent>();
+        await handler.Process(@event);
+    }
+}

--- a/src/Indice.Features.Messages.Worker/WorkerHostBuilderExtensions.cs
+++ b/src/Indice.Features.Messages.Worker/WorkerHostBuilderExtensions.cs
@@ -88,12 +88,29 @@ public static class WorkerHostBuilderExtensions
             options.MaxPollingInterval = options.PollingInterval + messageOptions.QueueMaxPollingInterval;
             options.InstanceCount = 1;
         })
+        .AddJob<MarkAllAsReadHandler>().WithQueueTrigger<MarkMessagesReadEvent>(options => {
+            options.QueueName = EventNames.SendSms;
+            options.PollingInterval = random.Next((int)messageOptions.QueuePollingInterval, (int)messageOptions.QueuePollingInterval + 200);
+            options.MaxPollingInterval = options.PollingInterval + messageOptions.QueueMaxPollingInterval;
+            options.InstanceCount = 1;
+        })
+        .AddJob<MarkAllAsUnreadHandler>().WithQueueTrigger<MarkMessagesUnreadEvent>(options => {
+            options.QueueName = EventNames.SendSms;
+            options.PollingInterval = random.Next((int)messageOptions.QueuePollingInterval, (int)messageOptions.QueuePollingInterval + 200);
+            options.MaxPollingInterval = options.PollingInterval + messageOptions.QueueMaxPollingInterval;
+            options.InstanceCount = 1;
+        })
+        .AddJob<MergeContactsHandler>().WithQueueTrigger<MergeContactsEvent>(options => {
+            options.QueueName = EventNames.SendSms;
+            options.PollingInterval = random.Next((int)messageOptions.QueuePollingInterval, (int)messageOptions.QueuePollingInterval + 200);
+            options.MaxPollingInterval = options.PollingInterval + messageOptions.QueueMaxPollingInterval;
+            options.InstanceCount = 1;
+        })
         .AddJob<MessagingDatabaseCleanUpJobHandler>().WithScheduleTrigger(messageOptions.DatabaseCleanUpCronExpression, options => {
             options.Singleton = true;
             options.Name = nameof(MessagingDatabaseCleanUpJobHandler);
             options.Group = nameof(MessagingDatabaseCleanUpJobHandler);
         });
-
     }
 
     private static void AddJobHandlerServices(this IServiceCollection services) {

--- a/src/Indice.Features.Messages.Worker/WorkerHostBuilderExtensions.cs
+++ b/src/Indice.Features.Messages.Worker/WorkerHostBuilderExtensions.cs
@@ -89,19 +89,19 @@ public static class WorkerHostBuilderExtensions
             options.InstanceCount = 1;
         })
         .AddJob<MarkAllAsReadHandler>().WithQueueTrigger<MarkMessagesReadEvent>(options => {
-            options.QueueName = EventNames.SendSms;
+            options.QueueName = EventNames.MarkAllAsRead;
             options.PollingInterval = random.Next((int)messageOptions.QueuePollingInterval, (int)messageOptions.QueuePollingInterval + 200);
             options.MaxPollingInterval = options.PollingInterval + messageOptions.QueueMaxPollingInterval;
             options.InstanceCount = 1;
         })
         .AddJob<MarkAllAsUnreadHandler>().WithQueueTrigger<MarkMessagesUnreadEvent>(options => {
-            options.QueueName = EventNames.SendSms;
+            options.QueueName = EventNames.MarkAllAsUnread;
             options.PollingInterval = random.Next((int)messageOptions.QueuePollingInterval, (int)messageOptions.QueuePollingInterval + 200);
             options.MaxPollingInterval = options.PollingInterval + messageOptions.QueueMaxPollingInterval;
             options.InstanceCount = 1;
         })
         .AddJob<MergeContactsHandler>().WithQueueTrigger<MergeContactsEvent>(options => {
-            options.QueueName = EventNames.SendSms;
+            options.QueueName = EventNames.MergeContacts;
             options.PollingInterval = random.Next((int)messageOptions.QueuePollingInterval, (int)messageOptions.QueuePollingInterval + 200);
             options.MaxPollingInterval = options.PollingInterval + messageOptions.QueueMaxPollingInterval;
             options.InstanceCount = 1;

--- a/test/Indice.Features.Messages.Tests/MergeContactTests.cs
+++ b/test/Indice.Features.Messages.Tests/MergeContactTests.cs
@@ -40,6 +40,7 @@ public class MergeContactTests : IAsyncLifetime
             .AddTransient<IContactService, ContactService>()
             .AddTransient(serviceProvider => new DatabaseSchemaNameResolver("cmp"))
             .AddTransient<IUserNameAccessor, UserNameAccessorNoOp>()
+            .AddTransient<IEventDispatcherFactory, DefaultEventDispatcherFactory>()
             .AddTransient<UserNameAccessorAggregate>()
             .AddOptions()
             .Configure<MessageManagementOptions>(configuration);


### PR DESCRIPTION
- Refactored exception handling in `ContactService` to automerge duplicate contacts.
- Introduced `MergeContacts` constant in `Constants.cs`.
- Updated `ContactService` to handle duplicate contacts.
- Added `MergeContactsEvent` and `MergeContactsEventHandler`.
- Updated `HostBuilderExtensions` for `MergeContacts` event.
- Added `MergeContactsHandler` for worker processing.
- Updated `QueueTriggers` and `ServiceBusTriggers` for new event.
- Registered `MergeContactsHandler` in `WorkerHostBuilderExtensions`.
- Added `MarkAllAsReadHandler` and `MarkAllAsUnreadHandler`.