### PR TITLE
[messaging] - Add output caching to analytics endpoints with auth

### DIFF
--- a/src/Indice.Features.Messages.AspNetCore/Endpoints/AnalyticsApi.cs
+++ b/src/Indice.Features.Messages.AspNetCore/Endpoints/AnalyticsApi.cs
@@ -25,6 +25,7 @@ internal static class AnalyticsApi
             group.WithGroupName(options.GroupName);
         }
         group.WithTags("Analytics");
+        group.WithCacheTag(AnalyticsHandlers.CacheTag);
         var allowedScopes = new[] { options.RequiredScope }.Where(x => x != null).ToArray();
 
         group.RequireAuthorization(pb => pb.AddAuthenticationSchemes(MessagesApi.AuthenticationScheme)
@@ -43,20 +44,24 @@ internal static class AnalyticsApi
              .WithName(nameof(AnalyticsHandlers.GetOverview))
              .WithSummary("Gets the overview analytics.")
              .CacheOutput(policy => policy.Expire(TimeSpan.FromMinutes(10))
-                                          .SetAuthorized());
+                                          .SetAuthorized().SetAutoTag());
 
         group.MapGet("events", AnalyticsHandlers.GetEventsList)
              .WithName(nameof(AnalyticsHandlers.GetEventsList))
              .WithSummary("Gets a result set of events.")
              .CacheOutput(policy => policy.Expire(TimeSpan.FromMinutes(10))
-                                          .SetAuthorized());
+                                          .SetAuthorized().SetAutoTag());
 
 
         group.MapGet("events/series", AnalyticsHandlers.GetEventsSeriesList)
              .WithName(nameof(AnalyticsHandlers.GetEventsSeriesList))
              .WithSummary("Gets a result set of events.")
              .CacheOutput(policy => policy.Expire(TimeSpan.FromMinutes(10))
-                                          .SetAuthorized());
+                                          .SetAuthorized().SetAutoTag());
+
+        group.MapPost("refresh", AnalyticsHandlers.RefreshCache)
+             .WithName(nameof(AnalyticsHandlers.RefreshCache))
+             .WithSummary("Refreshes the analytics cache.");
 
         return group;
     }

--- a/src/Indice.Features.Messages.AspNetCore/Endpoints/AnalyticsApi.cs
+++ b/src/Indice.Features.Messages.AspNetCore/Endpoints/AnalyticsApi.cs
@@ -41,15 +41,22 @@ internal static class AnalyticsApi
 
         group.MapGet("overview", AnalyticsHandlers.GetOverview)
              .WithName(nameof(AnalyticsHandlers.GetOverview))
-             .WithSummary("Gets the overview analytics.");
+             .WithSummary("Gets the overview analytics.")
+             .CacheOutput(policy => policy.Expire(TimeSpan.FromMinutes(10))
+                                          .SetAuthorized());
 
         group.MapGet("events", AnalyticsHandlers.GetEventsList)
              .WithName(nameof(AnalyticsHandlers.GetEventsList))
-             .WithSummary("Gets a result set of events.");
+             .WithSummary("Gets a result set of events.")
+             .CacheOutput(policy => policy.Expire(TimeSpan.FromMinutes(10))
+                                          .SetAuthorized());
+
 
         group.MapGet("events/series", AnalyticsHandlers.GetEventsSeriesList)
              .WithName(nameof(AnalyticsHandlers.GetEventsSeriesList))
-             .WithSummary("Gets a result set of events.");
+             .WithSummary("Gets a result set of events.")
+             .CacheOutput(policy => policy.Expire(TimeSpan.FromMinutes(10))
+                                          .SetAuthorized());
 
         return group;
     }

--- a/src/Indice.Features.Messages.AspNetCore/Endpoints/AnalyticsHandlers.cs
+++ b/src/Indice.Features.Messages.AspNetCore/Endpoints/AnalyticsHandlers.cs
@@ -6,6 +6,7 @@ using Indice.Features.Messages.Core.Services.Abstractions;
 using Indice.Types;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.OutputCaching;
 
 namespace Indice.Features.Messages.AspNetCore.Endpoints;
 
@@ -44,4 +45,10 @@ internal static class AnalyticsHandlers
         var result = await messageEventService.GetSeriesAsync(filter);
         return TypedResults.Ok(result);
     }
+
+    public static async Task<NoContent> RefreshCache(IOutputCacheStore cacheStore,CancellationToken cancellationToken) {
+        await cacheStore.EvictByTagAsync(CacheTag, cancellationToken);
+        return TypedResults.NoContent();
+    }
+    internal const string CacheTag = "Analytics";
 }


### PR DESCRIPTION
Added 10-minute output caching to the "overview", "events", and "events/series" analytics endpoints using .CacheOutput with .Expire and .SetAuthorized policies.