### PR TITLE
[agents] Make ingest scope configurable in documents API policy

### DIFF
--- a/src/Indice.Features.Agents.Core/Indice.Features.Agents.Core.csproj
+++ b/src/Indice.Features.Agents.Core/Indice.Features.Agents.Core.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks></TargetFrameworks>
     <TargetFramework>net10.0</TargetFramework>
     <VersionPrefix>$(VersionPrefixAgents)</VersionPrefix>
-    <VersionSuffix>beta09</VersionSuffix>
+    <VersionSuffix>beta10</VersionSuffix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Indice.Features.Agents.Server/Endpoints/IngestionApi.cs
+++ b/src/Indice.Features.Agents.Server/Endpoints/IngestionApi.cs
@@ -23,9 +23,7 @@ internal static class IngestionApi
                           .WithName(options.GroupName)
                           .WithTags("Documents");
         group.RequireAuthorization(pb => pb.RequireAuthenticatedUser()
-                                           .RequireClaim(BasicClaimTypes.Scope, allowedScopes)
-                                           .RequireAssertion(context => context.User.IsInRole(BasicRoleNames.AgentsAdmin) ||
-                                                                        context.User.IsAdmin()));
+                                           .RequireAssertion(context =>  (!string.IsNullOrEmpty(options.IngestRequiredScope) && context.User.HasScope(options.IngestRequiredScope)) || context.User.IsInRole(BasicRoleNames.AgentsAdmin) || context.User.IsAdmin()));
         
         group.WithOpenApiSecurityRequirement("oauth2", allowedScopes);
         group.WithHandledException<BusinessException>()

--- a/src/Indice.Features.Agents.Server/Indice.Features.Agents.Server.csproj
+++ b/src/Indice.Features.Agents.Server/Indice.Features.Agents.Server.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks></TargetFrameworks>
     <TargetFramework>net10.0</TargetFramework>
     <VersionPrefix>$(VersionPrefixAgents)</VersionPrefix>
-    <VersionSuffix>beta09</VersionSuffix>
+    <VersionSuffix>beta10</VersionSuffix>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Indice.AspNetCore.Builder" Version="$(VersionPrefixAspNet)-*" />

--- a/src/Indice.Features.Agents.UI/Indice.Features.Agents.UI.csproj
+++ b/src/Indice.Features.Agents.UI/Indice.Features.Agents.UI.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks></TargetFrameworks>
     <TargetFramework>net10.0</TargetFramework>    
     <VersionPrefix>$(VersionPrefixAgents)</VersionPrefix>
-    <VersionSuffix>beta09</VersionSuffix>
+    <VersionSuffix>beta10</VersionSuffix>
     
     <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
     <SpaProjectName>browser</SpaProjectName>


### PR DESCRIPTION
The documents API group authorization policy now allows access if the user has the configurable IngestRequiredScope (if set), or is an AgentsAdmin, or is an admin. This change makes the required scope for ingestion flexible and easier to manage.