### PR TITLE
[aspnetcore] Add null check for schema.Annotations in transformer

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,20 +7,20 @@
     <VersionPrefixMajor>8</VersionPrefixMajor>
     <VersionPrefixBase>$(VersionPrefixMajor).48</VersionPrefixBase>
 
-    <VersionPrefixCore>$(VersionPrefixBase).0</VersionPrefixCore>
-    <VersionPrefixIdentity>$(VersionPrefixBase).0</VersionPrefixIdentity>
-    <VersionPrefixIdentityUI>$(VersionPrefixBase).0</VersionPrefixIdentityUI>
-    <VersionPrefixCases>$(VersionPrefixBase).0</VersionPrefixCases>
-    <VersionPrefixMessages>$(VersionPrefixBase).0</VersionPrefixMessages>
-    <VersionPrefixMultitenancy>$(VersionPrefixBase).0</VersionPrefixMultitenancy>
-    <VersionPrefixRisk>$(VersionPrefixBase).0</VersionPrefixRisk>
-    <VersionPrefixMedia>$(VersionPrefixBase).0</VersionPrefixMedia>
-    <VersionPrefixGeoIP>$(VersionPrefixBase).0</VersionPrefixGeoIP>
-    <VersionPrefixGovGr>$(VersionPrefixBase).0</VersionPrefixGovGr>
-    <VersionPrefixAspNet>$(VersionPrefixBase).0</VersionPrefixAspNet>
-    <VersionPrefixActivityLogs>$(VersionPrefixBase).0</VersionPrefixActivityLogs>
-    <VersionPrefixFtpServer>$(VersionPrefixBase).0</VersionPrefixFtpServer>
-    <VersionPrefix>$(VersionPrefixBase).0</VersionPrefix>
+    <VersionPrefixCore>$(VersionPrefixBase).1</VersionPrefixCore>
+    <VersionPrefixIdentity>$(VersionPrefixBase).1</VersionPrefixIdentity>
+    <VersionPrefixIdentityUI>$(VersionPrefixBase).1</VersionPrefixIdentityUI>
+    <VersionPrefixCases>$(VersionPrefixBase).1</VersionPrefixCases>
+    <VersionPrefixMessages>$(VersionPrefixBase).1</VersionPrefixMessages>
+    <VersionPrefixMultitenancy>$(VersionPrefixBase).1</VersionPrefixMultitenancy>
+    <VersionPrefixRisk>$(VersionPrefixBase).1</VersionPrefixRisk>
+    <VersionPrefixMedia>$(VersionPrefixBase).1</VersionPrefixMedia>
+    <VersionPrefixGeoIP>$(VersionPrefixBase).1</VersionPrefixGeoIP>
+    <VersionPrefixGovGr>$(VersionPrefixBase).1</VersionPrefixGovGr>
+    <VersionPrefixAspNet>$(VersionPrefixBase).1</VersionPrefixAspNet>
+    <VersionPrefixActivityLogs>$(VersionPrefixBase).1</VersionPrefixActivityLogs>
+    <VersionPrefixFtpServer>$(VersionPrefixBase).1</VersionPrefixFtpServer>
+    <VersionPrefix>$(VersionPrefixBase).1</VersionPrefix>
 
     <!--<VersionSuffix>rc06</VersionSuffix>-->
     <Authors>Constantinos Leftheris</Authors>

--- a/src/Indice.AspNetCore/OpenApi/Transformers/NullableTransformer.net9.cs
+++ b/src/Indice.AspNetCore/OpenApi/Transformers/NullableTransformer.net9.cs
@@ -90,7 +90,7 @@ public static class NullableTransformer
             }
             if (context.ParameterDescription is not null) {
                 // And remove default value of null if set
-                if (schema.Default is OpenApiNull && schema.Annotations.Any(x => x.Value != null) == true) {
+                if (schema.Default is OpenApiNull && schema.Annotations?.Any(x => x.Value != null) == true) {
                     schema.Default = null;
                 }
             }


### PR DESCRIPTION
Added a null-conditional operator when accessing schema.Annotations to prevent potential NullReferenceException if Annotations is null. This improves robustness when handling OpenApi schema defaults.

Update all VersionPrefix* properties to use .1 instead of .0, incrementing the patch version for all related projects. No other changes included.