### PR TITLE
[identity] Use Code property for authentication method lookup

### DIFF
--- a/src/Indice.Features.Identity.Server/Totp/TotpHandlers.cs
+++ b/src/Indice.Features.Identity.Server/Totp/TotpHandlers.cs
@@ -29,7 +29,7 @@ internal static class TotpHandlers
         string? tokenProvider = null;
         if (!string.IsNullOrWhiteSpace(request.AuthenticationMethod)) {
             var authenticationMethod = (await authenticationMethodProvider.GetAllMethodsAsync())
-                .Where(x => x.DisplayName.Equals(request.AuthenticationMethod, StringComparison.OrdinalIgnoreCase))
+                .Where(x => x.Code.Equals(request.AuthenticationMethod, StringComparison.OrdinalIgnoreCase))
                 .FirstOrDefault();
             if (authenticationMethod is null) {
                 return TypedResults.ValidationProblem(ValidationErrors.AddError(nameof(request.AuthenticationMethod), $"Authentication method '{request.AuthenticationMethod}' is not configured in the system."));
@@ -98,7 +98,7 @@ internal static class TotpHandlers
         string? tokenProvider = null;
         if (!string.IsNullOrWhiteSpace(request.AuthenticationMethod)) {
             var authenticationMethod = (await authenticationMethodProvider.GetAllMethodsAsync())
-                .Where(x => x.DisplayName.Equals(request.AuthenticationMethod, StringComparison.OrdinalIgnoreCase))
+                .Where(x => x.Code.Equals(request.AuthenticationMethod, StringComparison.OrdinalIgnoreCase))
                 .FirstOrDefault();
             if (authenticationMethod is null) {
                 return TypedResults.ValidationProblem(ValidationErrors.AddError(nameof(request.AuthenticationMethod), $"Authentication method '{request.AuthenticationMethod}' is not configured in the system."));

--- a/src/Indice.Features.Identity.Server/Totp/TotpHandlers.cs
+++ b/src/Indice.Features.Identity.Server/Totp/TotpHandlers.cs
@@ -32,7 +32,7 @@ internal static class TotpHandlers
                 .Where(x => x.Code.Equals(request.AuthenticationMethod, StringComparison.OrdinalIgnoreCase))
                 .FirstOrDefault();
             if (authenticationMethod is null) {
-                return TypedResults.ValidationProblem(ValidationErrors.AddError(nameof(request.AuthenticationMethod), $"Authentication method '{request.AuthenticationMethod}' is not configured in the system."));
+                return TypedResults.ValidationProblem(ValidationErrors.AddError(nameof(request.AuthenticationMethod), $"Authentication method code '{request.AuthenticationMethod}' is not configured in the system."));
             }
             if (!authenticationMethod.SupportsDeliveryChannel() || !authenticationMethod.SupportsTokenProvider()) {
                 return TypedResults.ValidationProblem(ValidationErrors.AddError(nameof(request.AuthenticationMethod), $"Authentication method '{request.AuthenticationMethod}' must support a delivery channel and a token provider."));
@@ -101,7 +101,7 @@ internal static class TotpHandlers
                 .Where(x => x.Code.Equals(request.AuthenticationMethod, StringComparison.OrdinalIgnoreCase))
                 .FirstOrDefault();
             if (authenticationMethod is null) {
-                return TypedResults.ValidationProblem(ValidationErrors.AddError(nameof(request.AuthenticationMethod), $"Authentication method '{request.AuthenticationMethod}' is not configured in the system."));
+                return TypedResults.ValidationProblem(ValidationErrors.AddError(nameof(request.AuthenticationMethod), $"Authentication method code '{request.AuthenticationMethod}' is not configured in the system."));
             }
             if (!authenticationMethod.SupportsTokenProvider()) {
                 return TypedResults.ValidationProblem(ValidationErrors.AddError(nameof(request.AuthenticationMethod), $"Authentication method '{request.AuthenticationMethod}' must support a token provider."));


### PR DESCRIPTION
Updated TOTP generation and verification to match authentication methods using the Code property instead of DisplayName. This ensures lookups are consistent with the method's code identifier.