### PR TITLE
[agents] Add structural Markdown chunker and pipeline support

### DIFF
--- a/src/Indice.Features.Agents.Core/AgentsOptions.cs
+++ b/src/Indice.Features.Agents.Core/AgentsOptions.cs
@@ -137,11 +137,11 @@ public class AgentsOptions
     /// <summary>Ingestion-time knobs.</summary>
     public class IngestionOptions
     {
-        /// <summary>Target chunk size in tokens.</summary>
-        public int ChunkTargetTokens { get; set; } = 256;
+        /// <summary>Target chunk size in characters.</summary>
+        public int ChunkTargetChars { get; set; } = 1024;
 
-        /// <summary>Overlap between adjacent chunks in tokens.</summary>
-        public int ChunkOverlapTokens { get; set; } = 50;
+        /// <summary>Overlap between adjacent chunks in characters.</summary>
+        public int ChunkOverlapChars { get; set; } = 200;
 
         /// <summary>Maximum inputs per embedding call.</summary>
         public int EmbedBatchSize { get; set; } = 10;

--- a/src/Indice.Features.Agents.Core/Indice.Features.Agents.Core.csproj
+++ b/src/Indice.Features.Agents.Core/Indice.Features.Agents.Core.csproj
@@ -20,6 +20,7 @@
     <!-- 3rd Party -->
     <PackageReference Include="Duende.IdentityModel" Version="8.1.0" />
     <PackageReference Include="Handlebars.Net" Version="2.1.6" />
+    <PackageReference Include="Markdig" Version="1.3.2" />
     <PackageReference Include="Azure.AI.OpenAI" Version="2.5.0-beta.1" />
     <PackageReference Include="FluentValidation" Version="12.0.0" />
   </ItemGroup>

--- a/src/Indice.Features.Agents.Core/Models/DocumentType.cs
+++ b/src/Indice.Features.Agents.Core/Models/DocumentType.cs
@@ -1,8 +1,10 @@
 ﻿namespace Indice.Features.Agents.Core.Models;
 
-/// <summary>Represents the type of a document./// </summary>
+/// <summary>Represents the type of a document.</summary>
 public enum DocumentType
 {
-    /// <summary>Represents a Markdown FAQ document type.</summary>
-    MarkdownFaq = 0
+    /// <summary>A Markdown FAQ document — a flat list of <c>## Question</c> / answer pairs parsed one chunk per pair.</summary>
+    MarkdownFaq = 0,
+    /// <summary>A general-structure Markdown document — chunked by heading section with a token-budget fallback.</summary>
+    Markdown = 1
 }

--- a/src/Indice.Features.Agents.Core/Models/IngestRequest.cs
+++ b/src/Indice.Features.Agents.Core/Models/IngestRequest.cs
@@ -5,6 +5,8 @@
 /// </summary>
 public class IngestRequest
 {
+    /// <summary>The type of the document, selecting the parsing/chunking strategy.</summary>
+    public DocumentType DocumentType { get; set; }
     /// <summary>Opens a UTF-8 text based content stream. Can consume markdown.</summary>
     /// <remarks>This is used as the tokenization input</remarks>
     public Func<Stream> OpenMarkdownSourceStream { get; set; } = null!;

--- a/src/Indice.Features.Agents.Core/Workflows/DefaultIngestionPipeline.cs
+++ b/src/Indice.Features.Agents.Core/Workflows/DefaultIngestionPipeline.cs
@@ -27,7 +27,12 @@ public class DefaultIngestionPipeline : IIngestionPipeline
     public async Task<IngestionReport> IngestAsync(IngestRequest request, CancellationToken cancellationToken) {
         using var reader = new StreamReader(request.OpenMarkdownSourceStream(), Encoding.UTF8, leaveOpen: false);
         var body = await reader.ReadToEndAsync(cancellationToken);
-        var (firstCategory, chunks) = ParseFaq(body);
+        var title = Path.GetFileNameWithoutExtension(request.FileName);
+        var (firstCategory, chunks) = request.DocumentType switch {
+            DocumentType.MarkdownFaq => ParseFaq(body),
+            DocumentType.Markdown => (null, MarkdownChunker.Chunk(body, title, _options.Ingestion)),
+            _ => throw new BusinessException($"Unsupported document type '{request.DocumentType}'.", "UNSUPPORTED_DOCUMENT_TYPE"),
+        };
 
         var effectiveCategory = firstCategory ?? (string.IsNullOrWhiteSpace(request.Category) ? null : request.Category.Trim());
         var effectiveLanguage = string.IsNullOrWhiteSpace(request.Language) ? null : request.Language.Trim();
@@ -42,8 +47,6 @@ public class DefaultIngestionPipeline : IIngestionPipeline
                 $"Allowed languages: {string.Join(", ", _options.Taxonomy.Languages)}.",
             ]);
         }
