### PR TITLE
Add config flag for Developer Exception Page control

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,9 +7,9 @@
     <VersionPrefixMajor>8</VersionPrefixMajor>
     <VersionPrefixBase>$(VersionPrefixMajor).49</VersionPrefixBase>
 
-    <VersionPrefixCore>$(VersionPrefixBase).0</VersionPrefixCore>
-    <VersionPrefixIdentity>$(VersionPrefixBase).0</VersionPrefixIdentity>
-    <VersionPrefixIdentityUI>$(VersionPrefixBase).0</VersionPrefixIdentityUI>
+    <VersionPrefixCore>$(VersionPrefixBase).1</VersionPrefixCore>
+    <VersionPrefixIdentity>$(VersionPrefixBase).1</VersionPrefixIdentity>
+    <VersionPrefixIdentityUI>$(VersionPrefixBase).1</VersionPrefixIdentityUI>
     <VersionPrefixCases>$(VersionPrefixBase).0</VersionPrefixCases>
     <VersionPrefixMessages>$(VersionPrefixBase).0</VersionPrefixMessages>
     <VersionPrefixMultitenancy>$(VersionPrefixBase).0</VersionPrefixMultitenancy>
@@ -17,7 +17,7 @@
     <VersionPrefixMedia>$(VersionPrefixBase).0</VersionPrefixMedia>
     <VersionPrefixGeoIP>$(VersionPrefixBase).0</VersionPrefixGeoIP>
     <VersionPrefixGovGr>$(VersionPrefixBase).0</VersionPrefixGovGr>
-    <VersionPrefixAspNet>$(VersionPrefixBase).0</VersionPrefixAspNet>
+    <VersionPrefixAspNet>$(VersionPrefixBase).1</VersionPrefixAspNet>
     <VersionPrefixActivityLogs>$(VersionPrefixBase).0</VersionPrefixActivityLogs>
     <VersionPrefixFtpServer>$(VersionPrefixBase).0</VersionPrefixFtpServer>
     <VersionPrefix>$(VersionPrefixBase).0</VersionPrefix>

--- a/src/Indice.AspNetCore.Builder/IndiceWebApplicationBuilder.cs
+++ b/src/Indice.AspNetCore.Builder/IndiceWebApplicationBuilder.cs
@@ -84,13 +84,14 @@ public class IndiceWebApplicationBuilder : IHostApplicationBuilder
         }
 
         app.UseCors();
-        app.UseExceptionHandler();
+        if (app.Environment.IsDevelopment() && app.Configuration.UseDeveloperExceptionPage()) {
+            app.UseDeveloperExceptionPage();
+        } else {
+            app.UseExceptionHandler();
+        }
         app.UseStatusCodePages();
         app.UseAuthentication();
         app.UseAuthorization();
-        if (app.Environment.IsDevelopment()) {
-            app.UseDeveloperExceptionPage();
-        }
         app.UseRequestLocalization();
         return app;
     }

--- a/src/Indice.Features.Identity.Core/Constants.cs
+++ b/src/Indice.Features.Identity.Core/Constants.cs
@@ -104,6 +104,8 @@ public class IdentityServerFeatures
     public const string ImpossibleTravel = nameof(ImpossibleTravel);
     /// <summary>Activity logs.</summary>
     public const string ActivityLogs = nameof(ActivityLogs);
+    /// <summary>Disable security notifications.</summary>
+    public const string DisableSecurityNotifications = nameof(DisableSecurityNotifications);
 }
 
 

--- a/src/Indice.Features.Identity.Core/SecurityNotificationEventHandler.cs
+++ b/src/Indice.Features.Identity.Core/SecurityNotificationEventHandler.cs
@@ -33,7 +33,7 @@ public class SecurityNotificationEventHandler : IPlatformEventHandler<SecurityNo
     public SecurityNotificationEventHandler(IEmailService emailService, IdentityMessageDescriber messageDescriber, IConfiguration configuration) {
         _emailService = emailService ?? throw new ArgumentNullException(nameof(emailService));
         _messageDescriber = messageDescriber;
-        _disableSecurityNotification = configuration.GetSection("IdentityServer").GetValue<bool?>("DisableSecurityNotifications") ?? false;
+        _disableSecurityNotification = configuration.GetSection("IdentityServer:Features").GetValue<bool?>(nameof(IdentityServerFeatures.DisableSecurityNotifications)) ?? false;
     }
 
     /// <inheritdoc/>

