### PR TITLE
[messaging] Fix missing services for `AddCampaignCore`

### DIFF
--- a/src/Indice.Extensions.Configuration.Database/DatabaseConfigurationExtensions.cs
+++ b/src/Indice.Extensions.Configuration.Database/DatabaseConfigurationExtensions.cs
@@ -44,4 +44,35 @@ public static class DatabaseConfigurationExtensions
             options.ReloadOnInterval = TimeSpan.FromSeconds(30);
             options.ConfigureDbContext = dbBuilder => dbBuilder.UseSqlServer(configuration.GetConnectionString("AppSettingsDb"));
         }));
+
+    /// <summary>Registers and configures the <see cref="EntityConfigurationProvider{T}"/> using some default values.</summary>
+    /// <typeparam name="TContext">The type of the <see cref="DbContext"/>.</typeparam>
+    /// <param name="builder">A builder for the application host.</param>
+    /// <param name="configureAction">The <see cref="EntityConfigurationOptions"/> to use.</param>
+    /// <returns>The <see cref="IHostApplicationBuilder"/>.</returns>
+    public static IHostApplicationBuilder AddDatabaseSettings<TContext>(this IHostApplicationBuilder builder, Action<EntityConfigurationOptions, IConfiguration> configureAction) where TContext : DbContext, IAppSettingsDbContext {
+        var options = new EntityConfigurationOptions();
+        configureAction?.Invoke(options, builder.Configuration);
+        var result = options.Validate();
+        if (!result.Succedded) {
+            throw new ArgumentException(result.Error);
+        }
+        builder.Configuration.Add(new EntityConfigurationSource<TContext>(options));
+        if (typeof(TContext).Equals(typeof(DefaultAppSettingsDbContext))) {
+            builder.Services.AddDbContext<TContext>(options.ConfigureDbContext);
+        }
+        builder.Services.AddTransient<IAppSettingsDbContext, TContext>();
+        return builder;
+    }
+
+    /// <summary>Registers and configures the <see cref="EntityConfigurationProvider{T}"/> using some default values. These are A database connection string named <strong>AppSettingsDb</strong> and a refresh interval of <strong>30 secconds</strong>.</summary>
+    /// <param name="builder">A builder for the application host.</param>
+    /// <param name="configureAction">The <see cref="EntityConfigurationOptions"/> to use.</param>
+    /// <returns>The <see cref="IHostApplicationBuilder"/>.</returns>
+    /// <remarks>The database will not create the table <strong>[config].[AppSetting]</strong> by itself. Using the internal DbContext for app settings means that we need to manually create the table and schema in our target database</remarks>
+    public static IHostApplicationBuilder AddDatabaseSettingsDefaults(this IHostApplicationBuilder builder, Action<EntityConfigurationOptions, IConfiguration>? configureAction = null) =>
+        AddDatabaseSettings<DefaultAppSettingsDbContext>(builder, configureAction ?? new Action<EntityConfigurationOptions, IConfiguration>((options, configuration) => {
+            options.ReloadOnInterval = TimeSpan.FromSeconds(30);
+            options.ConfigureDbContext = dbBuilder => dbBuilder.UseSqlServer(configuration.GetConnectionString("AppSettingsDb"));
+        }));
 }

--- a/src/Indice.Features.Messages.AspNetCore/MessageFeatureExtensions.cs
+++ b/src/Indice.Features.Messages.AspNetCore/MessageFeatureExtensions.cs
@@ -153,6 +153,8 @@ public static class MessageFeatureExtensions
         });
         // Register validators.
         services.AddValidatorsFromAssemblyContaining<CreateCampaignRequestValidator>();
+        services.TryAddTransient<CreateCampaignRequestValidator>();
+        services.TryAddTransient<CreateMessageTypeRequestValidator>();
         // Register framework services.
         services.AddResponseCaching();
         services.AddOutputCache();

--- a/src/Indice.Features.Messages.AspNetCore/MessageFeatureExtensions.cs
+++ b/src/Indice.Features.Messages.AspNetCore/MessageFeatureExtensions.cs
@@ -94,9 +94,6 @@ public static class MessageFeatureExtensions
         // Register framework services.
         services.AddHttpContextAccessor();
         services.TryAddSingleton<MediaBaseHrefResolver>();
