### PR TITLE
[agents] Add SourceDocumentLink and propagate sources

### DIFF
--- a/src/Indice.Features.Agents.Core/AgentsFeatureExtensions.cs
+++ b/src/Indice.Features.Agents.Core/AgentsFeatureExtensions.cs
@@ -69,7 +69,7 @@ public static class AgentsFeatureExtensions
         services.TryAddSingleton<WorkflowClaimsPrincipalSelector>(sp =>
             () => null
         );
-
+        services.TryAddSingleton<ISourceLinkGenerator, NoOpSourceLinkGenerator>();
         services.AddDefaultDexPipeline();
         return services;
     }

--- a/src/Indice.Features.Agents.Core/Data/DbChunk.cs
+++ b/src/Indice.Features.Agents.Core/Data/DbChunk.cs
@@ -52,4 +52,7 @@ public class DbChunk
 
     /// <summary>Creation timestamp.</summary>
     public DateTimeOffset CreatedAt { get; set; }
+
+    /// <summary>Navigation: parent document.</summary>
+    public virtual DbDocument Document { get; set; } = null!;
 }

--- a/src/Indice.Features.Agents.Core/Data/DbDocument.cs
+++ b/src/Indice.Features.Agents.Core/Data/DbDocument.cs
@@ -38,9 +38,6 @@ public class DbDocument
     /// <summary>Timestamp at which the document was last ingested.</summary>
     public DateTimeOffset IngestedAt { get; set; }
 
-    /// <summary>Navigation: chunks belonging to this document.</summary>
-    public ICollection<DbChunk> Chunks { get; set; } = [];
-
     /// <summary>Navigation: optional binary payload and file metadata. Not loaded by default.</summary>
     public DbDocumentBlob? Blob { get; set; }
     /// <summary>Indicates whether the document is private and should not be exposed to unauthorized users.</summary>

--- a/src/Indice.Features.Agents.Core/Data/Mappings/DbChunkMap.cs
+++ b/src/Indice.Features.Agents.Core/Data/Mappings/DbChunkMap.cs
@@ -23,5 +23,10 @@ public class DbChunkMap : IEntityTypeConfiguration<DbChunk>
         builder.Property(x => x.Embedding)
                .HasColumnType($"vector({AgentsOptions.EmbeddingDimensionsDefault})")
                .IsRequired();
+
+        builder.HasOne(x => x.Document)
+               .WithMany()
+               .HasForeignKey(c => c.DocumentId)
+               .OnDelete(DeleteBehavior.Cascade);
     }
 }

--- a/src/Indice.Features.Agents.Core/Data/Mappings/DbDocumentMap.cs
+++ b/src/Indice.Features.Agents.Core/Data/Mappings/DbDocumentMap.cs
@@ -22,9 +22,5 @@ public class DbDocumentMap : IEntityTypeConfiguration<DbDocument>
         builder.Property(x => x.ChunkCount).HasDefaultValue(0);
         builder.Property(x => x.IsPrivate).HasDefaultValue(false);
         builder.HasIndex(x => x.Source).IsUnique();
-        builder.HasMany(x => x.Chunks)
-               .WithOne()
-               .HasForeignKey(c => c.DocumentId)
-               .OnDelete(DeleteBehavior.Cascade);
     }
 }

--- a/src/Indice.Features.Agents.Core/Indice.Features.Agents.Core.csproj
+++ b/src/Indice.Features.Agents.Core/Indice.Features.Agents.Core.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks></TargetFrameworks>
     <TargetFramework>net10.0</TargetFramework>
     <VersionPrefix>$(VersionPrefixAgents)</VersionPrefix>
-    <VersionSuffix>beta07</VersionSuffix>
+    <VersionSuffix>beta08</VersionSuffix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Indice.Features.Agents.Core/Models/ChatMessage.cs
+++ b/src/Indice.Features.Agents.Core/Models/ChatMessage.cs
@@ -16,5 +16,8 @@ public class ChatMessage
     public DateTimeOffset CreatedAt { get; init; }
 
     /// <summary>References to chunks.</summary>
