### PR TITLE
[spa] Fix missing tailwind styles from ng-components library

### DIFF
--- a/src/Indice.Features.Cases.App/src/styles.css
+++ b/src/Indice.Features.Cases.App/src/styles.css
@@ -1,11 +1,10 @@
 @import "tailwindcss";
-@source "../node_modules/@indice/ng-components";
-@plugin "@tailwindcss/forms";
 @import "../node_modules/@indice/ng-components/src/styles.css";
-
 @import "quill/dist/quill.core.css";
 @import "quill/dist/quill.bubble.css";
 @import "quill/dist/quill.snow.css";
+@source "../node_modules/@indice/ng-components/**/*.{html,ts}";
+@plugin "@tailwindcss/forms";
 
 @theme {
     /* Custom colors */

--- a/src/Indice.Features.Messages.App/src/styles.css
+++ b/src/Indice.Features.Messages.App/src/styles.css
@@ -1,7 +1,8 @@
 @import "tailwindcss";
-@plugin "@tailwindcss/forms";
 @import "../node_modules/@indice/ng-components/src/styles.css";
 @import "../node_modules/highlight.js/styles/github.css";
+@source "../node_modules/@indice/ng-components/**/*.{html,ts}";
+@plugin "@tailwindcss/forms";
 
 :root {
   --ng-progress-color: #ffc107;

--- a/src/Indice.Features.Risk.App/src/styles.css
+++ b/src/Indice.Features.Risk.App/src/styles.css
@@ -1,10 +1,11 @@
 @import "tailwindcss";
 @import "../node_modules/@indice/ng-components/src/styles.css";
+@source "../node_modules/@indice/ng-components";
 @plugin '@tailwindcss/typography';
 @plugin '@tailwindcss/forms';
 @plugin '@tailwindcss/aspect-ratio';
 
-@theme inline {
+@theme {
   --color-dusty-orange: #f27731;
   --color-dusty-orange-opacity: #f2773199;
   --color-dark-green: #03292e;
@@ -12,12 +13,6 @@
 }
 
 @layer components {
-  .h-5 {
-    height: 1.25rem;
-  }
-  .w-5 {
-    width: 1.25rem;
-  }
   .kpi-chart-container {
     @apply h-full w-full;
   }

--- a/src/Indice.Features.Risk.App/src/styles.css
+++ b/src/Indice.Features.Risk.App/src/styles.css
@@ -1,6 +1,6 @@
 @import "tailwindcss";
 @import "../node_modules/@indice/ng-components/src/styles.css";
-@source "../node_modules/@indice/ng-components";
+@source "../node_modules/@indice/ng-components/**/*.{html,ts}";
 @plugin '@tailwindcss/typography';
 @plugin '@tailwindcss/forms';
 @plugin '@tailwindcss/aspect-ratio';


### PR DESCRIPTION
Before changes:
<img width="267" height="94" alt="image" src="https://github.com/user-attachments/assets/c51214ff-8751-4957-8172-b87c059067dd" />

After changes:
<img width="193" height="78" alt="image" src="https://github.com/user-attachments/assets/2e9d63c9-57fe-4cc5-8dc9-789a3b5f9bfe" />
After clicking the dropdown menu:
<img width="253" height="115" alt="image" src="https://github.com/user-attachments/assets/433670c5-ecac-4d91-9be4-6eb7ec238487" />

*You will notice in the after pictures only after I clicked the profile button the dropdown menu opened.*

**External styles and plugins:**

* Added a new `@source` directive to include styles from `@indice/ng-components`, ensuring tailwind classes that used in the library don't get purged.
* Updated the use of the `@theme` directive by removing the `inline` keyword. This is the standard for [tailwind v4](https://tailwindcss.com/docs/theme).

**Component and utility classes:**

* Removed custom utility classes `.h-5` and `.w-5` from the `@layer components` section, to avoid redundancy with Tailwind's built-in utilities. Since these classes now don't get purged by tailwind.