### PR TITLE
[agents] Update chat API URLs

### DIFF
--- a/src/Indice.Features.Agents.App/src/app/core/services/chat-stream.service.ts
+++ b/src/Indice.Features.Agents.App/src/app/core/services/chat-stream.service.ts
@@ -20,14 +20,14 @@ export class ChatStreamService {
     '',
   );
 
-  /** POST /api/my/chats/stream — create a session and stream the first turn. */
+  /** POST /my/chats/stream — create a session and stream the first turn. */
   streamCreate(text: string): Observable<IChatStreamEvent> {
-    return this.stream(`${this.baseUrl}/api/my/chats/stream`, text);
+    return this.stream(`${this.baseUrl}/my/chats/stream`, text);
   }
 
-  /** POST /api/my/chats/{id}/messages/stream — stream a follow-up turn in an existing session. */
+  /** POST /my/chats/{id}/messages/stream — stream a follow-up turn in an existing session. */
   streamMessage(sessionId: string, text: string): Observable<IChatStreamEvent> {
-    return this.stream(`${this.baseUrl}/api/my/chats/${sessionId}/messages/stream`, text);
+    return this.stream(`${this.baseUrl}/my/chats/${sessionId}/messages/stream`, text);
   }
 
   private stream(url: string, text: string): Observable<IChatStreamEvent> {

--- a/src/Indice.Features.Agents.Core/Indice.Features.Agents.Core.csproj
+++ b/src/Indice.Features.Agents.Core/Indice.Features.Agents.Core.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks></TargetFrameworks>
     <TargetFramework>net10.0</TargetFramework>
     <VersionPrefix>$(VersionPrefixAgents)</VersionPrefix>
-    <VersionSuffix>beta00</VersionSuffix>
+    <VersionSuffix>beta01</VersionSuffix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Indice.Features.Agents.Server/Indice.Features.Agents.Server.csproj
+++ b/src/Indice.Features.Agents.Server/Indice.Features.Agents.Server.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks></TargetFrameworks>
     <TargetFramework>net10.0</TargetFramework>
     <VersionPrefix>$(VersionPrefixAgents)</VersionPrefix>
-    <VersionSuffix>beta00</VersionSuffix>
+    <VersionSuffix>beta01</VersionSuffix>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Indice.AspNetCore.Builder" Version="$(VersionPrefixAspNet)-*" />

--- a/src/Indice.Features.Agents.UI/Indice.Features.Agents.UI.csproj
+++ b/src/Indice.Features.Agents.UI/Indice.Features.Agents.UI.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks></TargetFrameworks>
     <TargetFramework>net10.0</TargetFramework>    
     <VersionPrefix>$(VersionPrefixAgents)</VersionPrefix>
-    <VersionSuffix>beta00</VersionSuffix>
+    <VersionSuffix>beta01</VersionSuffix>
     
     <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
     <SpaProjectName>browser</SpaProjectName>


### PR DESCRIPTION
Removed /api prefix from chat streaming endpoints in ChatStreamService and updated related documentation comments. Incremented VersionSuffix to beta01 in all Agents project files for new prerelease versioning.