-    public List<Citation> Citations { get; set; } = new List<Citation>();
+    public List<Citation> Citations { get; set; } = [];
+    
+    /// <summary>References to source documents.</summary>
+    public List<SourceDocumentLink> Sources { get; set; } = [];
 }

--- a/src/Indice.Features.Agents.Core/Models/ChatResponse.cs
+++ b/src/Indice.Features.Agents.Core/Models/ChatResponse.cs
@@ -13,7 +13,10 @@ public class ChatResponse
     public string? Answer { get; init; }
 
     /// <summary>Citations supporting the answer; empty for out-of-scope responses and on error.</summary>
-    public IReadOnlyList<Citation> Citations { get; init; } = Array.Empty<Citation>();
+    public IReadOnlyList<Citation> Citations { get; init; } = [];
+
+    /// <summary>Links to the source documents that were retrieved and used to compose the answer; empty for out-of-scope responses and on error.</summary>
+    public IReadOnlyList<SourceDocumentLink> Sources { get; init; } = [];
 
     /// <summary>True when a pipeline step threw and the workflow halted. Out-of-scope is NOT a failure — its refusal text flows through <see cref="Answer"/>.</summary>
     public bool Failed { get; init; }

--- a/src/Indice.Features.Agents.Core/Models/ChatStreamEvent.cs
+++ b/src/Indice.Features.Agents.Core/Models/ChatStreamEvent.cs
@@ -26,6 +26,9 @@ public class ChatStreamEvent
     /// <summary>Citations supporting the answer; populated on <c>complete</c>.</summary>
     public IReadOnlyList<Citation>? Citations { get; init; }
 
+    /// <summary>Citations supporting the answer; populated on <c>complete</c>.</summary>
+    public IReadOnlyList<SourceDocumentLink>? Sources { get; init; }
+
     /// <summary>Identifier of the session this turn belongs to; populated on <c>complete</c>.</summary>
     public Guid? SessionId { get; init; }
 

--- a/src/Indice.Features.Agents.Core/Models/ChatStreamEvent.cs
+++ b/src/Indice.Features.Agents.Core/Models/ChatStreamEvent.cs
@@ -26,7 +26,7 @@ public class ChatStreamEvent
     /// <summary>Citations supporting the answer; populated on <c>complete</c>.</summary>
     public IReadOnlyList<Citation>? Citations { get; init; }
 
-    /// <summary>Citations supporting the answer; populated on <c>complete</c>.</summary>
+    /// <summary>Links to the source documents supporting the answer; populated on <c>complete</c>.</summary>
     public IReadOnlyList<SourceDocumentLink>? Sources { get; init; }
 
     /// <summary>Identifier of the session this turn belongs to; populated on <c>complete</c>.</summary>

--- a/src/Indice.Features.Agents.Core/Models/ChatStreamEvent.cs
+++ b/src/Indice.Features.Agents.Core/Models/ChatStreamEvent.cs
@@ -9,7 +9,7 @@ namespace Indice.Features.Agents.Core.Models;
 ///   <item><term>complete</term><description><see cref="SessionId"/>, <see cref="MessageId"/>, <see cref="Answer"/>, <see cref="Citations"/>, <see cref="Failed"/>, <see cref="FailureReason"/>.</description></item>
 /// </list>
 /// </summary>
