### PR TITLE
[identity] Support culture-aware Terms/Privacy URL resolvers

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,7 +9,7 @@
 
     <VersionPrefixCore>$(VersionPrefixBase).1</VersionPrefixCore>
     <VersionPrefixIdentity>$(VersionPrefixBase).1</VersionPrefixIdentity>
-    <VersionPrefixIdentityUI>$(VersionPrefixBase).1</VersionPrefixIdentityUI>
+    <VersionPrefixIdentityUI>$(VersionPrefixBase).2</VersionPrefixIdentityUI>
     <VersionPrefixCases>$(VersionPrefixBase).1</VersionPrefixCases>
     <VersionPrefixMessages>$(VersionPrefixBase).1</VersionPrefixMessages>
     <VersionPrefixMultitenancy>$(VersionPrefixBase).1</VersionPrefixMultitenancy>

--- a/src/Indice.Features.Identity.UI/IdentityBuilderUIExtensions.cs
+++ b/src/Indice.Features.Identity.UI/IdentityBuilderUIExtensions.cs
@@ -70,7 +70,7 @@ public static class IdentityBuilderUIExtensions
             foreach (var url in configuredOptions.ValidReturnUrls) {
                 options.ValidReturnUrls.Add(url);
             }
-            options.ProductionEnvironments.UnionWith(configuredOptions.ProductionEnvironments);
+            options.ProductionEnvironmentsSet.UnionWith(configuredOptions.ProductionEnvironmentsSet);
         });
 #if NET9_0_OR_GREATER
         services.AddSingleton<IConfigureOptions<IdentityServerOptions>, IdentityServerOptionsConfigure>();

--- a/src/Indice.Features.Identity.UI/IdentityBuilderUIExtensions.cs
+++ b/src/Indice.Features.Identity.UI/IdentityBuilderUIExtensions.cs
@@ -59,17 +59,18 @@ public static class IdentityBuilderUIExtensions
             options.HomePageSlogan = configuredOptions.HomePageSlogan;
             options.HtmlBodyBackgroundCssClass = configuredOptions.HtmlBodyBackgroundCssClass;
             options.OverrideDefaultStaticFileMiddleware = configuredOptions.OverrideDefaultStaticFileMiddleware;
+            options.PrivacyUrlResolver = configuredOptions.PrivacyUrlResolver;
+            options.TermsUrlResolver = configuredOptions.TermsUrlResolver;
             options.PrivacyUrl = configuredOptions.PrivacyUrl;
+            options.TermsUrl = configuredOptions.TermsUrl;
             options.RememberMeLoginDuration = configuredOptions.RememberMeLoginDuration;
             options.ShowLogoutPrompt = configuredOptions.ShowLogoutPrompt;
-            options.TermsUrl = configuredOptions.TermsUrl;
             options.Events = configuredOptions.Events;
             options.EnablePhoneNumberCallingCodes = configuredOptions.EnablePhoneNumberCallingCodes;
             foreach (var url in configuredOptions.ValidReturnUrls) {
                 options.ValidReturnUrls.Add(url);
             }
-            options.ProductionEnvironments = new StringValues(options.ProductionEnvironments.Concat(configuredOptions.ProductionEnvironments)
-                                                                                            .Distinct(StringComparer.OrdinalIgnoreCase).ToArray());
+            options.ProductionEnvironments.UnionWith(configuredOptions.ProductionEnvironments);
         });
 #if NET9_0_OR_GREATER
         services.AddSingleton<IConfigureOptions<IdentityServerOptions>, IdentityServerOptionsConfigure>();

--- a/src/Indice.Features.Identity.UI/IdentityUIOptions.cs
+++ b/src/Indice.Features.Identity.UI/IdentityUIOptions.cs
@@ -1,4 +1,5 @@
-﻿using System.Security.Claims;
+﻿using System.Globalization;
+using System.Security.Claims;
 using Indice.Features.Identity.Core.Data.Models;
 using Indice.Security;
 using Microsoft.AspNetCore.Http;
@@ -27,12 +28,33 @@ public class IdentityUIOptions
     /// </list>
     /// </remarks>
     public string HomePageSlogan { get; set; } = "Welcome to the {0} Digital Services <strong>Portal</strong>";
+
+    /// <summary>
+    /// A function that resolves the terms and conditions url based on the current culture. 
+    /// It will be used in the login and register pages. If not set, the default behavior is to use the <see cref="TermsUrl"/> property which can also be set with culture placeholders like {0} for two letter ISO language name and {1} for region name. For example: https://example.com/terms-{0}-{1}.html 
+    /// </summary>
+    public Func<CultureInfo, string?>? TermsUrlResolver { get; set; }
+
+    /// <summary>
+    /// A function that resolves the privacy url based on the current culture. 
+    /// It will be used in the login and register pages. If not set, the default behavior is to use the <see cref="PrivacyUrl"/> property which can also be set with culture placeholders like {0} for two letter ISO language name and {1} for region name. For example: https://example.com/privacy-{0}-{1}.html 
+    /// </summary>
+    public Func<CultureInfo, string?>? PrivacyUrlResolver { get; set; }
+
     /// <summary>An absolute URL to the <strong>terms and conditions</strong> web page. Use it when this page is located to (or shared with) an external website.</summary>
     /// <remarks>If left null the <strong>./legal/terms.md</strong> will be used. If populated it will do a redirect to this URL</remarks>