-
-        var title = Path.GetFileNameWithoutExtension(request.FileName);
 
         byte[]? data = null;
         var toByteArray = (Stream stream) => {

--- a/src/Indice.Features.Agents.Core/Workflows/MarkdownChunker.cs
+++ b/src/Indice.Features.Agents.Core/Workflows/MarkdownChunker.cs
@@ -171,18 +171,15 @@ public static class MarkdownChunker
         }
         return windows;
 
-        // Largest break in (start, ceiling]; -1 when none exists.
+        // Largest break in (start, ceiling]; -1 when none exists. Binary search over the sorted
+        // breaks list keeps splitting ~O(n log n) instead of O(breaks × windows).
         int FloorBreak(int start, int ceiling) {
-            var found = -1;
-            foreach (var b in breaks) {
-                if (b > ceiling) {
-                    break;
-                }
-                if (b > start) {
-                    found = b;
-                }
+            var index = breaks.BinarySearch(ceiling);
+            if (index < 0) {
+                index = ~index - 1; // largest break strictly less than ceiling (~index is the first break above it)
             }
-            return found;
+            // breaks[index] is now the largest break <= ceiling (index is -1 when every break exceeds ceiling).
+            return index >= 0 && breaks[index] > start ? breaks[index] : -1;
         }
 
     }