-        // Register Validators.
-        services.TryAddTransient<CreateCampaignRequestValidator>();
-        services.TryAddTransient<CreateMessageTypeRequestValidator>();
         return services;
     }
 

--- a/src/Indice.Features.Messages.AspNetCore/MessageFeatureExtensions.cs
+++ b/src/Indice.Features.Messages.AspNetCore/MessageFeatureExtensions.cs
@@ -93,18 +93,8 @@ public static class MessageFeatureExtensions
         services.AddSingleton(new DatabaseSchemaNameResolver(apiOptions.DatabaseSchema));
         // Register framework services.
         services.AddHttpContextAccessor();
-        // Register events.
         services.TryAddSingleton<MediaBaseHrefResolver>();
-        services.TryAddTransient<IPlatformEventService, DefaultPlatformEventService>();
-        services.TryAddTransient<IContactService, ContactService>();
-        services.TryAddTransient<ITemplateService, TemplateService>();
-        services.TryAddTransient<IPartialTemplateResolverFactory, DbBackedPartialTemplateResolverFactory>();
-        services.TryAddTransient<ICampaignAttachmentService, CampaignAttachmentService>();
-        services.TryAddTransient<NotificationsManager>();
-        services.TryAddTransient<IDistributionListService, DistributionListService>();
-        services.TryAddTransient<ICampaignService, CampaignService>();
-        services.TryAddTransient<IMessageTypeService, MessageTypeService>();
-        services.TryAddTransient<IMessageSenderService, MessageSenderService>();
+        // Register Validators.
         services.TryAddTransient<CreateCampaignRequestValidator>();
         services.TryAddTransient<CreateMessageTypeRequestValidator>();
         return services;
@@ -161,13 +151,6 @@ public static class MessageFeatureExtensions
                 options.SerializerOptions.Converters.Add(new TypeConverterJsonAdapterFactory());
             }
         });
-        // Post configure Swagger options.
-        //services.PostConfigure<SwaggerGenOptions>(options => {
-        //    var enumFlagsSchemaFilterExists = options.SchemaFilterDescriptors.Any(x => x.Type == typeof(EnumFlagsSchemaFilter));
-        //    if (!enumFlagsSchemaFilterExists) {
-        //        options.SchemaFilter<EnumFlagsSchemaFilter>();
-        //    }
-        //});
         // Register validators.
         services.AddValidatorsFromAssemblyContaining<CreateCampaignRequestValidator>();
         // Register framework services.
@@ -175,7 +158,11 @@ public static class MessageFeatureExtensions
         services.AddOutputCache();
         services.AddEndpointParameterFluentValidation(typeof(UpdateMessageTypeRequestValidator).Assembly);
         // Register custom services.
+        services.TryAddTransient<IContactService, ContactService>();
+        services.TryAddTransient<ITemplateService, TemplateService>();
         services.TryAddTransient<ICampaignService, CampaignService>();
+        services.TryAddTransient<IPartialTemplateResolverFactory, DbBackedPartialTemplateResolverFactory>();
+        services.TryAddTransient<ICampaignAttachmentService, CampaignAttachmentService>();
         services.TryAddTransient<IMessageTypeService, MessageTypeService>();
         services.TryAddTransient<IMessageSenderService, MessageSenderService>();
         services.TryAddTransient<IDistributionListService, DistributionListService>();
@@ -185,7 +172,8 @@ public static class MessageFeatureExtensions
         services.TryAddScoped<UserNameAccessorAggregate>();
         services.TryAddTransient<IFileService, FileServiceNoop>();
         services.TryAddTransient<IFileServiceFactory, DefaultFileServiceFactory>();
-        services.TryAddTransient<IContactResolver, ContactResolverNoop>();
+        services.TryAddTransient<IContactResolver, ContactResolverNoop>(); 
+        services.TryAddTransient<NotificationsManager>();
         services.AddEventDispatcherNoop();
         services.AddFilesNoop();
         // Register application DbContext.


### PR DESCRIPTION
Reorganize and clarify service registrations by grouping validators and custom services into dedicated sections. Move AddHttpContextAccessor and MediaBaseHrefResolver earlier in the configuration for improved structure and maintainability. No functional changes to service behavior.