### PR TITLE
[services] fix KapaTEL SMS registration

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,21 +7,21 @@
     <VersionPrefixMajor>8</VersionPrefixMajor>
     <VersionPrefixBase>$(VersionPrefixMajor).51</VersionPrefixBase>
 
-    <VersionPrefixCore>$(VersionPrefixBase).0</VersionPrefixCore>
-    <VersionPrefixIdentity>$(VersionPrefixBase).0</VersionPrefixIdentity>
-    <VersionPrefixIdentityUI>$(VersionPrefixBase).0</VersionPrefixIdentityUI>
-    <VersionPrefixCases>$(VersionPrefixBase).0</VersionPrefixCases>
-    <VersionPrefixMessages>$(VersionPrefixBase).0</VersionPrefixMessages>
-    <VersionPrefixMultitenancy>$(VersionPrefixBase).0</VersionPrefixMultitenancy>
-    <VersionPrefixRisk>$(VersionPrefixBase).0</VersionPrefixRisk>
-    <VersionPrefixMedia>$(VersionPrefixBase).0</VersionPrefixMedia>
-    <VersionPrefixGeoIP>$(VersionPrefixBase).0</VersionPrefixGeoIP>
-    <VersionPrefixGovGr>$(VersionPrefixBase).0</VersionPrefixGovGr>
-    <VersionPrefixAspNet>$(VersionPrefixBase).0</VersionPrefixAspNet>
-    <VersionPrefixActivityLogs>$(VersionPrefixBase).0</VersionPrefixActivityLogs>
-    <VersionPrefixFtpServer>$(VersionPrefixBase).0</VersionPrefixFtpServer>
+    <VersionPrefixCore>$(VersionPrefixBase).1</VersionPrefixCore>
+    <VersionPrefixIdentity>$(VersionPrefixBase).1</VersionPrefixIdentity>
+    <VersionPrefixIdentityUI>$(VersionPrefixBase).1</VersionPrefixIdentityUI>
+    <VersionPrefixCases>$(VersionPrefixBase).1</VersionPrefixCases>
+    <VersionPrefixMessages>$(VersionPrefixBase).1</VersionPrefixMessages>
+    <VersionPrefixMultitenancy>$(VersionPrefixBase).1</VersionPrefixMultitenancy>
+    <VersionPrefixRisk>$(VersionPrefixBase).1</VersionPrefixRisk>
+    <VersionPrefixMedia>$(VersionPrefixBase).1</VersionPrefixMedia>
+    <VersionPrefixGeoIP>$(VersionPrefixBase).1</VersionPrefixGeoIP>
+    <VersionPrefixGovGr>$(VersionPrefixBase).1</VersionPrefixGovGr>
+    <VersionPrefixAspNet>$(VersionPrefixBase).1</VersionPrefixAspNet>
+    <VersionPrefixActivityLogs>$(VersionPrefixBase).1</VersionPrefixActivityLogs>
+    <VersionPrefixFtpServer>$(VersionPrefixBase).1</VersionPrefixFtpServer>
     <VersionPrefixAgents>8.0.0</VersionPrefixAgents>
-    <VersionPrefix>$(VersionPrefixBase).0</VersionPrefix>
+    <VersionPrefix>$(VersionPrefixBase).1</VersionPrefix>
 
     <!--<VersionSuffix>rc01</VersionSuffix>-->
     <Authors>Constantinos Leftheris</Authors>

--- a/src/Indice.Services/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Indice.Services/Extensions/IServiceCollectionExtensions.cs
@@ -226,7 +226,7 @@ public static class IndiceServicesServiceCollectionExtensions
                     break;
                 case "kapatel":
                 case "kapa_tel":
-                    services.AddSmsServiceApifonIM(configuration);
+                    services.AddSmsServiceKapaTEL(configuration);
                     break;
                 case "mstat":
                     services.AddSmsServiceMstat(configuration);


### PR DESCRIPTION
Incremented version suffix from .0 to .1 for all relevant project components in Directory.Build.props. Corrected SMS service registration for "kapatel" and "kapa_tel" to use AddSmsServiceKapaTEL instead of AddSmsServiceApifonIM.