-public class ChatStreamEvent
+public record ChatStreamEvent
 {
     /// <summary>Event discriminator: <c>step</c>, <c>delta</c>, or <c>complete</c>.</summary>
     public string Type { get; init; } = string.Empty;

--- a/src/Indice.Features.Agents.Core/Services/ChatsService.cs
+++ b/src/Indice.Features.Agents.Core/Services/ChatsService.cs
@@ -59,6 +59,7 @@ public class ChatsService : IChatsService
             Content = assistantText,
             CreatedAt = DateTimeOffset.UtcNow,
             Citations = result.Citations?.ToList() ?? [],
+            Sources = result.Sources?.ToList() ?? [],
         };
 
         var persistedAssistant = await _store.AppendTurnAsync(session.Id, userMessage, assistantMessage,
@@ -70,6 +71,7 @@ public class ChatsService : IChatsService
             MessageId = persistedAssistant.Id,
             Answer = assistantText,
             Citations = result.Citations ?? [],
+            Sources = result.Sources ?? [],
             Failed = result.Failed,
             FailureReason = result.FailureReason,
             QuestionsUsed = _sessionOptions.GetQuestionsUsed(session.MessageCount + 2),
@@ -109,7 +111,8 @@ public class ChatsService : IChatsService
             SessionId = session.Id,
             MessageId = Guid.Empty,
             Answer = message,
-            Citations = Array.Empty<Citation>(),
+            Citations = [],
+            Sources = [],
             LimitReached = true,
             QuestionsUsed = _sessionOptions.GetQuestionsUsed(session.MessageCount),
             QuestionsTotal = _sessionOptions.GetQuestionsTotal(),
@@ -151,6 +154,7 @@ public class ChatsService : IChatsService
             Content = assistantText, 
             CreatedAt = final?.TimeStamp ?? DateTimeOffset.UtcNow,
             Citations = final?.Citations?.ToList() ?? [],
+            Sources = final?.Sources?.ToList() ?? [],
         };
 
         var persistedAssistant = await _store.AppendTurnAsync(session.Id, userMessage, assistantMessage,
@@ -162,7 +166,8 @@ public class ChatsService : IChatsService
             SessionId = session.Id,
             MessageId = persistedAssistant.Id,
             Answer = assistantText,
-            Citations = final?.Citations ?? Array.Empty<Citation>(),
+            Citations = final?.Citations ?? [],
+            Sources = final?.Sources ?? [],
             Failed = final?.Failed ?? false,
             FailureReason = final?.FailureReason,
             QuestionsUsed = _sessionOptions.GetQuestionsUsed(session.MessageCount + 2),

--- a/src/Indice.Features.Agents.Core/Services/DocumentsService.cs
+++ b/src/Indice.Features.Agents.Core/Services/DocumentsService.cs
@@ -1,4 +1,4 @@
-using System.Net.Mime;
+using System.Linq.Expressions;
 using Indice.Features.Agents.Core.Data;
 using Indice.Features.Agents.Core.Models;
 using Indice.Features.Agents.Core.Workflows;
@@ -24,9 +24,13 @@ public class DocumentsService : IDocumentsService
 
     /// <inheritdoc/>
     public async Task<SourceDocument?> FindBySourceAsync(string source, bool includeData, CancellationToken cancellationToken) {
+        Expression<Func<DbDocument, bool>> predicate = d => d.Source == source;
+        if (Guid.TryParse(source, out var documentId)) {
+            predicate = d => d.Id == documentId;
+        }
         var query = _db.Set<DbDocument>()
             .AsNoTracking()
-            .Where(d => d.Source == source)
+            .Where(predicate)
             .Select(d => new SourceDocument { 
                 Id = d.Id, 
                 ContentHash = d.ContentHash, 
@@ -111,8 +115,17 @@ public class DocumentsService : IDocumentsService
             .OrderBy(c => EF.Functions.VectorDistance("cosine", c.Embedding, sqlVector))
             .Take(topK)
             .Select(c => new RetrievedChunk {
-                ChunkId = c.Id,
-                DocumentId = c.DocumentId,
+                Id = c.Id,
+                Source = new SourceDocumentLink {
+                    Id = c.DocumentId,
+                    SourceTitle = c.Document.Title,
+                    SourceUrl = c.Document.Source,
+                    IsPrivate = c.Document.IsPrivate,
+                    ContentHash = c.Document.ContentHash,
+                    ContentType = c.Document.Blob == null ? "application/markdown" : c.Document.Blob.ContentType,
+                    Length = c.Document.Blob == null ? -1 : c.Document.Blob.ContentLength,
+                    FileName = c.Document.Blob == null ? c.Document.Title : c.Document.Blob.FileName,
+                },
                 Title = c.Title,
                 HeadingPath = c.HeadingPath,
                 Content = c.Content,

--- a/src/Indice.Features.Agents.Core/Services/DocumentsService.cs
+++ b/src/Indice.Features.Agents.Core/Services/DocumentsService.cs
@@ -12,12 +12,14 @@ namespace Indice.Features.Agents.Core.Services;
 public class DocumentsService : IDocumentsService
 {
     private readonly AgentsDbContext _db;
+    private readonly ISourceLinkGenerator _sourceLinkGenerator;
     private readonly string _embeddingModel;
     private readonly int _embeddingDimensions;
 
     /// <summary>Creates a new <see cref="DocumentsService"/>.</summary>
-    public DocumentsService(AgentsDbContext db, IOptions<AgentsOptions> options) {
-        _db = db;
+    public DocumentsService(AgentsDbContext db, IOptions<AgentsOptions> options, ISourceLinkGenerator sourceLinkGenerator) {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _sourceLinkGenerator = sourceLinkGenerator ?? throw new ArgumentNullException(nameof(sourceLinkGenerator));
         _embeddingModel = options.Value.AzureOpenAI.Deployments.Embedding ?? string.Empty;
         _embeddingDimensions = options.Value.AzureOpenAI.EmbeddingDimensions;
     }
@@ -119,7 +121,7 @@ public class DocumentsService : IDocumentsService
                 Source = new SourceDocumentLink {
                     Id = c.DocumentId,
                     SourceTitle = c.Document.Title,
-                    SourceUrl = c.Document.Source,
+                    SourceUrl = _sourceLinkGenerator.GenerateLink(c.Document.Source),
                     IsPrivate = c.Document.IsPrivate,
                     ContentHash = c.Document.ContentHash,
                     ContentType = c.Document.Blob == null ? "application/markdown" : c.Document.Blob.ContentType,

--- a/src/Indice.Features.Agents.Core/Services/SessionsStore.cs
+++ b/src/Indice.Features.Agents.Core/Services/SessionsStore.cs
@@ -11,11 +11,13 @@ namespace Indice.Features.Agents.Core.Services;
 public class SessionsStore : ISessionsStore
 {
     private readonly AgentsDbContext _db;
+    private readonly ISourceLinkGenerator _sourceLinkGenerator;
     private readonly SessionOptions _sessionOptions;
 
     /// <summary>Creates a new <see cref="SessionsStore"/>.</summary>
-    public SessionsStore(AgentsDbContext db, IOptions<AgentsOptions> options) {
-        _db = db;
+    public SessionsStore(AgentsDbContext db, IOptions<AgentsOptions> options, ISourceLinkGenerator sourceLinkGenerator) {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _sourceLinkGenerator = sourceLinkGenerator ?? throw new ArgumentNullException(nameof(sourceLinkGenerator));
         _sessionOptions = options.Value.Session;
     }
 
@@ -93,7 +95,7 @@ public class SessionsStore : ISessionsStore
                         Sources = m.Citations.Select(c => new SourceDocumentLink {
                             Id = c.Chunk.DocumentId,
                             SourceTitle = c.Chunk.Document.Title,
-                            SourceUrl = c.Chunk.Document.Source,
+                            SourceUrl = _sourceLinkGenerator.GenerateLink(c.Chunk.Document.Source),
                             IsPrivate = c.Chunk.Document.IsPrivate,
                             ContentHash = c.Chunk.Document.ContentHash,
                             ContentType = c.Chunk.Document.Blob == null ? "application/markdown" : c.Chunk.Document.Blob.ContentType,
@@ -138,7 +140,7 @@ public class SessionsStore : ISessionsStore
                 Sources = m.Citations.Select(c => new SourceDocumentLink {
                     Id = c.Chunk.DocumentId,
                     SourceTitle = c.Chunk.Document.Title,
-                    SourceUrl = c.Chunk.Document.Source,
+                    SourceUrl = _sourceLinkGenerator.GenerateLink(c.Chunk.Document.Source),
                     IsPrivate = c.Chunk.Document.IsPrivate,
                     ContentHash = c.Chunk.Document.ContentHash,
                     ContentType = c.Chunk.Document.Blob == null ? "application/markdown" : c.Chunk.Document.Blob.ContentType,

--- a/src/Indice.Features.Agents.Core/Services/SessionsStore.cs
+++ b/src/Indice.Features.Agents.Core/Services/SessionsStore.cs
@@ -90,10 +90,25 @@ public class SessionsStore : ISessionsStore
                             Number = c.Number,
                             Score = c.Score,
                         }).ToList(),
-                    })
+                        Sources = m.Citations.Select(c => new SourceDocumentLink {
+                            Id = c.Chunk.DocumentId,
+                            SourceTitle = c.Chunk.Document.Title,
+                            SourceUrl = c.Chunk.Document.Source,
+                            IsPrivate = c.Chunk.Document.IsPrivate,
+                            ContentHash = c.Chunk.Document.ContentHash,
+                            ContentType = c.Chunk.Document.Blob == null ? "application/markdown" : c.Chunk.Document.Blob.ContentType,
+                            Length = c.Chunk.Document.Blob == null ? -1 : c.Chunk.Document.Blob.ContentLength,
+                            FileName = c.Chunk.Document.Blob == null ? c.Chunk.Document.Title : c.Chunk.Document.Blob.FileName,
+                        }).ToList()
+                    })   
                     .ToList(),
             })
             .FirstOrDefaultAsync(cancellationToken);
+        if (session is not null) { 
+            foreach (var message in session.Messages) {
+                message.Sources = message.Sources.DistinctBy(s => s.Id).ToList();
+            }
+        }
         return session;
     }
 
@@ -101,7 +116,7 @@ public class SessionsStore : ISessionsStore
     public async Task<IReadOnlyList<ChatMessage>> GetHistoryAsync(Guid sessionId, CancellationToken cancellationToken) {
         // HistoryWindow counts turns (user+assistant pairs); each turn is two persisted rows.
         var messageTake = _sessionOptions.HistoryWindow * 2;
-        return await _db.SessionMessages
+        var messages = await _db.SessionMessages
             .AsNoTracking()
             .Where(m => m.SessionId == sessionId)
             .OrderByDescending(m => m.CreatedAt)
@@ -120,8 +135,22 @@ public class SessionsStore : ISessionsStore
                     Number = c.Number,
                     Score = c.Score,
                 }).ToList(),
+                Sources = m.Citations.Select(c => new SourceDocumentLink {
+                    Id = c.Chunk.DocumentId,
+                    SourceTitle = c.Chunk.Document.Title,
+                    SourceUrl = c.Chunk.Document.Source,
+                    IsPrivate = c.Chunk.Document.IsPrivate,
+                    ContentHash = c.Chunk.Document.ContentHash,
+                    ContentType = c.Chunk.Document.Blob == null ? "application/markdown" : c.Chunk.Document.Blob.ContentType,
+                    Length = c.Chunk.Document.Blob == null ? -1 : c.Chunk.Document.Blob.ContentLength,
+                    FileName = c.Chunk.Document.Blob == null ? c.Chunk.Document.Title : c.Chunk.Document.Blob.FileName,
+                }).ToList()
             })
             .ToListAsync(cancellationToken);
+        foreach (var message in messages) {
+            message.Sources = message.Sources.DistinctBy(s => s.Id).ToList();
+        }
+        return messages;
     }
 
     /// <inheritdoc/>

--- a/src/Indice.Features.Agents.Core/Services/SourceLinkGenerator.cs
+++ b/src/Indice.Features.Agents.Core/Services/SourceLinkGenerator.cs
@@ -1,0 +1,15 @@
+﻿namespace Indice.Features.Agents.Core.Services;
+
+/// <summary>Generates links to source documents.</summary>
+public interface ISourceLinkGenerator
+{
+    /// <summary>Generates a link to a source document.</summary>
+    string GenerateLink(string sourceUrl);
+}
+
+/// <summary>A no-op implementation of <see cref="ISourceLinkGenerator"/> that returns the source URL as-is.</summary>
+public interface NoOpSourceLinkGenerator : ISourceLinkGenerator
+{
+    /// <inheritdoc/>
+    public string GenerateLink(string sourceUrl) => sourceUrl;
+}

--- a/src/Indice.Features.Agents.Core/Services/SourceLinkGenerator.cs
+++ b/src/Indice.Features.Agents.Core/Services/SourceLinkGenerator.cs
@@ -8,7 +8,7 @@ public interface ISourceLinkGenerator
 }
 
 /// <summary>A no-op implementation of <see cref="ISourceLinkGenerator"/> that returns the source URL as-is.</summary>
-public interface NoOpSourceLinkGenerator : ISourceLinkGenerator
+public class NoOpSourceLinkGenerator : ISourceLinkGenerator
 {
     /// <inheritdoc/>
     public string GenerateLink(string sourceUrl) => sourceUrl;

--- a/src/Indice.Features.Agents.Core/Workflows/Chunk.cs
+++ b/src/Indice.Features.Agents.Core/Workflows/Chunk.cs
@@ -1,13 +1,15 @@
+using Indice.Features.Agents.Core.Models;
+
 namespace Indice.Features.Agents.Core.Workflows;
 
 /// <summary>Read-only projection of a stored chunk surfaced from the store to the RAG pipeline.</summary>
 public class Chunk
 {
     /// <summary>Primary key of the chunk (<c>dex.Chunks.Id</c>).</summary>
-    public Guid ChunkId { get; init; }
+    public Guid Id { get; init; }
 
     /// <summary>Primary key of the parent document (<c>dex.Documents.Id</c>).</summary>
-    public Guid DocumentId { get; init; }
+    public SourceDocumentLink Source { get; init; } = null!;
 
     /// <summary>Optional display title (heading or document title).</summary>
     public string? Title { get; init; }

--- a/src/Indice.Features.Agents.Core/Workflows/DexRunner.cs
+++ b/src/Indice.Features.Agents.Core/Workflows/DexRunner.cs
@@ -71,6 +71,7 @@ public class DexRunner : IDexRunner
         return new RagResult {
             Answer = final?.Payload?.Answer,
             Citations = final?.Payload?.Citations ?? [],
+            Sources = final?.Payload?.Sources ?? [],
             Failed = failure is not null,
             FailureReason = failure,
             Usage = usage,
@@ -120,6 +121,7 @@ public class DexRunner : IDexRunner
         yield return new DexFinalEvent {
             Answer = final?.Payload?.Answer,
             Citations = final?.Payload?.Citations ?? [],
+            Sources = final?.Payload?.Sources ?? [],
             Failed = failure is not null,
             FailureReason = failure,
             Usage = usage,

--- a/src/Indice.Features.Agents.Core/Workflows/DexStreamEvent.cs
+++ b/src/Indice.Features.Agents.Core/Workflows/DexStreamEvent.cs
@@ -50,7 +50,10 @@ public sealed class DexFinalEvent : DexStreamEvent
     public string? Answer { get; init; }
 
     /// <summary>Citations supporting the answer; empty for out-of-scope responses and on error.</summary>
-    public IReadOnlyList<Citation> Citations { get; init; } = Array.Empty<Citation>();
+    public IReadOnlyList<Citation> Citations { get; init; } = [];
+
+    /// <summary>Links to the source documents that were retrieved and used to compose the answer; empty for out-of-scope responses and on error.</summary>
+    public IReadOnlyList<SourceDocumentLink> Sources { get; init; } = [];
 
     /// <summary>True when a step threw and the workflow halted. Out-of-scope is NOT a failure.</summary>
     public bool Failed { get; init; }

--- a/src/Indice.Features.Agents.Core/Workflows/RagPipelineOutput.cs
+++ b/src/Indice.Features.Agents.Core/Workflows/RagPipelineOutput.cs
@@ -12,5 +12,8 @@ public class RagPipelineOutput
     public string? Answer { get; init; }
 
     /// <summary>Citations the answer was grounded against, projected from the reranked candidates.</summary>
-    public IReadOnlyList<Citation> Citations { get; init; } = Array.Empty<Citation>();
+    public IReadOnlyList<Citation> Citations { get; init; } = [];
+
+    /// <summary>Links to the source documents that were retrieved and used to compose the answer; empty for out-of-scope responses and on error.</summary>
+    public IReadOnlyList<SourceDocumentLink> Sources { get; init; } = [];
 }

--- a/src/Indice.Features.Agents.Core/Workflows/RagResult.cs
+++ b/src/Indice.Features.Agents.Core/Workflows/RagResult.cs
@@ -14,7 +14,10 @@ public class RagResult
     public string? Answer { get; init; }
 
     /// <summary>Citations accumulated across retrieval/rerank/compose, surfaced from the final payload.</summary>
-    public IReadOnlyList<Citation> Citations { get; init; } = Array.Empty<Citation>();
+    public IReadOnlyList<Citation> Citations { get; init; } = [];
+
+    /// <summary>Links to the source documents that were retrieved and used to compose the answer, surfaced from the final payload.</summary>
+    public IReadOnlyList<SourceDocumentLink> Sources { get; init; } = [];
 
     /// <summary>True when a step threw and the workflow halted (surfaced via MAF's <c>ExecutorFailedEvent</c>). Out-of-scope is NOT a failure — it flows through <c>OutOfScopeResponder</c> and produces a regular <see cref="Answer"/>.</summary>
     public bool Failed { get; init; }

--- a/src/Indice.Features.Agents.Core/Workflows/Reranking/LlmListwiseReranker.cs
+++ b/src/Indice.Features.Agents.Core/Workflows/Reranking/LlmListwiseReranker.cs
@@ -46,8 +46,8 @@ public class LlmListwiseReranker : ILlmReranker
             .ToDictionary(s => s.Index, s => s.Score);
         var reranked = candidates
             .Select((c, i) => new RetrievedChunk {
-                ChunkId = c.ChunkId,
-                DocumentId = c.DocumentId,
+                Id = c.Id,
+                Source = c.Source,
                 Title = c.Title,
                 HeadingPath = c.HeadingPath,
                 Content = c.Content,

--- a/src/Indice.Features.Agents.Core/Workflows/Steps/AnswerComposer.cs
+++ b/src/Indice.Features.Agents.Core/Workflows/Steps/AnswerComposer.cs
@@ -75,18 +75,19 @@ public sealed class AnswerComposer : Executor<PipelineStepContext<RerankOutput>,
 
         var citations = candidates
             .Select((c, index) => new Models.Citation {
-                ChunkId = c.ChunkId,
-                DocumentId = c.DocumentId,
+                ChunkId = c.Id,
+                DocumentId = c.Source.Id,
                 Title = c.Title,
                 HeadingPath = c.HeadingPath,
                 Score = c.Score,
                 Number = index + 1,
             })
             .ToList();
-
+        var sources = candidates.Select(c => c.Source).DistinctBy(x => x.Id).ToList();
         return envelope.Next(new RagPipelineOutput {
             Answer = answer.ToString(),
             Citations = citations,
+            Sources = sources,
         });
     }
 
@@ -98,7 +99,7 @@ public sealed class AnswerComposer : Executor<PipelineStepContext<RerankOutput>,
         }
         for (var i = 0; i < candidates.Count; i++) {
             var c = candidates[i];
-            sb.Append($"[{i + 1}](#{c.ChunkId}) ");
+            sb.Append($"[{i + 1}](#{c.Id}) ");
             if (!string.IsNullOrWhiteSpace(c.Title)) {
                 sb.Append(c.Title).Append(" — ");
             }

--- a/src/Indice.Features.Agents.Core/Workflows/Steps/Retriever.cs
+++ b/src/Indice.Features.Agents.Core/Workflows/Steps/Retriever.cs
@@ -39,8 +39,8 @@ public sealed class Retriever : Executor<PipelineStepContext<QueryRewriteOutput>
             var hits = await _documentsService.SearchAsync(vector, filters, topK, _options.Retrieval.MinScore, cancellationToken);
             //kinda optional , but if the same chunk is returned for multiple rewrites, we want to keep the highest score
             //could also become a weighted function of the score and the rewrite rank, but let's keep it simple for now
-            foreach (var hit in hits.Where(hit => !relevantAnswers.TryGetValue(hit.ChunkId, out var prior) || hit.Score > prior.Score)) {
-                relevantAnswers[hit.ChunkId] = hit;
+            foreach (var hit in hits.Where(hit => !relevantAnswers.TryGetValue(hit.Id, out var prior) || hit.Score > prior.Score)) {
+                relevantAnswers[hit.Id] = hit;
             }
         }
         var candidates = relevantAnswers.Values

--- a/src/Indice.Features.Agents.Server/AgentsServerFeatureExtensions.cs
+++ b/src/Indice.Features.Agents.Server/AgentsServerFeatureExtensions.cs
@@ -29,8 +29,8 @@ public static class AgentsServerFeatureExtensions
         if(configureOptions is not null) { 
             services.Configure(configureOptions);
         }
+        services.AddTransient<ISourceLinkGenerator, SourceLinkGenerator>();
         services.AddAgentsCore(configuration, options.ConfigureAgents);
-
         services.AddMyProfileFeature();
         services.AddChatsFeature();
         services.AddIngestionFeature();

--- a/src/Indice.Features.Agents.Server/Indice.Features.Agents.Server.csproj
+++ b/src/Indice.Features.Agents.Server/Indice.Features.Agents.Server.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks></TargetFrameworks>
     <TargetFramework>net10.0</TargetFramework>
     <VersionPrefix>$(VersionPrefixAgents)</VersionPrefix>
-    <VersionSuffix>beta07</VersionSuffix>
+    <VersionSuffix>beta08</VersionSuffix>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Indice.AspNetCore.Builder" Version="$(VersionPrefixAspNet)-*" />

--- a/src/Indice.Features.Agents.Server/Services/SourceLinkGenerator.cs
+++ b/src/Indice.Features.Agents.Server/Services/SourceLinkGenerator.cs
@@ -1,0 +1,23 @@
+﻿using Indice.Features.Agents.Core.Services;
+using Indice.Features.Agents.Server.Endpoints;
+using Microsoft.AspNetCore.Routing;
+
+namespace Indice.Features.Agents.Server.Services;
+
+/// <summary>Generates links to source documents.</summary>
+public class SourceLinkGenerator : ISourceLinkGenerator
+{
+    /// <summary>Creates a new instance of <see cref="SourceLinkGenerator"/>.</summary>
+    public SourceLinkGenerator(LinkGenerator linkGenerator) {
+        LinkGenerator = linkGenerator ?? throw new ArgumentNullException(nameof(linkGenerator));
+    }
+
+    /// <summary>Gets the LinkGenerator instance.</summary>
+    public LinkGenerator LinkGenerator { get; }
+
+    /// <inheritdoc/>
+    public string GenerateLink(string sourceUrl) => 
+        sourceUrl.StartsWith("local://", StringComparison.OrdinalIgnoreCase) ? 
+        LinkGenerator.GetPathByName(nameof(SourcesHandlers.GetActualSource), new { path = sourceUrl.Substring(8) }) ?? throw new InvalidOperationException("Failed to generate link.") : 
+        sourceUrl;
+}

--- a/src/Indice.Features.Agents.UI/Indice.Features.Agents.UI.csproj
+++ b/src/Indice.Features.Agents.UI/Indice.Features.Agents.UI.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks></TargetFrameworks>
     <TargetFramework>net10.0</TargetFramework>    
     <VersionPrefix>$(VersionPrefixAgents)</VersionPrefix>
-    <VersionSuffix>beta07</VersionSuffix>
+    <VersionSuffix>beta08</VersionSuffix>
     
     <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
     <SpaProjectName>browser</SpaProjectName>


### PR DESCRIPTION
Introduce SourceDocumentLink to represent document metadata and update retrieval, rerank, and answer composition to use it. Replace ChunkId/DocumentId with Source in chunk models. Add Sources property to chat and pipeline models. Update EF navigation properties, use collection initializers, deduplicate sources, and perform minor cleanup.