### PR TITLE
[Identity] Support disabling Security Notification email

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,22 +5,22 @@
     <!--<TargetFramework></TargetFramework>-->
 
     <VersionPrefixMajor>8</VersionPrefixMajor>
-    <VersionPrefixBase>$(VersionPrefixMajor).48</VersionPrefixBase>
+    <VersionPrefixBase>$(VersionPrefixMajor).49</VersionPrefixBase>
 
-    <VersionPrefixCore>$(VersionPrefixBase).1</VersionPrefixCore>
-    <VersionPrefixIdentity>$(VersionPrefixBase).1</VersionPrefixIdentity>
-    <VersionPrefixIdentityUI>$(VersionPrefixBase).1</VersionPrefixIdentityUI>
-    <VersionPrefixCases>$(VersionPrefixBase).1</VersionPrefixCases>
-    <VersionPrefixMessages>$(VersionPrefixBase).1</VersionPrefixMessages>
-    <VersionPrefixMultitenancy>$(VersionPrefixBase).1</VersionPrefixMultitenancy>
-    <VersionPrefixRisk>$(VersionPrefixBase).1</VersionPrefixRisk>
-    <VersionPrefixMedia>$(VersionPrefixBase).1</VersionPrefixMedia>
-    <VersionPrefixGeoIP>$(VersionPrefixBase).1</VersionPrefixGeoIP>
-    <VersionPrefixGovGr>$(VersionPrefixBase).1</VersionPrefixGovGr>
-    <VersionPrefixAspNet>$(VersionPrefixBase).1</VersionPrefixAspNet>
-    <VersionPrefixActivityLogs>$(VersionPrefixBase).1</VersionPrefixActivityLogs>
-    <VersionPrefixFtpServer>$(VersionPrefixBase).1</VersionPrefixFtpServer>
-    <VersionPrefix>$(VersionPrefixBase).1</VersionPrefix>
+    <VersionPrefixCore>$(VersionPrefixBase).0</VersionPrefixCore>
+    <VersionPrefixIdentity>$(VersionPrefixBase).0</VersionPrefixIdentity>
+    <VersionPrefixIdentityUI>$(VersionPrefixBase).0</VersionPrefixIdentityUI>
+    <VersionPrefixCases>$(VersionPrefixBase).0</VersionPrefixCases>
+    <VersionPrefixMessages>$(VersionPrefixBase).0</VersionPrefixMessages>
+    <VersionPrefixMultitenancy>$(VersionPrefixBase).0</VersionPrefixMultitenancy>
+    <VersionPrefixRisk>$(VersionPrefixBase).0</VersionPrefixRisk>
+    <VersionPrefixMedia>$(VersionPrefixBase).0</VersionPrefixMedia>
+    <VersionPrefixGeoIP>$(VersionPrefixBase).0</VersionPrefixGeoIP>
+    <VersionPrefixGovGr>$(VersionPrefixBase).0</VersionPrefixGovGr>
+    <VersionPrefixAspNet>$(VersionPrefixBase).0</VersionPrefixAspNet>
+    <VersionPrefixActivityLogs>$(VersionPrefixBase).0</VersionPrefixActivityLogs>
+    <VersionPrefixFtpServer>$(VersionPrefixBase).0</VersionPrefixFtpServer>
+    <VersionPrefix>$(VersionPrefixBase).0</VersionPrefix>
 
     <!--<VersionSuffix>rc06</VersionSuffix>-->
     <Authors>Constantinos Leftheris</Authors>

--- a/src/Indice.Features.Identity.Core/Extensions/IdentityBuilderExtensions.cs
+++ b/src/Indice.Features.Identity.Core/Extensions/IdentityBuilderExtensions.cs
@@ -9,6 +9,7 @@ using Indice.Features.Identity.Core.Events;
 using Indice.Features.Identity.Core.Models;
 using Indice.Features.Identity.Core.PasswordValidation;
 using Indice.Features.Identity.Core.TokenProviders;