--- a/src/Indice.Features.Agents.Core/Workflows/MarkdownChunker.cs
+++ b/src/Indice.Features.Agents.Core/Workflows/MarkdownChunker.cs
@@ -1,0 +1,202 @@
+using System.Security.Cryptography;
+using System.Text;
+using Markdig;
+using Markdig.Extensions.Yaml;
+using Markdig.Syntax;
+using Markdig.Syntax.Inlines;
+
+namespace Indice.Features.Agents.Core.Workflows;
+
+/// <summary>
+/// Structural, heading-aware chunker for general Markdown. Walks the Markdig AST in source order, tracking a
+/// heading breadcrumb, and emits one chunk per heading section — splitting oversized sections by a token budget
+/// with overlap. Content with no enclosing heading (a flat file, or intro prose above the first heading) is
+/// anchored to <c>documentTitle</c>. Original source text is sliced verbatim, so code fences, tables, and lists
+/// survive intact.
+/// </summary>
+public static class MarkdownChunker
+{
+    private static readonly MarkdownPipeline Pipeline = new MarkdownPipelineBuilder()
+        .UseAdvancedExtensions()
+        .UseYamlFrontMatter()
+        .Build();
+
+    /// <summary>Splits <paramref name="body"/> into structural chunks.</summary>
+    /// <param name="body">The raw Markdown text.</param>
+    /// <param name="documentTitle">Breadcrumb root for content that has no heading above it.</param>
+    /// <param name="options">Ingestion knobs (<see cref="AgentsOptions.IngestionOptions.ChunkTargetTokens"/> / <see cref="AgentsOptions.IngestionOptions.ChunkOverlapTokens"/>).</param>
+    public static IReadOnlyList<DocumentChunk> Chunk(string body, string documentTitle, AgentsOptions.IngestionOptions options) {
+        var chunks = new List<DocumentChunk>();
+        if (string.IsNullOrWhiteSpace(body)) {
+            return chunks;
+        }
+
+        var document = Markdown.Parse(body, Pipeline);
+        var headings = new List<(int Level, string Text)>();
+        int? sectionStart = null;
+        var sectionEnd = 0;
+        var chunkIndex = 0;
+
+        foreach (var block in document) {
+            if (block is YamlFrontMatterBlock) {
+                continue;
+            }
+            if (block is HeadingBlock heading) {
+                Flush();
+                while (headings.Count > 0 && headings[^1].Level >= heading.Level) {
+                    headings.RemoveAt(headings.Count - 1);
+                }
+                headings.Add((heading.Level, HeadingText(heading)));
+                continue;
+            }
+            if (block.Span.Length <= 0) {
+                continue;
+            }
+            sectionStart ??= block.Span.Start;
+            sectionEnd = block.Span.End;
+        }
+        Flush();
+        return chunks;
+
+        void Flush() {
+            if (sectionStart is null) {
+                return;
+            }
+            var text = body.Substring(sectionStart.Value, sectionEnd - sectionStart.Value + 1).Trim();
+            sectionStart = null;
+            if (text.Length == 0) {
+                return;
+            }
+            var breadcrumb = headings.Count > 0 ? string.Join(" > ", headings.Select(h => h.Text)) : documentTitle;
+            var title = headings.Count > 0 ? headings[^1].Text : documentTitle;
+            foreach (var piece in SplitText(text, options)) {
+                if (piece.Length > 0) {
+                    Emit(breadcrumb, title, piece);
+                }
+            }
+        }
+
+        void Emit(string headingPath, string title, string text) {
+            var content = $"{headingPath}\n\n{text}";
+            chunks.Add(new DocumentChunk {
+                ChunkIndex = chunkIndex++,
+                Content = content,
+                ContentHash = Sha256Hex(content),
+                HeadingPath = headingPath,
+                Title = title,
+                Category = null,
+                TokenCount = EstimateTokens(text),
+            });
+        }
+    }
+
+    /// <summary>
+    /// Extracts the plain-text label of a heading from its parsed inline tree — correct for both ATX (<c>## Foo</c>)
+    /// and setext (<c>Foo</c> underlined with <c>===</c>) styles, and strips inline markup so <c>## **Bold** `code`</c>
+    /// yields <c>Bold code</c>.
+    /// </summary>
+    private static string HeadingText(HeadingBlock heading) {
+        if (heading.Inline is null) {
+            return string.Empty;
+        }
+        var builder = new StringBuilder();
+        foreach (var inline in heading.Inline.Descendants()) {
+            switch (inline) {
+                case LiteralInline literal:
+                    builder.Append(literal.Content.ToString());
+                    break;
+                case CodeInline code:
+                    builder.Append(code.Content);
+                    break;
+                case LineBreakInline:
+                    builder.Append(' ');
+                    break;
+            }
+        }
+        return builder.ToString().Trim();
+    }
+
+    /// <summary>
+    /// Splits <paramref name="text"/> into windows of at most <see cref="AgentsOptions.IngestionOptions.ChunkTargetTokens"/>,
+    /// each seeded with a ~<see cref="AgentsOptions.IngestionOptions.ChunkOverlapTokens"/> tail of the previous one. Cuts fall on
+    /// whitespace-run boundaries — which coincide with paragraph, sentence, and word boundaries — preferring the furthest one
+    /// that fits the budget; a hard character limit guarantees a bounded chunk even for an unbroken wall of text.
+    /// </summary>
+    private static IReadOnlyList<string> SplitText(string text, AgentsOptions.IngestionOptions options) {
+        var target = Math.Max(1, options.ChunkTargetTokens);
+        if (EstimateTokens(text) <= target) {
+            return [text];
+        }
+        var overlap = Math.Clamp(options.ChunkOverlapTokens, 0, target - 1);
+        var targetChars = target * CharsPerToken;
+        var overlapChars = overlap * CharsPerToken;
+
+        // Candidate cut offsets: the position after each maximal whitespace run, plus the end of the text.
+        var breaks = new List<int>();
+        for (var i = 0; i < text.Length; i++) {
+            if (char.IsWhiteSpace(text[i])) {
+                while (i < text.Length && char.IsWhiteSpace(text[i])) {
+                    i++;
+                }
+                breaks.Add(i);
+                i--;
+            }
+        }
+        if (breaks.Count == 0 || breaks[^1] != text.Length) {
+            breaks.Add(text.Length);
+        }
+
+        // Largest break in (start, ceiling]; -1 when none exists.
+        int FloorBreak(int start, int ceiling) {
+            var found = -1;
+            foreach (var b in breaks) {
+                if (b > ceiling) {
+                    break;
+                }
+                if (b > start) {
+                    found = b;
+                }
+            }
+            return found;
+        }
+
+        var windows = new List<string>();
+        var start = 0;
+        while (start < text.Length) {
+            int end;
+            if (start + targetChars >= text.Length) {
+                end = text.Length;
+            } else {
+                var boundary = FloorBreak(start, start + targetChars);
+                end = boundary > start ? boundary : Math.Min(start + targetChars, text.Length);
+            }
+            var slice = text[start..end].Trim();
+            if (slice.Length > 0) {
+                windows.Add(slice);
+            }
+            if (end >= text.Length) {
+                break;
+            }
+            // Back up ~overlapChars to a boundary to seed the next window; never regress past start.
+            var nextStart = end;
+            if (overlapChars > 0) {
+                var boundary = FloorBreak(start, end - overlapChars);
+                if (boundary > start) {
+                    nextStart = boundary;
+                }
+            }
+            start = nextStart > start ? nextStart : end;
+        }
+        return windows;
+    }
+
+    private const int CharsPerToken = 4;
+
+    /// <summary>Approximate token count (~4 chars per token). Documented as an estimate; a precise tokenizer can replace this without changing the contract.</summary>
+    private static int EstimateTokens(string text) => Math.Max(1, (int)Math.Ceiling((double)text.Length / CharsPerToken));
+
+    private static string Sha256Hex(string input) {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(input));
+        return Convert.ToHexString(bytes);
+    }
+}

--- a/src/Indice.Features.Agents.Core/Workflows/MarkdownChunker.cs
+++ b/src/Indice.Features.Agents.Core/Workflows/MarkdownChunker.cs
@@ -9,7 +9,7 @@ namespace Indice.Features.Agents.Core.Workflows;
 
 /// <summary>
 /// Structural, heading-aware chunker for general Markdown. Walks the Markdig AST in source order, tracking a
