### PR TITLE
[identity] Add full CRUD support for API scopes and claims

### DIFF
--- a/src/Indice.Features.Identity.Server/Manager/ResourceHandlers.cs
+++ b/src/Indice.Features.Identity.Server/Manager/ResourceHandlers.cs
@@ -310,11 +310,11 @@ internal static class ResourceHandlers
             return TypedResults.ValidationProblem(ValidationErrors.AddError(nameof(scopeName).ToLower(), "ScopeName is required"));
         }
         scopeName = scopeName.Trim();
-        var apiScope = await configurationDbContext.ApiScopes.SingleOrDefaultAsync(x => x.Name == scopeName);
+        var apiScope = await configurationDbContext.ApiScopes.Include(x => x.UserClaims).SingleOrDefaultAsync(x => x.Name == scopeName);
         if (apiScope == null) {
             return TypedResults.NotFound();
         }
-        if (!(claims?.Length > 0)) {
+        if (claims is not [_, ..]) {
             return TypedResults.ValidationProblem(ValidationErrors.AddError("claims", "A claims list is required"));
         }
         apiScope.UserClaims =
@@ -519,7 +519,7 @@ internal static class ResourceHandlers
         if (resource == null) {
             return TypedResults.NotFound();
         }
-        if (!(claims?.Length > 0)) {
+        if (claims is not [_, ..]) {
             return TypedResults.ValidationProblem(ValidationErrors.AddError("claims", "A claims list is required"));
         }
         resource.UserClaims =

--- a/src/Indice.Features.Identity.Server/Manager/ResourceHandlers.cs
+++ b/src/Indice.Features.Identity.Server/Manager/ResourceHandlers.cs
@@ -209,6 +209,148 @@ internal static class ResourceHandlers
         return TypedResults.Ok(scopes);
     }
 
+    internal static async Task<Results<Ok<ApiScopeInfo>, NotFound, ValidationProblem>> CreateApiScope(
+        ExtendedConfigurationDbContext configurationDbContext,
+        CreateApiScopeRequest request
+    ) {
+        if (string.IsNullOrWhiteSpace(request.Name)) {
+            return TypedResults.ValidationProblem(ValidationErrors.AddError(nameof(request.Name).ToLower(), "Name is required"));
+        }
+        var scope = request.Name.Trim();
+        var apiScope = await configurationDbContext.ApiScopes.AsNoTracking().SingleOrDefaultAsync(apiScope => apiScope.Name == scope);
+        if (apiScope != null) {
+            return TypedResults.ValidationProblem(ValidationErrors.AddError(nameof(request.Name).ToLower(), $"There is already an API scope with name: {apiScope.Name}."));
+        }
+        var apiScopeToAdd = new ApiScope {
+            Name = request.Name.Trim(),
+            DisplayName = request.DisplayName,
+            Description = request.Description,
+            Enabled = true,
+            Emphasize = request.Emphasize,
+            ShowInDiscoveryDocument = request.ShowInDiscoveryDocument,
+            Required = request.Required,
+            UserClaims = request.UserClaims.Select(claim => new ApiScopeClaim { Type = claim }).ToList(),
+            Properties = new List<ApiScopeProperty>()
+        };
+        if (request.Translations.Any()) {
+            AddTranslationsToApiScope(apiScopeToAdd, request.Translations.ToJson());
+        }
+        configurationDbContext.ApiScopes.Add(apiScopeToAdd);
+        await configurationDbContext.SaveChangesAsync();
+        return TypedResults.Ok(new ApiScopeInfo {
+            Id = apiScopeToAdd.Id,
+            Name = apiScopeToAdd.Name,
+            DisplayName = apiScopeToAdd.DisplayName,
+            Description = apiScopeToAdd.Description,
+            UserClaims = apiScopeToAdd.UserClaims.Select(x => x.Type),
+            Emphasize = apiScopeToAdd.Emphasize,
+            ShowInDiscoveryDocument = apiScopeToAdd.ShowInDiscoveryDocument,
+            Translations = TranslationDictionary<ApiScopeTranslation>.FromJson(apiScopeToAdd.Properties.Any(x => x.Key == ClientPropertyKeys.Translation)
+                ? apiScopeToAdd.Properties.Single(x => x.Key == ClientPropertyKeys.Translation).Value
+                : string.Empty
+            )
+        });
+    }
+
+    internal static async Task<Results<NoContent, NotFound, ValidationProblem>> DeleteApiScope(
+        ExtendedConfigurationDbContext configurationDbContext,
+        string scopeName
+    ) {
+        if (string.IsNullOrWhiteSpace(scopeName)) {
+            return TypedResults.ValidationProblem(ValidationErrors.AddError(nameof(scopeName).ToLower(), "Name is required"));
+        }
+        scopeName = scopeName.Trim();
+        var apiScope = await configurationDbContext.ApiScopes.AsNoTracking().SingleOrDefaultAsync(apiScope => apiScope.Name == scopeName);
+        if (apiScope == null) {
+            return TypedResults.NotFound();
+        }
+        var canDelete = await configurationDbContext.ApiResources.AnyAsync(x => x.Scopes.Any(s => s.Scope == scopeName));
+        if (!canDelete) {
+            return TypedResults.ValidationProblem(ValidationErrors.AddError(nameof(scopeName).ToLower(), "Cannot delete API scope as it is in use."));
+        }
+
+        configurationDbContext.ApiScopes.Remove(apiScope);
+        await configurationDbContext.SaveChangesAsync();
+        return TypedResults.NoContent();
+    }
+
+    internal static async Task<Results<NoContent, ValidationProblem, NotFound>> UpdateApiScope(
+        ExtendedConfigurationDbContext configurationDbContext,
+        string scopeName,
+        UpdateApiScopeRequest request
+    ) {
+        if (string.IsNullOrWhiteSpace(scopeName)) {
+            return TypedResults.ValidationProblem(ValidationErrors.AddError(nameof(scopeName).ToLower(), "ScopeName is required"));
+        }
+        scopeName = scopeName.Trim();
+        var apiScope = await configurationDbContext.ApiScopes.Include(x => x.Properties).Where(x => x.Name == scopeName).SingleOrDefaultAsync();
+        if (apiScope is null) {
+            return TypedResults.NotFound();
+        }
+        apiScope.DisplayName = request.DisplayName;
+        apiScope.Description = request.Description;
+        apiScope.Required = request.Required;
+        apiScope.ShowInDiscoveryDocument = request.ShowInDiscoveryDocument;
+        apiScope.Emphasize = request.Emphasize;
+        var apiScoreTranslations = apiScope.Properties?.SingleOrDefault(x => x.Key == ClientPropertyKeys.Translation);
+        if (apiScoreTranslations == null) {
+            AddTranslationsToApiScope(apiScope, request.Translations.ToJson());
+        } else {
+            apiScoreTranslations.Value = request.Translations.ToJson() ?? string.Empty;
+        }
+        await configurationDbContext.SaveChangesAsync();
+        return TypedResults.NoContent();
+    }
+    internal static async Task<Results<NoContent, NotFound, ValidationProblem>> AddApiScopeClaims(
+        ExtendedConfigurationDbContext configurationDbContext,
+        string scopeName,
+        string[] claims
+    ) {
+        if (string.IsNullOrWhiteSpace(scopeName)) {
+            return TypedResults.ValidationProblem(ValidationErrors.AddError(nameof(scopeName).ToLower(), "ScopeName is required"));
+        }
+        scopeName = scopeName.Trim();
+        var apiScope = await configurationDbContext.ApiScopes.SingleOrDefaultAsync(x => x.Name == scopeName);
+        if (apiScope == null) {
+            return TypedResults.NotFound();
+        }
+        if (!(claims?.Length > 0)) {
+            return TypedResults.ValidationProblem(ValidationErrors.AddError("claims", "A claims list is required"));
+        }
+        apiScope.UserClaims =
+        [
+            .. claims.Select(x => new ApiScopeClaim {
+                ScopeId = apiScope.Id,
+                Type = x
+            }),
+        ];
+        await configurationDbContext.SaveChangesAsync();
+        return TypedResults.NoContent();
+    }
+
+    internal static async Task<Results<NoContent, NotFound, ValidationProblem>> DeleteApiScopeClaim(
+        ExtendedConfigurationDbContext configurationDbContext,
+        string scopeName,
+        string claim
+    ) {
+        if (string.IsNullOrWhiteSpace(scopeName)) {
+            return TypedResults.ValidationProblem(ValidationErrors.AddError(nameof(scopeName).ToLower(), "ScopeName is required"));
+        }
+        scopeName = scopeName.Trim();
+        var apiScope = await configurationDbContext.ApiScopes.Include(x => x.UserClaims).SingleOrDefaultAsync(x => x.Name == scopeName);
+        if (apiScope == null) {
+            return TypedResults.NotFound();
+        }
+        apiScope.UserClaims ??= [];
+        var claimToRemove = apiScope.UserClaims.Select(x => x.Type == claim).ToList();
+        if (claimToRemove?.Count == 0) {
+            return TypedResults.NotFound();
+        }
+        apiScope.UserClaims.RemoveAll(x => x.Type == claim);
+        await configurationDbContext.SaveChangesAsync();
+        return TypedResults.NoContent();
+    }
+
     internal static async Task<Results<Ok<ApiResourceInfo>, NotFound>> GetApiResource(
         ExtendedConfigurationDbContext configurationDbContext,
         int resourceId
@@ -419,41 +561,54 @@ internal static class ResourceHandlers
         if (resource == null) {
             return TypedResults.NotFound();
         }
-        var apiScope = await configurationDbContext.ApiScopes.AsNoTracking().SingleOrDefaultAsync(apiScope => apiScope.Name == request.Name);
-        if (apiScope != null) {
-            return TypedResults.ValidationProblem(ValidationErrors.AddError(nameof(request.Name).ToLower(), $"There is already an API scope with name: {apiScope.Name}."));
+        if (string.IsNullOrWhiteSpace(request.Name)) {
+            return TypedResults.ValidationProblem(ValidationErrors.AddError(nameof(request.Name).ToLower(), "Name is required"));
+        }
+        var scope = request.Name.Trim();
+        var apiResourceScopeExists = resource.Scopes.Any(x => x.Scope == scope);
+        if (apiResourceScopeExists) {
+            return TypedResults.ValidationProblem(ValidationErrors.AddError(nameof(request.Name).ToLower(), $"There is already an API scope with name: {scope} associated with this resource."));
+        }
+        var apiScope = await configurationDbContext.ApiScopes
+                                                   .Include(x => x.UserClaims)
+                                                   .Include(x => x.Properties)
+                                                   .AsNoTracking()
+                                                   .SingleOrDefaultAsync(apiScope => apiScope.Name == scope);
+
+        if (apiScope == null) {
+            apiScope = new ApiScope {
+                Name = scope,
+                DisplayName = request.DisplayName,
+                Description = request.Description,
+                Enabled = true,
+                Emphasize = request.Emphasize,
+                ShowInDiscoveryDocument = request.ShowInDiscoveryDocument,
+                Required = request.Required,
+                UserClaims = request.UserClaims.Select(claim => new ApiScopeClaim { Type = claim }).ToList(),
+                Properties = new List<ApiScopeProperty>()
+            };
+            if (request.Translations.Any()) {
+                AddTranslationsToApiScope(apiScope, request.Translations.ToJson());
+            }
+            configurationDbContext.ApiScopes.Add(apiScope);
         }
         var apiResourceScope = new ApiResourceScope {
-            Scope = request.Name,
+            Scope = scope,
             ApiResourceId = resource.Id
         };
         resource.Scopes.Add(apiResourceScope);
-        var apiScopeToAdd = new ApiScope {
-            Name = request.Name.Trim(),
-            DisplayName = request.DisplayName,
-            Description = request.Description,
-            Enabled = true,
-            Emphasize = request.Emphasize,
-            ShowInDiscoveryDocument = request.ShowInDiscoveryDocument,
-            Required = request.Required,
-            UserClaims = request.UserClaims.Select(claim => new ApiScopeClaim { Type = claim }).ToList(),
-            Properties = new List<ApiScopeProperty>()
-        };
-        if (request.Translations.Any()) {
-            AddTranslationsToApiScope(apiScopeToAdd, request.Translations.ToJson());
-        }
-        configurationDbContext.ApiScopes.Add(apiScopeToAdd);
+        
         await configurationDbContext.SaveChangesAsync();
         return TypedResults.Ok(new ApiScopeInfo {
             Id = apiResourceScope.Id,
-            Name = apiScopeToAdd.Name,
-            DisplayName = apiScopeToAdd.DisplayName,
-            Description = apiScopeToAdd.Description,
-            UserClaims = apiScopeToAdd.UserClaims.Select(x => x.Type),
-            Emphasize = apiScopeToAdd.Emphasize,
-            ShowInDiscoveryDocument = apiScopeToAdd.ShowInDiscoveryDocument,
-            Translations = TranslationDictionary<ApiScopeTranslation>.FromJson(apiScopeToAdd.Properties.Any(x => x.Key == ClientPropertyKeys.Translation)
-                ? apiScopeToAdd.Properties.Single(x => x.Key == ClientPropertyKeys.Translation).Value
+            Name = apiScope.Name,
+            DisplayName = apiScope.DisplayName,
+            Description = apiScope.Description,
+            UserClaims = apiScope.UserClaims.Select(x => x.Type),
+            Emphasize = apiScope.Emphasize,
+            ShowInDiscoveryDocument = apiScope.ShowInDiscoveryDocument,
+            Translations = TranslationDictionary<ApiScopeTranslation>.FromJson(apiScope.Properties.Any(x => x.Key == ClientPropertyKeys.Translation)
+                ? apiScope.Properties.Single(x => x.Key == ClientPropertyKeys.Translation).Value
                 : string.Empty
             )
         });

--- a/src/Indice.Features.Identity.Server/Manager/ResourceHandlers.cs
+++ b/src/Indice.Features.Identity.Server/Manager/ResourceHandlers.cs
@@ -209,7 +209,7 @@ internal static class ResourceHandlers
         return TypedResults.Ok(scopes);
     }
 
-    internal static async Task<Results<Ok<ApiScopeInfo>, NotFound, ValidationProblem>> CreateApiScope(
+    internal static async Task<Results<Ok<ApiScopeInfo>, ValidationProblem>> CreateApiScope(
         ExtendedConfigurationDbContext configurationDbContext,
         CreateApiScopeRequest request
     ) {
@@ -264,8 +264,8 @@ internal static class ResourceHandlers
         if (apiScope == null) {
             return TypedResults.NotFound();
         }
-        var canDelete = await configurationDbContext.ApiResources.AnyAsync(x => x.Scopes.Any(s => s.Scope == scopeName));
-        if (!canDelete) {
+        var isInUse = await configurationDbContext.ApiResources.AnyAsync(x => x.Scopes.Any(s => s.Scope == scopeName));
+        if (isInUse) {
             return TypedResults.ValidationProblem(ValidationErrors.AddError(nameof(scopeName).ToLower(), "Cannot delete API scope as it is in use."));
         }
 
@@ -292,11 +292,11 @@ internal static class ResourceHandlers
         apiScope.Required = request.Required;
         apiScope.ShowInDiscoveryDocument = request.ShowInDiscoveryDocument;
         apiScope.Emphasize = request.Emphasize;
-        var apiScoreTranslations = apiScope.Properties?.SingleOrDefault(x => x.Key == ClientPropertyKeys.Translation);
-        if (apiScoreTranslations == null) {
+        var apiScopeTranslations = apiScope.Properties?.SingleOrDefault(x => x.Key == ClientPropertyKeys.Translation);
+        if (apiScopeTranslations == null) {
             AddTranslationsToApiScope(apiScope, request.Translations.ToJson());
         } else {
-            apiScoreTranslations.Value = request.Translations.ToJson() ?? string.Empty;
+            apiScopeTranslations.Value = request.Translations.ToJson() ?? string.Empty;
         }
         await configurationDbContext.SaveChangesAsync();
         return TypedResults.NoContent();
@@ -336,14 +336,17 @@ internal static class ResourceHandlers
         if (string.IsNullOrWhiteSpace(scopeName)) {
             return TypedResults.ValidationProblem(ValidationErrors.AddError(nameof(scopeName).ToLower(), "ScopeName is required"));
         }
+        if (string.IsNullOrWhiteSpace(claim)) {
+            return TypedResults.ValidationProblem(ValidationErrors.AddError(nameof(claim).ToLower(), "Claim is required"));
+        }
         scopeName = scopeName.Trim();
+        claim = claim.Trim();
         var apiScope = await configurationDbContext.ApiScopes.Include(x => x.UserClaims).SingleOrDefaultAsync(x => x.Name == scopeName);
         if (apiScope == null) {
             return TypedResults.NotFound();
         }
         apiScope.UserClaims ??= [];
-        var claimToRemove = apiScope.UserClaims.Select(x => x.Type == claim).ToList();
-        if (claimToRemove?.Count == 0) {
+        if (!apiScope.UserClaims.Any(x => x.Type == claim)) {
             return TypedResults.NotFound();
         }
         apiScope.UserClaims.RemoveAll(x => x.Type == claim);

--- a/src/Indice.Features.Identity.Server/Manager/ResourcesApi.cs
+++ b/src/Indice.Features.Identity.Server/Manager/ResourcesApi.cs
@@ -85,8 +85,39 @@ public static class ResourcesApi
 
         group.MapGet("protected/scopes", ResourceHandlers.GetApiScopes)
              .WithName(nameof(ResourceHandlers.GetApiScopes))
-             .WithSummary("Returns a list of ApiResourceInfo objects containing the total number of API resources in the database and the data filtered according to the provided ListOptions.")
+             .WithSummary("Returns a list of API scopes.")
              .RequireAuthorization(IdentityEndpoints.Policies.BeClientsReader);
+
+        group.MapPost("protected/scopes", ResourceHandlers.CreateApiScope)
+             .WithName(nameof(ResourceHandlers.CreateApiScope))
+             .WithSummary("Creates a new API scope.")
+             .RequireAuthorization(IdentityEndpoints.Policies.BeClientsWriter)
+             .WithParameterValidation<CreateApiScopeRequest>();
+
+        group.MapPut("protected/scopes/{scopeName}", ResourceHandlers.UpdateApiScope)
+             .WithName(nameof(ResourceHandlers.UpdateApiScope))
+             .WithSummary("Updates a specified API scope.")
+             .RequireAuthorization(IdentityEndpoints.Policies.BeClientsWriter)
+             .InvalidateCacheTag(CacheTagPrefix, ["scopeName"], [])
+             .WithParameterValidation<UpdateApiScopeRequest>();
+
+        group.MapDelete("protected/scopes/{scopeName}", ResourceHandlers.DeleteApiScope)
+             .WithName(nameof(ResourceHandlers.DeleteApiScope))
+             .WithSummary("Deletes an existing API scope.")
+             .InvalidateCacheTag(CacheTagPrefix, ["scopeName"], [])
+             .RequireAuthorization(IdentityEndpoints.Policies.BeClientsWriter);
+
+        group.MapPost("protected/scopes/{scopeName}/claims", ResourceHandlers.AddApiScopeClaims)
+             .WithName(nameof(ResourceHandlers.AddApiScopeClaims))
+             .WithSummary("Adds claims to an API Scope.")
+             .RequireAuthorization(IdentityEndpoints.Policies.BeClientsWriter)
+             .InvalidateCacheTag(CacheTagPrefix, ["scopeName"], []);
+
+        group.MapDelete("protected/scopes/{scopeName}/claims/{claim}", ResourceHandlers.DeleteApiScopeClaim)
+             .WithName(nameof(ResourceHandlers.DeleteApiScopeClaim))
+             .WithSummary("Removes a specified claim from an API Scope.")
+             .RequireAuthorization(IdentityEndpoints.Policies.BeClientsWriter)
+             .InvalidateCacheTag(CacheTagPrefix, ["scopeName"], []);
 
         group.MapGet("protected/{resourceId:int}", ResourceHandlers.GetApiResource)
              .WithName(nameof(ResourceHandlers.GetApiResource))


### PR DESCRIPTION
Implemented Create, Read, Update, and Delete operations for API scopes in ResourceHandlers, including claim management. Updated GetApiResource to prevent duplicate scope associations. Extended ResourcesApi with new endpoints, summaries, and cache invalidation for improved API management and documentation.