### PR TITLE
[cases] Bugfix on tableFilters.ReferenceNumber

### DIFF
--- a/src/Indice.Features.Cases.App/src/app/features/cases/general-cases/general-cases.component.ts
+++ b/src/Indice.Features.Cases.App/src/app/features/cases/general-cases/general-cases.component.ts
@@ -104,7 +104,7 @@ export class GeneralCasesComponent extends BaseListComponent<CasePartial> implem
             //TODO: this should not be needed - we assign this so its available for the async calls
             this.caseTypes = caseTypes;
             const tempSearchOptions: SearchOption[] = [];
-            if (this.tableFilters.OwnerId) {
+            if (this.tableFilters.ReferenceNumber) {
                 tempSearchOptions.push({
                     field: 'referenceNumber',
                     name: 'ΑΡΙΘΜΟΣ ΥΠΟΘΕΣΗΣ',

--- a/src/Indice.Features.Cases.UI/CHANGELOG.md
+++ b/src/Indice.Features.Cases.UI/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.42.2] - 2026-06-04
+### Fixed
+- A bug when the configuration had `ReferenceNumber` filter enabledm, the filter was not shown.
+
 ## [7.31.2] - 2024-10-11
 ### Added
 - `UnauthorizedComponent` from `Indice.Angular` library to handle Forbidden requests.


### PR DESCRIPTION
This pull request makes a small adjustment to the filtering logic in the `GeneralCasesComponent`. The filter now checks for `ReferenceNumber` instead of `OwnerId` when adding a search option.