-/// heading breadcrumb, and emits one chunk per heading section — splitting oversized sections by a token budget
+/// heading breadcrumb, and emits one chunk per heading section — splitting oversized sections by a character budget
 /// with overlap. Content with no enclosing heading (a flat file, or intro prose above the first heading) is
 /// anchored to <c>documentTitle</c>. Original source text is sliced verbatim, so code fences, tables, and lists
 /// survive intact.
@@ -24,7 +24,7 @@ public static class MarkdownChunker
     /// <summary>Splits <paramref name="body"/> into structural chunks.</summary>
     /// <param name="body">The raw Markdown text.</param>
     /// <param name="documentTitle">Breadcrumb root for content that has no heading above it.</param>
-    /// <param name="options">Ingestion knobs (<see cref="AgentsOptions.IngestionOptions.ChunkTargetTokens"/> / <see cref="AgentsOptions.IngestionOptions.ChunkOverlapTokens"/>).</param>
+    /// <param name="options">Ingestion knobs (<see cref="AgentsOptions.IngestionOptions.ChunkTargetChars"/> / <see cref="AgentsOptions.IngestionOptions.ChunkOverlapChars"/>).</param>
     public static IReadOnlyList<DocumentChunk> Chunk(string body, string documentTitle, AgentsOptions.IngestionOptions options) {
         var chunks = new List<DocumentChunk>();
         if (string.IsNullOrWhiteSpace(body)) {
@@ -62,17 +62,15 @@ public static class MarkdownChunker
             if (sectionStart is null) {
                 return;
             }
-            var text = body.Substring(sectionStart.Value, sectionEnd - sectionStart.Value + 1).Trim();
+            var text = body.Substring(sectionStart.Value, sectionEnd - sectionStart.Value + 1).Trim('\r', '\n');
             sectionStart = null;
             if (text.Length == 0) {
                 return;
             }
             var breadcrumb = headings.Count > 0 ? string.Join(" > ", headings.Select(h => h.Text)) : documentTitle;
             var title = headings.Count > 0 ? headings[^1].Text : documentTitle;
-            foreach (var piece in SplitText(text, options)) {
-                if (piece.Length > 0) {
-                    Emit(breadcrumb, title, piece);
-                }
+            foreach (var piece in SplitText(text, options).Where(piece => piece.Length > 0)) {
+                Emit(breadcrumb, title, piece);
             }
         }
 
@@ -85,7 +83,7 @@ public static class MarkdownChunker
                 HeadingPath = headingPath,
                 Title = title,
                 Category = null,
-                TokenCount = EstimateTokens(text),
+                TokenCount = EstimateTokens(content),
             });
         }
     }
