### PR TITLE
[cases] Update auth policy in my Case types and add EF Core packages

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -10,7 +10,7 @@
     <VersionPrefixCore>$(VersionPrefixBase).0</VersionPrefixCore>
     <VersionPrefixIdentity>$(VersionPrefixBase).0</VersionPrefixIdentity>
     <VersionPrefixIdentityUI>$(VersionPrefixBase).0</VersionPrefixIdentityUI>
-    <VersionPrefixCases>$(VersionPrefixBase).0</VersionPrefixCases>
+    <VersionPrefixCases>$(VersionPrefixBase).1</VersionPrefixCases>
     <VersionPrefixMessages>$(VersionPrefixBase).0</VersionPrefixMessages>
     <VersionPrefixMultitenancy>$(VersionPrefixBase).0</VersionPrefixMultitenancy>
     <VersionPrefixRisk>$(VersionPrefixBase).0</VersionPrefixRisk>

--- a/src/Indice.Features.Cases.Server/Endpoints/MyCaseTypesApi.cs
+++ b/src/Indice.Features.Cases.Server/Endpoints/MyCaseTypesApi.cs
@@ -1,5 +1,6 @@
 ﻿using Indice.Features.Cases.Server;
 using Indice.Features.Cases.Server.Endpoints;
+using Indice.Security;
 using Indice.Types;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -30,7 +31,7 @@ internal static class MyCaseTypesApi
         group.RequireAuthorization(policy => policy
             .RequireAuthenticatedUser()
             .AddAuthenticationSchemes("Bearer")
-            .RequireCasesAccess()
+            .RequireClaim(BasicClaimTypes.Subject)
         ).WithHandledException<BusinessException>();
 
         group.WithOpenApiSecurityRequirement("oauth2", allowedScopes);

--- a/src/Indice.Features.Cases.Workflows/Indice.Features.Cases.Workflows.csproj
+++ b/src/Indice.Features.Cases.Workflows/Indice.Features.Cases.Workflows.csproj
@@ -31,9 +31,17 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="9.0.16" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.16" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.16" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.16" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.16" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Indice.AspNetCore\Indice.AspNetCore.csproj" />


### PR DESCRIPTION
Removed RequireCasesAccess from MyCaseTypesApi in favor of requiring only the "subject" claim for authentication. Added EF Core package references for net9.0 and net10.0 target frameworks to ensure correct dependency alignment.