+using Indice.Features.Identity.SignInLogs.Events;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
@@ -58,9 +59,12 @@ public static class IdentityBuilderExtensions
     /// <typeparam name="TUser">The type of <see cref="User"/> used by the identity system.</typeparam>
     /// <param name="builder">The type of builder for configuring identity services.</param>
     public static IdentityBuilder AddExtendedUserManager<TUser>(this IdentityBuilder builder) where TUser : User, new() {
+        builder.Services.AddGeoIPResolver();
         builder.Services.AddPlatformEventHandler<UserBlockedEvent, UserBlockedEventHandler>();
         builder.Services.AddPlatformEventHandler<UserLoginEvent, UserLoginEventHandler>();
         builder.Services.AddPlatformEventHandler<UserPasswordLoginEvent, UserPasswordLoginEventHandler>();
+        builder.Services.AddPlatformEventHandler<SecurityNotificationEvent, SecurityNotificationEventHandler>();
+        builder.Services.AddPlatformEventHandler<TwoFactorPreferenceChangedEvent, TwoFactorPreferenceChangedEventHandler>();
         builder.AddEntityFrameworkStores<ExtendedIdentityDbContext<TUser, Role>>()
                .AddUserStore<ExtendedUserStore<ExtendedIdentityDbContext<TUser, Role>, TUser, Role>>()
                .AddUserManager<ExtendedUserManager<TUser>>();

--- a/src/Indice.Features.Identity.Core/SecurityNotificationEventHandler.cs
+++ b/src/Indice.Features.Identity.Core/SecurityNotificationEventHandler.cs
@@ -33,7 +33,7 @@ public class SecurityNotificationEventHandler : IPlatformEventHandler<SecurityNo
     public SecurityNotificationEventHandler(IEmailService emailService, IdentityMessageDescriber messageDescriber, IConfiguration configuration) {
         _emailService = emailService ?? throw new ArgumentNullException(nameof(emailService));
         _messageDescriber = messageDescriber;
-        _disableSecurityNotification = configuration.GetIdentityOption<bool?>($"{nameof(IdentityOptions.User)}", "DisableSecurityNotifications") ?? false;
+        _disableSecurityNotification = configuration.GetSection("IdentityServer").GetValue<bool?>("DisableSecurityNotifications") ?? false;
     }
 
     /// <inheritdoc/>

--- a/src/Indice.Features.Identity.Core/SecurityNotificationEventHandler.cs
+++ b/src/Indice.Features.Identity.Core/SecurityNotificationEventHandler.cs
@@ -1,12 +1,13 @@
 ﻿using Indice.Events;
-using Indice.Features.Identity.Core;
 using Indice.Features.Identity.Core.Events.Models;
 using Indice.Features.Identity.Core.Models;
 using Indice.Features.Identity.SignInLogs.Events;
 using Indice.Localization;
 using Indice.Services;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Configuration;
 
-namespace Indice.Features.Identity.UI.EventHandlers;
+namespace Indice.Features.Identity.Core;
 
 /// <summary>
 /// Handles security notification events by processing the event data and sending notifications.
@@ -18,22 +19,28 @@ public class SecurityNotificationEventHandler : IPlatformEventHandler<SecurityNo
 {
     private readonly IEmailService _emailService;
     private readonly IdentityMessageDescriber _messageDescriber;
+    private readonly bool? _disableSecurityNotification;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SecurityNotificationEventHandler"/> class.
     /// </summary>
     /// <param name="emailService">The email service used to send security notifications. This parameter cannot be <see langword="null"/>.</param>
     /// <param name="messageDescriber">Provides the various messages used throughout Indice packages.</param>
+    /// <param name="configuration">The configuration used to retrieve identity options.</param>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="emailService"/> is <see langword="null"/>.</exception>
 
 
-    public SecurityNotificationEventHandler(IEmailService emailService, IdentityMessageDescriber messageDescriber) {
+    public SecurityNotificationEventHandler(IEmailService emailService, IdentityMessageDescriber messageDescriber, IConfiguration configuration) {
         _emailService = emailService ?? throw new ArgumentNullException(nameof(emailService));
         _messageDescriber = messageDescriber;
+        _disableSecurityNotification = configuration.GetIdentityOption<bool?>($"{nameof(IdentityOptions.User)}", "DisableSecurityNotifications") ?? false;
     }
 
     /// <inheritdoc/>
     public async Task Handle(SecurityNotificationEvent @event, PlatformEventArgs args) {
+        if (_disableSecurityNotification == true) {
+            return;
+        }
         if (string.IsNullOrWhiteSpace(@event.User.Email)) {
             return; // No email to send notification to.
         }

--- a/src/Indice.Features.Identity.Core/TwoFactorPreferenceChangedEventHandler.cs
+++ b/src/Indice.Features.Identity.Core/TwoFactorPreferenceChangedEventHandler.cs
@@ -9,7 +9,6 @@ using IdentityServer4.Stores;
 #endif
 using System.Security.Claims;
 using Indice.Events;
-using Indice.Features.Identity.Core;
 using Indice.Features.Identity.Core.Data.Models;
 using Indice.Features.Identity.Core.Events;
 using Indice.Features.Identity.Core.Events.Models;
@@ -20,7 +19,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Net.Http.Headers;
 
 
-namespace Indice.Features.Identity.UI.EventHandlers;
+namespace Indice.Features.Identity.Core;
 
 /// <summary>Handles <see cref="TwoFactorPreferenceChangedEvent"/> by sending an email notification to the user.</summary>
 public class TwoFactorPreferenceChangedEventHandler : IPlatformEventHandler<TwoFactorPreferenceChangedEvent>

--- a/src/Indice.Features.Identity.UI/IdentityBuilderUIExtensions.cs
+++ b/src/Indice.Features.Identity.UI/IdentityBuilderUIExtensions.cs
@@ -1,25 +1,19 @@
 ﻿using System.Reflection;
 using FluentValidation;
 using FluentValidation.AspNetCore;
-using Indice.AspNetCore.Features.Recaptcha;
 using Indice.Features.Identity.Core;
-using Indice.Features.Identity.Core.Events;
-using Indice.Features.Identity.SignInLogs.Events;
 using Indice.Features.Identity.UI;
-using Indice.Features.Identity.UI.EventHandlers;
 using Indice.Features.Identity.UI.Localization;
 using Indice.Features.Identity.UI.Telemetry;
 using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.AspNetCore.Mvc.Razor;
 using Microsoft.AspNetCore.Mvc.Razor.Compilation;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
-using Microsoft.Extensions.Primitives;
 
 
 #if NET9_0_OR_GREATER

--- a/src/Indice.Features.Identity.UI/IdentityBuilderUIExtensions.cs
+++ b/src/Indice.Features.Identity.UI/IdentityBuilderUIExtensions.cs
@@ -116,10 +116,7 @@ public static class IdentityBuilderUIExtensions
         services.AddMarkdown();
         services.TryAddTransient<ITelemetryJavaScriptSnippet, AzureMonitorTelemetryJavaScriptSnippet>(); // browser ui telemetry.
 
-        services.AddPlatformEventHandler<SecurityNotificationEvent, SecurityNotificationEventHandler>();
-        services.AddPlatformEventHandler<TwoFactorPreferenceChangedEvent, TwoFactorPreferenceChangedEventHandler>();
         services.TryAddScoped<IdentityUILocalizer>();
-        services.AddGeoIPResolver();
         // Add reCAPTCHA service with options pattern
         services.AddRecaptcha(configuration);
         return services;

--- a/src/Indice.Features.Identity.UI/Indice.Features.Identity.UI.csproj
+++ b/src/Indice.Features.Identity.UI/Indice.Features.Identity.UI.csproj
@@ -53,7 +53,6 @@
       <LastGenOutput>TelemetryJavascriptResources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
-  
   <Target Name="NpmInstall" BeforeTargets="DispatchToInnerBuilds">
     <Exec Command="npm install" EnvironmentVariables="PATH=$(Path.Replace(';', '%3B'))" ContinueOnError="true">
       <Output TaskParameter="ExitCode" PropertyName="ErrorCode" />


### PR DESCRIPTION
- Add option to disable Security Notification emails.
- SecurityNotificationEventHandler and TwoFactorPreferenceChangedEventHandler were moved from UI.EventHandlers to Core, with namespaces and usings updated.
- SecurityNotificationEventHandler now supports disabling notifications via config.
- Registration of both handlers was shifted from IdentityBuilderUIExtensions to IdentityBuilderExtensions (AddExtendedUserManager).
- Version prefixes bumped to 8.49.x.0.
- Minor cleanup and whitespace adjustments.