@@ -103,7 +101,7 @@ public static class MarkdownChunker
         foreach (var inline in heading.Inline.Descendants()) {
             switch (inline) {
                 case LiteralInline literal:
-                    builder.Append(literal.Content.ToString());
+                    builder.Append(literal.Content);
                     break;
                 case CodeInline code:
                     builder.Append(code.Content);
@@ -117,19 +115,17 @@ public static class MarkdownChunker
     }
 
     /// <summary>
-    /// Splits <paramref name="text"/> into windows of at most <see cref="AgentsOptions.IngestionOptions.ChunkTargetTokens"/>,
-    /// each seeded with a ~<see cref="AgentsOptions.IngestionOptions.ChunkOverlapTokens"/> tail of the previous one. Cuts fall on
+    /// Splits <paramref name="text"/> into windows of at most <see cref="AgentsOptions.IngestionOptions.ChunkTargetChars"/> characters,
+    /// each seeded with a ~<see cref="AgentsOptions.IngestionOptions.ChunkOverlapChars"/>-character tail of the previous one. Cuts fall on
     /// whitespace-run boundaries — which coincide with paragraph, sentence, and word boundaries — preferring the furthest one
     /// that fits the budget; a hard character limit guarantees a bounded chunk even for an unbroken wall of text.
     /// </summary>
     private static IReadOnlyList<string> SplitText(string text, AgentsOptions.IngestionOptions options) {
-        var target = Math.Max(1, options.ChunkTargetTokens);
-        if (EstimateTokens(text) <= target) {
+        var target = Math.Max(1, options.ChunkTargetChars);
+        if (text.Length <= target) {
             return [text];
         }
-        var overlap = Math.Clamp(options.ChunkOverlapTokens, 0, target - 1);
-        var targetChars = target * CharsPerToken;
-        var overlapChars = overlap * CharsPerToken;
+        var overlap = Math.Clamp(options.ChunkOverlapChars, 0, target - 1);
 
         // Candidate cut offsets: the position after each maximal whitespace run, plus the end of the text.
         var breaks = new List<int>();
@@ -146,6 +142,35 @@ public static class MarkdownChunker
             breaks.Add(text.Length);
         }
 
+        var windows = new List<string>();
+        var start = 0;
+        while (start < text.Length) {
+            int end;
+            if (start + target >= text.Length) {
+                end = text.Length;
+            } else {
+                var boundary = FloorBreak(start, start + target);
+                end = boundary > start ? boundary : Math.Min(start + target, text.Length);
+            }
+            var slice = text[start..end].Trim('\r', '\n');
+            if (slice.Length > 0) {
+                windows.Add(slice);
+            }
+            if (end >= text.Length) {
+                break;
+            }
+            // Back up ~overlap characters to a boundary to seed the next window; never regress past start.
+            var nextStart = end;
+            if (overlap > 0) {
+                var boundary = FloorBreak(start, end - overlap);
+                if (boundary > start) {
+                    nextStart = boundary;
+                }
+            }
+            start = nextStart > start ? nextStart : end;
+        }
+        return windows;
+
         // Largest break in (start, ceiling]; -1 when none exists.
         int FloorBreak(int start, int ceiling) {
             var found = -1;
@@ -160,39 +185,15 @@ public static class MarkdownChunker
             return found;
         }
 
-        var windows = new List<string>();
-        var start = 0;
-        while (start < text.Length) {
-            int end;
-            if (start + targetChars >= text.Length) {
-                end = text.Length;
-            } else {
-                var boundary = FloorBreak(start, start + targetChars);
-                end = boundary > start ? boundary : Math.Min(start + targetChars, text.Length);
-            }
-            var slice = text[start..end].Trim();
-            if (slice.Length > 0) {
-                windows.Add(slice);
-            }
-            if (end >= text.Length) {
-                break;
-            }
-            // Back up ~overlapChars to a boundary to seed the next window; never regress past start.
-            var nextStart = end;
-            if (overlapChars > 0) {
-                var boundary = FloorBreak(start, end - overlapChars);
-                if (boundary > start) {
-                    nextStart = boundary;
-                }
-            }
-            start = nextStart > start ? nextStart : end;
-        }
-        return windows;
     }
 
     private const int CharsPerToken = 4;
 
-    /// <summary>Approximate token count (~4 chars per token). Documented as an estimate; a precise tokenizer can replace this without changing the contract.</summary>
+    /// <summary>
+    /// Approximate token count (~4 chars per token), used only to populate the observability
+    /// <see cref="DocumentChunk.TokenCount"/> field — sizing is character-based and does not use this. A precise
+    /// tokenizer can replace this without changing the contract.
+    /// </summary>
     private static int EstimateTokens(string text) => Math.Max(1, (int)Math.Ceiling((double)text.Length / CharsPerToken));
 
     private static string Sha256Hex(string input) {

--- a/src/Indice.Features.Agents.Server/Endpoints/IngestionHandlers.cs
+++ b/src/Indice.Features.Agents.Server/Endpoints/IngestionHandlers.cs
@@ -27,6 +27,7 @@ internal static class IngestionHandlers
             }
         }
         var report = await pipeline.IngestAsync(new IngestRequest {
+            DocumentType = request.DocumentType,
             OpenMarkdownSourceStream = () => request.MarkdownSourceFile.OpenReadStream(),
             OpenActualSourceStream = request.ActualSourceFile is not null ? () => request.ActualSourceFile.OpenReadStream() : null,
             Source = !string.IsNullOrWhiteSpace(request.ActualSourceUrl) ? request.ActualSourceUrl :

--- a/test/Indice.Features.Agents.Core.Tests/MarkdownChunkerTests.cs
+++ b/test/Indice.Features.Agents.Core.Tests/MarkdownChunkerTests.cs
@@ -80,6 +80,19 @@ public class MarkdownChunkerTests
     }
 
     [Fact]
+    public void CutsFallOnExactWordBoundaries() {
+        // 5 four-char words, single spaces. With target 9 the next word boundary (10 chars in)
+        // never fits, so each window ends on a word boundary. Pins the exact cut offsets so any
+        // off-by-one in the boundary search is caught.
+        var body = "# H\n\naaaa bbbb cccc dddd eeee";
+
+        var chunks = MarkdownChunker.Chunk(body, "doc", Options(target: 9, overlap: 0));
+
+        var pieces = chunks.Select(c => c.Content.Split("\n\n")[1].Trim()).ToArray();
+        Assert.Equal(["aaaa", "bbbb", "cccc", "dddd eeee"], pieces);
+    }
+
+    [Fact]
     public void PreservesCodeFenceVerbatimAndDoesNotSplitOnHashLinesInsideIt() {
         var body = """
             # API

--- a/test/Indice.Features.Agents.Core.Tests/MarkdownChunkerTests.cs
+++ b/test/Indice.Features.Agents.Core.Tests/MarkdownChunkerTests.cs
@@ -1,0 +1,170 @@
+using Indice.Features.Agents.Core;
+using Indice.Features.Agents.Core.Workflows;
+
+namespace Indice.Features.Agents.Core.Tests;
+
+public class MarkdownChunkerTests
+{
+    private static AgentsOptions.IngestionOptions Options(int target = 800, int overlap = 100) =>
+        new() { ChunkTargetTokens = target, ChunkOverlapTokens = overlap };
+
+    [Fact]
+    public void BuildsHeadingBreadcrumbsFromNestedHeadings() {
+        var body = """
+            # Guide
+
+            Intro line.
+
+            ## Install
+
+            Install here.
+
+            ## Usage
+
+            Usage here.
+            """;
+
+        var chunks = MarkdownChunker.Chunk(body, "guide-doc", Options());
+
+        Assert.Equal(3, chunks.Count);
+        Assert.Equal(["Guide", "Guide > Install", "Guide > Usage"], chunks.Select(c => c.HeadingPath));
+        Assert.Equal(["Guide", "Install", "Usage"], chunks.Select(c => c.Title));
+        Assert.Equal([0, 1, 2], chunks.Select(c => c.ChunkIndex));
+    }
+
+    [Fact]
+    public void SplitsOversizedSectionIntoMultipleOverlappingChunks() {
+        // Each paragraph is ~33 chars (~9 tokens). target 18 (~2 paragraphs), overlap 9 (~1 paragraph).
+        var body = """
+            # Doc
+
+            MARKER_A alpha alpha alpha alpha.
+
+            MARKER_B bravo bravo bravo bravo.
+
+            MARKER_C charlie charlie charlie charlie.
+
+            MARKER_D delta delta delta delta.
+            """;
+        var markers = new[] { "MARKER_A", "MARKER_B", "MARKER_C", "MARKER_D" };
+
+        var chunks = MarkdownChunker.Chunk(body, "doc", Options(target: 18, overlap: 9));
+
+        Assert.True(chunks.Count >= 2, $"expected split, got {chunks.Count}");
+        Assert.All(chunks, c => Assert.Equal("Doc", c.HeadingPath));
+        Assert.Equal(Enumerable.Range(0, chunks.Count), chunks.Select(c => c.ChunkIndex));
+        // Every paragraph is covered somewhere.
+        Assert.All(markers, m => Assert.Contains(chunks, c => c.Content.Contains(m)));
+        // Overlap: at least one paragraph is carried into an adjacent chunk.
+        Assert.True(markers.Any(m => chunks.Count(c => c.Content.Contains(m)) >= 2),
+            "expected overlap to duplicate at least one paragraph across chunks");
+        // Bounded: no chunk wildly exceeds the target.
+        Assert.All(chunks, c => Assert.True(c.TokenCount <= 18 * 2, $"chunk too big: {c.TokenCount} tokens"));
+    }
+
+    [Fact]
+    public void FlatFileWithNoHeadingsDegradesToTokenWindowsAnchoredToDocumentTitle() {
+        // A docx/pdf->md dump: one wall of text, no headings, no blank lines.
+        var body = "This is a converted document with no markdown headings at all just flat prose "
+                 + "that runs on and on describing the system and its behavior across many clauses "
+                 + "until it is clearly longer than the configured chunk target size and must split.";
+
+        var chunks = MarkdownChunker.Chunk(body, "converted-report", Options(target: 20, overlap: 5));
+
+        Assert.True(chunks.Count >= 2, $"expected token-window split, got {chunks.Count}");
+        Assert.All(chunks, c => Assert.Equal("converted-report", c.HeadingPath));
+        Assert.All(chunks, c => Assert.Equal("converted-report", c.Title));
+        Assert.All(chunks, c => Assert.True(c.TokenCount <= 20 * 2, $"chunk too big: {c.TokenCount} tokens"));
+        Assert.Contains(chunks, c => c.Content.Contains("This is a converted document"));
+        Assert.Contains(chunks, c => c.Content.Contains("must split."));
+    }
+
+    [Fact]
+    public void PreservesCodeFenceVerbatimAndDoesNotSplitOnHashLinesInsideIt() {
+        var body = """
+            # API
+
+            Use it like this:
+
+            ```csharp
+            # this looks like a heading but is inside code
+            var x = 1;
+            ```
+
+            Done.
+            """;
+
+        var chunks = MarkdownChunker.Chunk(body, "api-doc", Options());
+
+        // The '#' line inside the fence must NOT open a new section.
+        Assert.Single(chunks);
+        Assert.Equal("API", chunks[0].HeadingPath);
+        Assert.Contains("```csharp", chunks[0].Content);
+        Assert.Contains("# this looks like a heading but is inside code", chunks[0].Content);
+        Assert.Contains("var x = 1;", chunks[0].Content);
+    }
+
+    [Fact]
+    public void ExtractsCleanTextFromSetextHeadings() {
+        // pandoc/docx->md often emit setext (underlined) headings instead of '#'.
+        var body = """
+            Title Line
+            ==========
+
+            Some content here.
+
+            Sub Heading
+            -----------
+
+            More content.
+            """;
+
+        var chunks = MarkdownChunker.Chunk(body, "doc", Options());
+
+        Assert.Equal(["Title Line", "Title Line > Sub Heading"], chunks.Select(c => c.HeadingPath));
+        Assert.Equal(["Title Line", "Sub Heading"], chunks.Select(c => c.Title));
+        // The '===' / '---' underline must not leak into breadcrumb or embedded content.
+        Assert.All(chunks, c => Assert.DoesNotContain('=', c.Content));
+    }
+
+    [Fact]
+    public void StripsInlineFormattingFromHeadingText() {
+        var body = """
+            ## Install **now** with `setup`
+
+            Body.
+            """;
+
+        var chunks = MarkdownChunker.Chunk(body, "doc", Options());
+
+        Assert.Equal("Install now with setup", chunks[0].HeadingPath);
+    }
+
+    [Fact]
+    public void ExcludesYamlFrontMatterFromChunks() {
+        var body = """
+            ---
+            title: Secret Title
+            category: policy
+            ---
+
+            # Real Heading
+
+            Body text here.
+            """;
+
+        var chunks = MarkdownChunker.Chunk(body, "fm-doc", Options());
+
+        Assert.All(chunks, c => Assert.DoesNotContain("Secret Title", c.Content));
+        Assert.All(chunks, c => Assert.DoesNotContain("category: policy", c.Content));
+        Assert.Contains(chunks, c => c.HeadingPath == "Real Heading" && c.Content.Contains("Body text here."));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   \n\n  \t ")]
+    public void EmptyOrWhitespaceBodyProducesNoChunks(string body) {
+        var chunks = MarkdownChunker.Chunk(body, "empty-doc", Options());
+        Assert.Empty(chunks);
+    }
+}

--- a/test/Indice.Features.Agents.Core.Tests/MarkdownChunkerTests.cs
+++ b/test/Indice.Features.Agents.Core.Tests/MarkdownChunkerTests.cs
@@ -6,7 +6,7 @@ namespace Indice.Features.Agents.Core.Tests;
 public class MarkdownChunkerTests
 {
     private static AgentsOptions.IngestionOptions Options(int target = 800, int overlap = 100) =>
-        new() { ChunkTargetTokens = target, ChunkOverlapTokens = overlap };
+        new() { ChunkTargetChars = target, ChunkOverlapChars = overlap };
 
     [Fact]
     public void BuildsHeadingBreadcrumbsFromNestedHeadings() {
@@ -34,7 +34,7 @@ public class MarkdownChunkerTests
 
     [Fact]
     public void SplitsOversizedSectionIntoMultipleOverlappingChunks() {
-        // Each paragraph is ~33 chars (~9 tokens). target 18 (~2 paragraphs), overlap 9 (~1 paragraph).
+        // Each paragraph is ~33 chars. target 72 chars (~2 paragraphs), overlap 36 chars (~1 paragraph).
         var body = """
             # Doc
 
@@ -48,7 +48,7 @@ public class MarkdownChunkerTests
             """;
         var markers = new[] { "MARKER_A", "MARKER_B", "MARKER_C", "MARKER_D" };
 
-        var chunks = MarkdownChunker.Chunk(body, "doc", Options(target: 18, overlap: 9));
+        var chunks = MarkdownChunker.Chunk(body, "doc", Options(target: 72, overlap: 36));
 
         Assert.True(chunks.Count >= 2, $"expected split, got {chunks.Count}");
         Assert.All(chunks, c => Assert.Equal("Doc", c.HeadingPath));
@@ -58,23 +58,23 @@ public class MarkdownChunkerTests
         // Overlap: at least one paragraph is carried into an adjacent chunk.
         Assert.True(markers.Any(m => chunks.Count(c => c.Content.Contains(m)) >= 2),
             "expected overlap to duplicate at least one paragraph across chunks");
-        // Bounded: no chunk wildly exceeds the target.
-        Assert.All(chunks, c => Assert.True(c.TokenCount <= 18 * 2, $"chunk too big: {c.TokenCount} tokens"));
+        // Bounded: no chunk wildly exceeds the target (breadcrumb prefix + a ≤target-char window).
+        Assert.All(chunks, c => Assert.True(c.Content.Length <= 72 * 2, $"chunk too big: {c.Content.Length} chars"));
     }
 
     [Fact]
-    public void FlatFileWithNoHeadingsDegradesToTokenWindowsAnchoredToDocumentTitle() {
+    public void FlatFileWithNoHeadingsDegradesToCharacterWindowsAnchoredToDocumentTitle() {
         // A docx/pdf->md dump: one wall of text, no headings, no blank lines.
         var body = "This is a converted document with no markdown headings at all just flat prose "
                  + "that runs on and on describing the system and its behavior across many clauses "
                  + "until it is clearly longer than the configured chunk target size and must split.";
 
-        var chunks = MarkdownChunker.Chunk(body, "converted-report", Options(target: 20, overlap: 5));
+        var chunks = MarkdownChunker.Chunk(body, "converted-report", Options(target: 80, overlap: 20));
 
-        Assert.True(chunks.Count >= 2, $"expected token-window split, got {chunks.Count}");
+        Assert.True(chunks.Count >= 2, $"expected character-window split, got {chunks.Count}");
         Assert.All(chunks, c => Assert.Equal("converted-report", c.HeadingPath));
         Assert.All(chunks, c => Assert.Equal("converted-report", c.Title));
-        Assert.All(chunks, c => Assert.True(c.TokenCount <= 20 * 2, $"chunk too big: {c.TokenCount} tokens"));
+        Assert.All(chunks, c => Assert.True(c.Content.Length <= 80 * 2, $"chunk too big: {c.Content.Length} chars"));
         Assert.Contains(chunks, c => c.Content.Contains("This is a converted document"));
         Assert.Contains(chunks, c => c.Content.Contains("must split."));
     }

--- a/test/Indice.Features.Agents.Core.Tests/MarkdownIngestionPipelineTests.cs
+++ b/test/Indice.Features.Agents.Core.Tests/MarkdownIngestionPipelineTests.cs
@@ -1,0 +1,81 @@
+using System.Text;
+using Indice.Features.Agents.Core;
+using Indice.Features.Agents.Core.Models;
+using Indice.Features.Agents.Core.Services;
+using Indice.Features.Agents.Core.Workflows;
+using Microsoft.Extensions.AI;
+
+namespace Indice.Features.Agents.Core.Tests;
+
+public class MarkdownIngestionPipelineTests
+{
+    [Fact]
+    public async Task IngestingMarkdownTypeRoutesThroughStructuralChunker() {
+        var body = """
+            Intro prose before any heading.
+
+            # Guide
+
+            ## Install
+
+            Install steps.
+            """;
+        var store = new CapturingDocumentsService();
+        var options = Microsoft.Extensions.Options.Options.Create(new AgentsOptions {
+            Taxonomy = new AgentsOptions.TaxonomyOptions { Categories = ["general"], Languages = ["en"] },
+        });
+        var pipeline = new DefaultIngestionPipeline(store, options, new StubEmbeddingGenerator());
+
+        var report = await pipeline.IngestAsync(Request(body, DocumentType.Markdown), CancellationToken.None);
+
+        Assert.False(report.Skipped);
+        Assert.Equal(store.Captured.Count, report.ChunksCreated);
+        // Structural chunker ran: intro prose above the first heading is captured (the FAQ parser discards it),
+        // a nested heading breadcrumb is produced, and content is NOT in the FAQ "Q:/A:" format.
+        Assert.Contains(store.Captured, c => c.Chunk.Content.Contains("Intro prose before any heading."));
+        Assert.Contains(store.Captured, c => c.Chunk.HeadingPath == "Guide > Install");
+        Assert.All(store.Captured, c => Assert.DoesNotContain("Q: ", c.Chunk.Content));
+    }
+
+    private static IngestRequest Request(string body, DocumentType type) => new() {
+        DocumentType = type,
+        OpenMarkdownSourceStream = () => new MemoryStream(Encoding.UTF8.GetBytes(body)),
+        Source = "local://test.md",
+        FileName = "test.md",
+        ContentType = "text/markdown",
+        ContentLength = body.Length,
+        Category = "general",
+        Language = "en",
+        IsPrivate = false,
+    };
+
+    private sealed class CapturingDocumentsService : IDocumentsService
+    {
+        public List<EmbeddedChunk> Captured { get; } = [];
+
+        public Task<SourceDocument?> FindBySourceAsync(string source, bool includeData, CancellationToken cancellationToken) =>
+            Task.FromResult<SourceDocument?>(null);
+
+        public Task<Guid> ReplaceAsync(Guid? existingDocumentId, IngestedDocument document, IReadOnlyList<EmbeddedChunk> chunks, CancellationToken cancellationToken) {
+            Captured.AddRange(chunks);
+            return Task.FromResult(new Guid("11111111-1111-1111-1111-111111111111"));
+        }
+
+        public Task<IReadOnlyList<RetrievedChunk>> SearchAsync(ReadOnlyMemory<float> queryVector, RetrievalFilters filters, int topK, double minScore, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task ClearAsync() => throw new NotSupportedException();
+    }
+
+    private sealed class StubEmbeddingGenerator : IEmbeddingGenerator<string, Embedding<float>>
+    {
+        public Task<GeneratedEmbeddings<Embedding<float>>> GenerateAsync(IEnumerable<string> values, EmbeddingGenerationOptions? options = null, CancellationToken cancellationToken = default) {
+            var embeddings = values.Select(_ => new Embedding<float>(new float[] { 0f, 0f, 0f })).ToList();
+            return Task.FromResult(new GeneratedEmbeddings<Embedding<float>>(embeddings));
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+        public void Dispose() { }
+    }
+}


### PR DESCRIPTION
Introduce MarkdownChunker for heading-aware chunking using Markdig. Extend DocumentType and IngestRequest to support general Markdown ingestion. Update pipeline and handlers to select chunker by document type. Add unit and integration tests for chunking logic. Add Markdig dependency.