--- a/src/Indice.Services/Configuration/GeneralSettings.cs
+++ b/src/Indice.Services/Configuration/GeneralSettings.cs
@@ -29,7 +29,7 @@ public class GeneralSettings
     public bool UseHttpsRedirection { get; set; }
     /// <summary>A flag that indicates whether the developer exception page is enabled.</summary>
     public bool UseDeveloperExceptionPage { get; set; }
-    /// <summary>A flag that indicates whether to redirect the setting that is definded in <see cref="Host"/>.</summary>
+    /// <summary>A flag that indicates whether to redirect the setting that is defined in <see cref="Host"/>.</summary>
     public bool UseRedirectToHost { get; set; }
     /// <summary>A flag that indicates whether to use certificate forwarding middleware.</summary>
     public bool UseCertificateForwarding { get; set; }

--- a/src/Indice.Services/Configuration/GeneralSettings.cs
+++ b/src/Indice.Services/Configuration/GeneralSettings.cs
@@ -27,6 +27,8 @@ public class GeneralSettings
     public bool MockServices { get; set; }
     /// <summary>A flag that indicates whether to redirect http to https.</summary>
     public bool UseHttpsRedirection { get; set; }
+    /// <summary>A flag that indicates whether the developer exception page is enabled.</summary>
+    public bool UseDeveloperExceptionPage { get; set; }
     /// <summary>A flag that indicates whether to redirect the setting that is definded in <see cref="Host"/>.</summary>
     public bool UseRedirectToHost { get; set; }
     /// <summary>A flag that indicates whether to use certificate forwarding middleware.</summary>

--- a/src/Indice.Services/Extensions/IConfigurationExtensions.cs
+++ b/src/Indice.Services/Extensions/IConfigurationExtensions.cs
@@ -22,7 +22,7 @@ public static class IConfigurationExtensions
     /// <param name="configuration">Represents a set of key/value application configuration properties.</param>
     /// <returns>True if specified flag is set to true, otherwise false.</returns>
     /// <remarks>Checks for the <strong>General:UseDeveloperExceptionPage</strong> option in appsettings.json file.</remarks>
-    public static bool UseDeveloperExceptionPage(this IConfiguration configuration) => configuration.GetSection(GeneralSettings.Name).GetValue<bool>(nameof(GeneralSettings.UseDeveloperExceptionPage));
+    public static bool UseDeveloperExceptionPage(this IConfiguration configuration) => configuration.GetSection(GeneralSettings.Name).GetValue<bool>(nameof(GeneralSettings.UseDeveloperExceptionPage), false);
 
     /// <summary>
     /// Determines whether client certificate forwarding is enabled based on the configuration settings. 

--- a/src/Indice.Services/Extensions/IConfigurationExtensions.cs
+++ b/src/Indice.Services/Extensions/IConfigurationExtensions.cs
@@ -18,6 +18,12 @@ public static class IConfigurationExtensions
     /// <remarks>Checks for the <strong>General:UseHttpsRedirection</strong> option in appsettings.json file. When true you can register HttpsPolicyBuilderExtensions.UseHttpsRedirection(IApplicationBuilder) middleware.</remarks>
     public static bool UseHttpsRedirection(this IConfiguration configuration) => configuration.GetSection(GeneralSettings.Name).GetValue<bool>(nameof(GeneralSettings.UseHttpsRedirection));
 
+    /// <summary>Indicates whether the developer exception page is enabled.</summary>
+    /// <param name="configuration">Represents a set of key/value application configuration properties.</param>
+    /// <returns>True if specified flag is set to true, otherwise false.</returns>
+    /// <remarks>Checks for the <strong>General:UseDeveloperExceptionPage</strong> option in appsettings.json file.</remarks>
+    public static bool UseDeveloperExceptionPage(this IConfiguration configuration) => configuration.GetSection(GeneralSettings.Name).GetValue<bool>(nameof(GeneralSettings.UseDeveloperExceptionPage));
+
     /// <summary>
     /// Determines whether client certificate forwarding is enabled based on the configuration settings. 
     /// </summary>


### PR DESCRIPTION
Introduce UseDeveloperExceptionPage setting in GeneralSettings and IConfigurationExtensions to allow toggling the Developer Exception Page in development environments. Update IndiceWebApplicationBuilder to conditionally use DeveloperExceptionPage or ExceptionHandler middleware based on this flag. Removes previous unconditional usage in development.