### PR TITLE
Update versioning and conditional GeoIP2 package refs

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,24 +5,24 @@
     <!--<TargetFramework></TargetFramework>-->
 
     <VersionPrefixMajor>8</VersionPrefixMajor>
-    <VersionPrefixBase>$(VersionPrefixMajor).49</VersionPrefixBase>
+    <VersionPrefixBase>$(VersionPrefixMajor).50</VersionPrefixBase>
 
-    <VersionPrefixCore>$(VersionPrefixBase).1</VersionPrefixCore>
-    <VersionPrefixIdentity>$(VersionPrefixBase).1</VersionPrefixIdentity>
-    <VersionPrefixIdentityUI>$(VersionPrefixBase).1</VersionPrefixIdentityUI>
+    <VersionPrefixCore>$(VersionPrefixBase).0</VersionPrefixCore>
+    <VersionPrefixIdentity>$(VersionPrefixBase).0</VersionPrefixIdentity>
+    <VersionPrefixIdentityUI>$(VersionPrefixBase).0</VersionPrefixIdentityUI>
     <VersionPrefixCases>$(VersionPrefixBase).0</VersionPrefixCases>
-    <VersionPrefixMessages>$(VersionPrefixBase).1</VersionPrefixMessages>
+    <VersionPrefixMessages>$(VersionPrefixBase).0</VersionPrefixMessages>
     <VersionPrefixMultitenancy>$(VersionPrefixBase).0</VersionPrefixMultitenancy>
     <VersionPrefixRisk>$(VersionPrefixBase).0</VersionPrefixRisk>
     <VersionPrefixMedia>$(VersionPrefixBase).0</VersionPrefixMedia>
     <VersionPrefixGeoIP>$(VersionPrefixBase).0</VersionPrefixGeoIP>
     <VersionPrefixGovGr>$(VersionPrefixBase).0</VersionPrefixGovGr>
-    <VersionPrefixAspNet>$(VersionPrefixBase).1</VersionPrefixAspNet>
+    <VersionPrefixAspNet>$(VersionPrefixBase).0</VersionPrefixAspNet>
     <VersionPrefixActivityLogs>$(VersionPrefixBase).0</VersionPrefixActivityLogs>
     <VersionPrefixFtpServer>$(VersionPrefixBase).0</VersionPrefixFtpServer>
     <VersionPrefix>$(VersionPrefixBase).0</VersionPrefix>
 
-    <!--<VersionSuffix>rc06</VersionSuffix>-->
+    <VersionSuffix>rc01</VersionSuffix>
     <Authors>Constantinos Leftheris</Authors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>Latest</LangVersion>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -22,7 +22,7 @@
     <VersionPrefixFtpServer>$(VersionPrefixBase).0</VersionPrefixFtpServer>
     <VersionPrefix>$(VersionPrefixBase).0</VersionPrefix>
 
-    <VersionSuffix>rc01</VersionSuffix>
+    <!--<VersionSuffix>rc01</VersionSuffix>-->
     <Authors>Constantinos Leftheris</Authors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>Latest</LangVersion>

--- a/src/Indice.Features.GeoIP/Indice.Features.GeoIP.csproj
+++ b/src/Indice.Features.GeoIP/Indice.Features.GeoIP.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  
+
   <PropertyGroup Label="Package">
     <PackageTags>GeoIP;Utilities</PackageTags>
     <PackageReleaseNotes>GeoLite based IP Address geolocator</PackageReleaseNotes>
     <VersionPrefix>$(VersionPrefixGeoIP)</VersionPrefix>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <EmbeddedResource Include="GeoLite2\GeoLite2-City.mmdb">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
@@ -20,9 +20,17 @@
 
   <ItemGroup>
     <PackageReference Include="Indice.Common" Version="$(VersionPrefixCore)-*" />
-    <PackageReference Include="MaxMind.GeoIP2" Version="6.0.0" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="MaxMind.GeoIP2" Version="5.4.1" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <PackageReference Include="MaxMind.GeoIP2" Version="5.4.1" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="MaxMind.GeoIP2" Version="6.0.0" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Indice.Common\Indice.Common.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Updated versioning in Directory.Build.props: incremented VersionPrefixBase to 8.50. In Indice.Features.GeoIP.csproj, made MaxMind.GeoIP2 package reference conditional by target framework—using v5.4.1 for net8.0/net9.0 and v6.0.0 for net10.0. Removed the unconditional GeoIP2 reference.