-    public string? TermsUrl { get; set; }
+    public string? TermsUrl {
+        get => TermsUrlResolver != null ? TermsUrlResolver(CultureInfo.CurrentCulture) : field;
+        set => field = TermsUrlResolver != null ? null : value;
+    }
+
     /// <summary>An absolute URL to the <strong>privacy</strong> web page. Use it when this page is located to (or shared with) an external website.</summary>
     /// <remarks>If left null the <strong>./legal/privacy.md</strong> will be used. If populated it will do a redirect to this URL</remarks>
-    public string? PrivacyUrl { get; set; }
+    public string? PrivacyUrl {
+        get => PrivacyUrlResolver != null ? PrivacyUrlResolver(CultureInfo.CurrentCulture) : field;
+        set => field = PrivacyUrlResolver != null ? null : value;
+    }
+
     /// <summary>An absolute URL to the <strong>Contact us</strong> web page. Use it when this page is located to (or shared with) an external website.</summary>
     /// <remarks>If left null the <strong>Contact Us</strong> link in the footer will disappear. If populated it will do a redirect to this URL. By default it is empty</remarks>
     public string? ContactUsUrl { get; set; }
@@ -96,12 +118,13 @@ public class IdentityUIOptions
     /// <summary>
     /// A collection of production environment names. Used to determine whether the environment is production and exclude the ribbon in the UI.
     /// </summary>
-    public StringValues ProductionEnvironments { get; set; } = new StringValues([ "prod", "Production", "live" ]);
+    public HashSet<string> ProductionEnvironments { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "prod", "Production", "live" };
+
 
     /// <summary>Services shown in the homepage.</summary>
-    public List<HomePageLink> HomepageLinks { get; } = new List<HomePageLink>() {
-        new HomePageLink("Admin","~/admin", CssClass:"admin", VisibilityPredicate: user => user.IsAdmin())
-    };
+    public List<HomePageLink> HomepageLinks { get; } = [
+        new ("Admin","~/admin", CssClass:"admin", VisibilityPredicate: user => user.IsAdmin())
+    ];
     /// <summary>
     /// Should show the Add Email page before sending the confirmation email prompt (in case of pernding confirmation login) or Confirm emai immediately.
     /// </summary>

--- a/src/Indice.Features.Identity.UI/IdentityUIOptions.cs
+++ b/src/Indice.Features.Identity.UI/IdentityUIOptions.cs
@@ -31,18 +31,18 @@ public class IdentityUIOptions
 
     /// <summary>
     /// A function that resolves the terms and conditions url based on the current culture. 
-    /// It will be used in the login and register pages. If not set, the default behavior is to use the <see cref="TermsUrl"/> property which can also be set with culture placeholders like {0} for two letter ISO language name and {1} for region name. For example: https://example.com/terms-{0}-{1}.html 
+    /// It will be used in the login and register pages. If not set, the default behavior is to use the <see cref="TermsUrl"/> property as-is. Use this resolver for culture-specific URLs.
     /// </summary>
     public Func<CultureInfo, string?>? TermsUrlResolver { get; set; }
 
     /// <summary>
     /// A function that resolves the privacy url based on the current culture. 
-    /// It will be used in the login and register pages. If not set, the default behavior is to use the <see cref="PrivacyUrl"/> property which can also be set with culture placeholders like {0} for two letter ISO language name and {1} for region name. For example: https://example.com/privacy-{0}-{1}.html 
+    /// It will be used in the login and register pages. If not set, the default behavior is to use the <see cref="PrivacyUrl"/> property as-is. Use this resolver for culture-specific URLs.
     /// </summary>
     public Func<CultureInfo, string?>? PrivacyUrlResolver { get; set; }
 
     /// <summary>An absolute URL to the <strong>terms and conditions</strong> web page. Use it when this page is located to (or shared with) an external website.</summary>
-    /// <remarks>If left null the <strong>./legal/terms.md</strong> will be used. If populated it will do a redirect to this URL</remarks>
+    /// <remarks>If left null the <strong>./legal/terms.md</strong> will be used. If populated it will do a redirect to this URL. This value is not format-expanded; use <see cref="TermsUrlResolver"/> for culture-specific URLs.</remarks>
     public string? TermsUrl {
         get => TermsUrlResolver != null ? TermsUrlResolver(CultureInfo.CurrentCulture) : field;
         set => field = TermsUrlResolver != null ? null : value;

--- a/src/Indice.Features.Identity.UI/IdentityUIOptions.cs
+++ b/src/Indice.Features.Identity.UI/IdentityUIOptions.cs
@@ -115,10 +115,13 @@ public class IdentityUIOptions
     /// </summary>
     public string PhoneNumberStoreFormat => EnablePhoneNumberCallingCodes ? "G" : "N";
 
+    /// <summary>The production environment names.</summary>
+    public StringValues ProductionEnvironments => new StringValues(ProductionEnvironmentsSet.ToArray());
+
     /// <summary>
     /// A collection of production environment names. Used to determine whether the environment is production and exclude the ribbon in the UI.
     /// </summary>
-    public HashSet<string> ProductionEnvironments { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "prod", "Production", "live" };
+    public HashSet<string> ProductionEnvironmentsSet { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "prod", "Production", "live" };
 
 
     /// <summary>Services shown in the homepage.</summary>


### PR DESCRIPTION
Add TermsUrlResolver and PrivacyUrlResolver to IdentityUIOptions for culture-specific URLs. Change ProductionEnvironments to HashSet<string> for better merging and case-insensitive checks. Update IdentityBuilderUIExtensions to handle new properties and use UnionWith for environment merging. Minor code style improvements.