### PR TITLE
[core] Add DateTimeOffset.Convert extension and related tests

### DIFF
--- a/src/Indice.Common/Extensions/DateTimeExtensions.cs
+++ b/src/Indice.Common/Extensions/DateTimeExtensions.cs
@@ -36,7 +36,7 @@ public static class DateTimeExtensions
 
     /// <summary>Converts the <paramref name="dateTime"/> to a local kind of <see cref="DateTime"/> in the given <paramref name="timeZoneId"/></summary>
     /// <param name="dateTime">The source <see cref="DateTime"/>.</param>
-    /// <param name="timeZoneId">The Windows or IANA time zone id.</param>
+    /// <param name="timeZoneId">The time zone identifier. For example, "Europe/Athens".</param>
     /// <param name="kind">Specify the kind of date you get.</param>
     public static DateTime Shift(this DateTime dateTime, string timeZoneId, DateTimeKind kind = DateTimeKind.Unspecified) {
         var zone = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
@@ -47,7 +47,7 @@ public static class DateTimeExtensions
 
     /// <summary>Converts the <paramref name="dateTime"/> to <see cref="DateTimeOffset"/> in the given <paramref name="timeZoneId"/></summary>
     /// <param name="dateTime">The source <see cref="DateTime"/></param>
-    /// <param name="timeZoneId">The Windows or IANA time zone id.</param>
+    /// <param name="timeZoneId">The time zone identifier. For example, "Europe/Athens".
     public static DateTimeOffset ToDateTimeOffset(this DateTime dateTime, string timeZoneId) {
         var zone = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
         var utc = dateTime.ToUniversalTime();
@@ -58,7 +58,7 @@ public static class DateTimeExtensions
 
     /// <summary>Converts the <paramref name="dateTimeOffset"/> to <see cref="DateTimeOffset"/> in the given <paramref name="timeZoneId"/></summary>
     /// <param name="dateTimeOffset">The source <see cref="DateTimeOffset"/></param>
-    /// <param name="timeZoneId">The Windows or IANA time zone id.</param>
+    /// <param name="timeZoneId">The time zone identifier. For example, "Europe/Athens".
     public static DateTimeOffset Convert(this DateTimeOffset dateTimeOffset, string timeZoneId) {
         var zone = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
         var offset = zone.GetUtcOffset(dateTimeOffset);

--- a/src/Indice.Common/Extensions/DateTimeExtensions.cs
+++ b/src/Indice.Common/Extensions/DateTimeExtensions.cs
@@ -36,7 +36,7 @@ public static class DateTimeExtensions
 
     /// <summary>Converts the <paramref name="dateTime"/> to a local kind of <see cref="DateTime"/> in the given <paramref name="timeZoneId"/></summary>
     /// <param name="dateTime">The source <see cref="DateTime"/>.</param>
-    /// <param name="timeZoneId">The Windows time zone id.</param>
+    /// <param name="timeZoneId">The Windows or IANA time zone id.</param>
     /// <param name="kind">Specify the kind of date you get.</param>
     public static DateTime Shift(this DateTime dateTime, string timeZoneId, DateTimeKind kind = DateTimeKind.Unspecified) {
         var zone = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
@@ -47,12 +47,21 @@ public static class DateTimeExtensions
 
     /// <summary>Converts the <paramref name="dateTime"/> to <see cref="DateTimeOffset"/> in the given <paramref name="timeZoneId"/></summary>
     /// <param name="dateTime">The source <see cref="DateTime"/></param>
-    /// <param name="timeZoneId">The Windows time zone id.</param>
+    /// <param name="timeZoneId">The Windows or IANA time zone id.</param>
     public static DateTimeOffset ToDateTimeOffset(this DateTime dateTime, string timeZoneId) {
         var zone = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
         var utc = dateTime.ToUniversalTime();
         var offset = zone.GetUtcOffset(utc);
         var local = DateTime.SpecifyKind(utc.Add(offset), DateTimeKind.Unspecified);
         return new DateTimeOffset(local, offset);
+    }
+
+    /// <summary>Converts the <paramref name="dateTimeOffset"/> to <see cref="DateTimeOffset"/> in the given <paramref name="timeZoneId"/></summary>
+    /// <param name="dateTimeOffset">The source <see cref="DateTimeOffset"/></param>
+    /// <param name="timeZoneId">The Windows or IANA time zone id.</param>
+    public static DateTimeOffset Convert(this DateTimeOffset dateTimeOffset, string timeZoneId) {
+        var zone = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
+        var offset = zone.GetUtcOffset(dateTimeOffset);
+        return dateTimeOffset.ToOffset(offset);
     }
 }

--- a/test/Indice.Common.Tests/DateTimeExtensionsTests.cs
+++ b/test/Indice.Common.Tests/DateTimeExtensionsTests.cs
@@ -8,10 +8,13 @@ public class DateTimeExtensionsTests
 
 
     [Trait("Tag", "TimeZone")]
-    [Fact]
-    public void ConvertTimeZoneFromUtc() {
+    [Theory]
+    [InlineData("Europe/Athens", "2026-07-06T14:31:22.7300379+03:00")]
+    [InlineData("America/New_York", "2026-07-06T07:31:22.7300379-04:00")]
+    [InlineData("GTB Standard Time", "2026-07-06T14:31:22.7300379+03:00")]
+    public void ConvertTimeZoneFromUtc(string timeZoneId, string expected) {
         var testDateTimeOffset = DateTimeOffset.Parse("2026-07-06T11:31:22.7300379+00:00");
-        var dateTimeToTargetOffset = testDateTimeOffset.Convert("Europe/Athens");
-        Assert.Equal("2026-07-06T14:31:22.7300379+03:00", dateTimeToTargetOffset.ToString("o"));
+        var dateTimeToTargetOffset = testDateTimeOffset.Convert(timeZoneId);
+        Assert.Equal(expected, dateTimeToTargetOffset.ToString("o"));
     }
 }

--- a/test/Indice.Common.Tests/DateTimeExtensionsTests.cs
+++ b/test/Indice.Common.Tests/DateTimeExtensionsTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Text;
-using Indice.Extensions;
+﻿using Indice.Extensions;
 using Xunit;
 
 namespace Indice.Common.Tests;
@@ -10,7 +9,7 @@ public class DateTimeExtensionsTests
 
     [Trait("Tag", "TimeZone")]
     [Fact]
-    public void ConvertTimeZoneFormUtc() {
+    public void ConvertTimeZoneFromUtc() {
         var testDateTimeOffset = DateTimeOffset.Parse("2026-07-06T11:31:22.7300379+00:00");
         var dateTimeToTargetOffset = testDateTimeOffset.Convert("Europe/Athens");
         Assert.Equal("2026-07-06T14:31:22.7300379+03:00", dateTimeToTargetOffset.ToString("o"));

--- a/test/Indice.Common.Tests/DateTimeExtensionsTests.cs
+++ b/test/Indice.Common.Tests/DateTimeExtensionsTests.cs
@@ -1,0 +1,18 @@
+﻿using System.Text;
+using Indice.Extensions;
+using Xunit;
+
+namespace Indice.Common.Tests;
+
+public class DateTimeExtensionsTests
+{
+
+
+    [Trait("Tag", "TimeZone")]
+    [Fact]
+    public void ConvertTimeZoneFormUtc() {
+        var testDateTimeOffset = DateTimeOffset.Parse("2026-07-06T11:31:22.7300379+00:00");
+        var dateTimeToTargetOffset = testDateTimeOffset.Convert("Europe/Athens");
+        Assert.Equal("2026-07-06T14:31:22.7300379+03:00", dateTimeToTargetOffset.ToString("o"));
+    }
+}


### PR DESCRIPTION
Updated XML docs to note support for Windows and IANA time zone IDs. Added a Convert extension method for DateTimeOffset to shift to a specified time zone. Introduced unit tests to verify correct time zone conversion.