### PR TITLE
[identity] refactor 2FA reset and 2FA token uniqueness logic

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,11 +5,11 @@
     <!--<TargetFramework></TargetFramework>-->
 
     <VersionPrefixMajor>8</VersionPrefixMajor>
-    <VersionPrefixBase>$(VersionPrefixMajor).53</VersionPrefixBase>
+    <VersionPrefixBase>$(VersionPrefixMajor).54</VersionPrefixBase>
 
     <VersionPrefixCore>$(VersionPrefixBase).0</VersionPrefixCore>
-    <VersionPrefixIdentity>$(VersionPrefixBase).1</VersionPrefixIdentity>
-    <VersionPrefixIdentityUI>$(VersionPrefixBase).1</VersionPrefixIdentityUI>
+    <VersionPrefixIdentity>$(VersionPrefixBase).0</VersionPrefixIdentity>
+    <VersionPrefixIdentityUI>$(VersionPrefixBase).0</VersionPrefixIdentityUI>
     <VersionPrefixCases>$(VersionPrefixBase).0</VersionPrefixCases>
     <VersionPrefixMessages>$(VersionPrefixBase).0</VersionPrefixMessages>
     <VersionPrefixMultitenancy>$(VersionPrefixBase).0</VersionPrefixMultitenancy>

--- a/src/Indice.Features.Identity.Core/Data/Stores/ExtendedUserStore.cs
+++ b/src/Indice.Features.Identity.Core/Data/Stores/ExtendedUserStore.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Security.Claims;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -48,7 +49,7 @@ public partial class ExtendedUserStore<TContext, TUser, TRole> : UserStore<TUser
     public ExtendedUserStore(TContext context, IConfiguration configuration, IdentityErrorDescriber? describer = null) : base(context, describer) {
         PasswordHistoryLimit = configuration.GetIdentityOption<int?>(nameof(IdentityOptions.Password), nameof(PasswordHistoryLimit));
         PasswordExpirationPolicy = configuration.GetIdentityOption<PasswordExpirationPolicy?>(nameof(IdentityOptions.Password), nameof(PasswordExpirationPolicy));
-        StorePictureAsClaim = configuration.GetIdentityOption<bool?> (nameof(IdentityOptions.User), nameof(StorePictureAsClaim)) ?? false;
+        StorePictureAsClaim = configuration.GetIdentityOption<bool?>(nameof(IdentityOptions.User), nameof(StorePictureAsClaim)) ?? false;
         TwoFactorPolicy = configuration.GetIdentityOption<MfaPolicy?>($"{nameof(IdentityOptions.SignIn)}:Mfa", "Policy");
     }
 
@@ -351,8 +352,8 @@ public partial class ExtendedUserStore<TContext, TUser, TRole> : UserStore<TUser
             }
         } else {
             var picture = await UserPictureSet.Where(x => x.UserId == user.Id).FirstOrDefaultAsync(cancellationToken);
-            if (picture is null) {  
-                return (null, string.Empty); 
+            if (picture is null) {
+                return (null, string.Empty);
             }
             return await GetUserPictureInternalAsync(picture.ContentType, new MemoryStream(picture.Data), contentType, size, cancellationToken);
         }
@@ -483,6 +484,13 @@ public partial class ExtendedUserStore<TContext, TUser, TRole> : UserStore<TUser
         return await base.GetTokenAsync(user, InternalLoginProvider, TwoFactorPreferenceTokenName, cancellationToken);
     }
 
+
+    /// <inheritdoc/>
+    public async Task RemoveAuthenticatorKeyAsync(TUser user, CancellationToken cancellationToken = default) {
+        await base.SetTokenAsync(user, InternalLoginProvider, AuthenticatorKeyTokenName, null, cancellationToken);
+    }
     private const string InternalLoginProvider = "[AspNetUserStore]";
     private const string TwoFactorPreferenceTokenName = "TwoFactorPreference";
+    private const string AuthenticatorKeyTokenName = "AuthenticatorKey";
+
 }

--- a/src/Indice.Features.Identity.Core/Data/Stores/ExtendedUserStore.cs
+++ b/src/Indice.Features.Identity.Core/Data/Stores/ExtendedUserStore.cs
@@ -1,6 +1,4 @@
-﻿using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
-using System.Security.Claims;
+﻿using System.Security.Claims;
 using System.Text;
 using System.Text.RegularExpressions;
 using Indice.Extensions;

--- a/src/Indice.Features.Identity.Core/Data/Stores/IExtendedUserStore.cs
+++ b/src/Indice.Features.Identity.Core/Data/Stores/IExtendedUserStore.cs
@@ -1,4 +1,5 @@
-﻿using System.Numerics;
+﻿using System.Diagnostics;
+using System.Numerics;
 using System.Security.Claims;
 using Indice.Features.Identity.Core.Data.Models;
 using Microsoft.AspNetCore.Identity;
@@ -75,4 +76,12 @@ public interface IExtendedUserStore<TUser> where TUser : User
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>The authentication method code preference or null</returns>
     Task<string?> GetTwoFactorPreferenceAsync(TUser user, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Remove user authenticator key
+    /// </summary>
+    /// <param name="user">The user for whom to get the two factor authentication preference.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    Task RemoveAuthenticatorKeyAsync(TUser user, CancellationToken cancellationToken = default);
+    
 }

--- a/src/Indice.Features.Identity.Core/Data/Stores/IExtendedUserStore.cs
+++ b/src/Indice.Features.Identity.Core/Data/Stores/IExtendedUserStore.cs
@@ -1,6 +1,4 @@
-﻿using System.Diagnostics;
-using System.Numerics;
-using System.Security.Claims;
+﻿using System.Security.Claims;
 using Indice.Features.Identity.Core.Data.Models;
 using Microsoft.AspNetCore.Identity;
 
@@ -77,10 +75,8 @@ public interface IExtendedUserStore<TUser> where TUser : User
     /// <returns>The authentication method code preference or null</returns>
     Task<string?> GetTwoFactorPreferenceAsync(TUser user, CancellationToken cancellationToken = default);
 
-    /// <summary>
-    /// Remove user authenticator key
-    /// </summary>
-    /// <param name="user">The user for whom to get the two factor authentication preference.</param>
+    /// <summary>Removes the authenticator key for the user.</summary>
+    /// <param name="user">The user whose authenticator key will be removed.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     Task RemoveAuthenticatorKeyAsync(TUser user, CancellationToken cancellationToken = default);
     

--- a/src/Indice.Features.Identity.Core/ExtendedUserManager.cs
+++ b/src/Indice.Features.Identity.Core/ExtendedUserManager.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using System.Security.Claims;
+﻿using System.Security.Claims;
 #if NET9_0_OR_GREATER
 using Duende.IdentityModel;
 #else
@@ -715,11 +714,12 @@ public partial class ExtendedUserManager<TUser> : UserManager<TUser> where TUser
     /// Resets the authenticator key for the user.
     /// </summary>
     /// <param name="user">The user.</param>
+    /// <param name="cancellationToken">The cancellation token</param>
     /// <returns>Whether the user was successfully updated.</returns>
-    public virtual async Task<IdentityResult> RemoveAuthenticatorKeyAsync(TUser user) {
+    public virtual async Task<IdentityResult> RemoveAuthenticatorKeyAsync(TUser user, CancellationToken cancellationToken = default) {
         ArgumentNullException.ThrowIfNull(user);
         var extendedStore = GetUserStore();
-        await extendedStore!.RemoveAuthenticatorKeyAsync(user).ConfigureAwait(false);
+        await extendedStore!.RemoveAuthenticatorKeyAsync(user, cancellationToken).ConfigureAwait(false);
         return await this.UpdateSecurityStampAsync(user).ConfigureAwait(false);
     }
 

--- a/src/Indice.Features.Identity.Core/ExtendedUserManager.cs
+++ b/src/Indice.Features.Identity.Core/ExtendedUserManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Security.Claims;
+﻿using System.Diagnostics;
+using System.Security.Claims;
 #if NET9_0_OR_GREATER
 using Duende.IdentityModel;
 #else
@@ -700,12 +701,29 @@ public partial class ExtendedUserManager<TUser> : UserManager<TUser> where TUser
         await extendedStore!.SetTwoFactorPreferenceAsync(user, null).ConfigureAwait(false);
 
         cancellationToken.ThrowIfCancellationRequested();
-        result = await ResetAuthenticatorKeyAsync(user);
+
+        result = await RemoveAuthenticatorKeyAsync(user);
         if (!result.Succeeded) {
             return result;
         }
         return result;
     }
+
+
+
+    /// <summary>
+    /// Resets the authenticator key for the user.
+    /// </summary>
+    /// <param name="user">The user.</param>
+    /// <returns>Whether the user was successfully updated.</returns>
+    public virtual async Task<IdentityResult> RemoveAuthenticatorKeyAsync(TUser user) {
+        ArgumentNullException.ThrowIfNull(user);
+        var extendedStore = GetUserStore();
+        await extendedStore!.RemoveAuthenticatorKeyAsync(user).ConfigureAwait(false);
+        return await this.UpdateSecurityStampAsync(user).ConfigureAwait(false);
+    }
+
+
     /// <summary>
     /// Resets the two-factor authentication for the specified user by disabling it, clearing any two-factor preferences, and resetting the authenticator key.
     /// </summary>

--- a/src/Indice.Features.Identity.Core/TokenProviders/ExtendedEmailTokenProvider.cs
+++ b/src/Indice.Features.Identity.Core/TokenProviders/ExtendedEmailTokenProvider.cs
@@ -31,7 +31,7 @@ public class ExtendedEmailTokenProvider<TUser> : EmailTokenProvider<TUser> where
     }
 
     private static async Task<byte[]> GetSecurityToken(string purpose, UserManager<TUser> userManager, TUser user) {
-        var securityToken = await userManager.CreateSecurityTokenAsync(user);
+        var securityToken = await userManager.CreateSecurityTokenAsync(user).ConfigureAwait(false);
         if (!string.Equals(purpose, "TwoFactor", StringComparison.Ordinal)) {
             return securityToken;
         }

--- a/src/Indice.Features.Identity.Core/TokenProviders/ExtendedEmailTokenProvider.cs
+++ b/src/Indice.Features.Identity.Core/TokenProviders/ExtendedEmailTokenProvider.cs
@@ -35,11 +35,14 @@ public class ExtendedEmailTokenProvider<TUser> : EmailTokenProvider<TUser> where
         if (purpose != "TwoFactor") {
             return securityToken;
         }
-        var timeStamp = Encoding.Unicode.GetBytes((user.LastSignInDate ?? DateTime.UtcNow).ToString("yyyyMMddHHmmsss"));
+        if (user.LastSignInDate == null) {
+            return securityToken;
+        }
+        var timeStamp = Encoding.Unicode.GetBytes(user.LastSignInDate.Value.ToString("yyyyMMddHHmmsss"));
         byte[] token = new byte[securityToken.Length + timeStamp.Length];
 
-        Buffer.BlockCopy(timeStamp, 0, token, 0, timeStamp.Length);
-        Buffer.BlockCopy(timeStamp, 0, token, timeStamp.Length, timeStamp.Length);
+        Buffer.BlockCopy(securityToken, 0, token, 0, securityToken.Length);
+        Buffer.BlockCopy(timeStamp, 0, token, securityToken.Length, timeStamp.Length);
         return token;
     }
     /// <inheritdoc />

--- a/src/Indice.Features.Identity.Core/TokenProviders/ExtendedEmailTokenProvider.cs
+++ b/src/Indice.Features.Identity.Core/TokenProviders/ExtendedEmailTokenProvider.cs
@@ -32,7 +32,7 @@ public class ExtendedEmailTokenProvider<TUser> : EmailTokenProvider<TUser> where
 
     private static async Task<byte[]> GetSecurityToken(string purpose, UserManager<TUser> userManager, TUser user) {
         var securityToken = await userManager.CreateSecurityTokenAsync(user);
-        if (purpose != "TwoFactor") {
+        if (!string.Equals(purpose, "TwoFactor", StringComparison.Ordinal)) {
             return securityToken;
         }
         if (user.LastSignInDate == null) {

--- a/src/Indice.Features.Identity.Core/TokenProviders/ExtendedEmailTokenProvider.cs
+++ b/src/Indice.Features.Identity.Core/TokenProviders/ExtendedEmailTokenProvider.cs
@@ -38,7 +38,7 @@ public class ExtendedEmailTokenProvider<TUser> : EmailTokenProvider<TUser> where
         if (user.LastSignInDate == null) {
             return securityToken;
         }
-        var timeStamp = Encoding.Unicode.GetBytes(user.LastSignInDate.Value.ToString("yyyyMMddHHmmsss"));
+        var timeStamp = Encoding.UTF8.GetBytes(user.LastSignInDate.Value.ToUnixTimeMilliseconds().ToString(CultureInfo.InvariantCulture));
         byte[] token = new byte[securityToken.Length + timeStamp.Length];
 
         Buffer.BlockCopy(securityToken, 0, token, 0, securityToken.Length);

--- a/src/Indice.Features.Identity.Core/TokenProviders/ExtendedEmailTokenProvider.cs
+++ b/src/Indice.Features.Identity.Core/TokenProviders/ExtendedEmailTokenProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System.Globalization;
 using System.Security;
+using System.Text;
 using Indice.Features.Identity.Core.Configuration;
 using Indice.Features.Identity.Core.Data.Models;
 using Microsoft.AspNetCore.Identity;
@@ -24,11 +25,23 @@ public class ExtendedEmailTokenProvider<TUser> : EmailTokenProvider<TUser> where
         if (manager is null) {
             throw new ArgumentNullException(nameof(manager));
         }
-        var token = await manager.CreateSecurityTokenAsync(user).ConfigureAwait(false);
+        var token = await GetSecurityToken(purpose, manager, user).ConfigureAwait(false);
         var modifier = await GetUserModifierAsync(purpose, manager, user).ConfigureAwait(false);
         return _rfc6238AuthenticationService.GenerateCode(token, modifier).ToString("D6", CultureInfo.InvariantCulture);
     }
 
+    private static async Task<byte[]> GetSecurityToken(string purpose, UserManager<TUser> userManager, TUser user) {
+        var securityToken = await userManager.CreateSecurityTokenAsync(user);
+        if (purpose != "TwoFactor") {
+            return securityToken;
+        }
+        var timeStamp = Encoding.Unicode.GetBytes((user.LastSignInDate ?? DateTime.UtcNow).ToString("yyyyMMddHHmmsss"));
+        byte[] token = new byte[securityToken.Length + timeStamp.Length];
+
+        Buffer.BlockCopy(timeStamp, 0, token, 0, timeStamp.Length);
+        Buffer.BlockCopy(timeStamp, 0, token, timeStamp.Length, timeStamp.Length);
+        return token;
+    }
     /// <inheritdoc />
     public async override Task<bool> ValidateAsync(string purpose, string token, UserManager<TUser> manager, TUser user) {
         if (manager is null) {
@@ -37,7 +50,7 @@ public class ExtendedEmailTokenProvider<TUser> : EmailTokenProvider<TUser> where
         if (!int.TryParse(token, out var code)) {
             return false;
         }
-        var securityToken = await manager.CreateSecurityTokenAsync(user).ConfigureAwait(false);
+        var securityToken = await GetSecurityToken(purpose, manager, user).ConfigureAwait(false);
         var modifier = await GetUserModifierAsync(purpose, manager, user).ConfigureAwait(false);
         return securityToken != null && _rfc6238AuthenticationService.ValidateCode(securityToken, code, modifier);
     }

--- a/src/Indice.Features.Identity.Core/TokenProviders/ExtendedPhoneNumberTokenProvider.cs
+++ b/src/Indice.Features.Identity.Core/TokenProviders/ExtendedPhoneNumberTokenProvider.cs
@@ -40,11 +40,14 @@ public class ExtendedPhoneNumberTokenProvider<TUser> : PhoneNumberTokenProvider<
         if (purpose != "TwoFactor") {
             return securityToken;
         }
-        var timeStamp = Encoding.Unicode.GetBytes((user.LastSignInDate ?? DateTime.UtcNow).ToString("yyyyMMddHHmmsss"));
+        if(user.LastSignInDate == null) {
+            return securityToken;
+        }
+        var timeStamp = Encoding.Unicode.GetBytes(user.LastSignInDate.Value.ToString("yyyyMMddHHmmsss"));
         byte[] token = new byte[securityToken.Length + timeStamp.Length];
 
-        Buffer.BlockCopy(timeStamp, 0, token, 0, timeStamp.Length);
-        Buffer.BlockCopy(timeStamp, 0, token, timeStamp.Length, timeStamp.Length);
+        Buffer.BlockCopy(securityToken, 0, token, 0, securityToken.Length);
+        Buffer.BlockCopy(timeStamp, 0, token, securityToken.Length, timeStamp.Length);
         return token;
     }
 

--- a/src/Indice.Features.Identity.Core/TokenProviders/ExtendedPhoneNumberTokenProvider.cs
+++ b/src/Indice.Features.Identity.Core/TokenProviders/ExtendedPhoneNumberTokenProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System.Globalization;
 using System.Security;
+using System.Text;
 using Indice.Features.Identity.Core.Configuration;
 using Indice.Features.Identity.Core.Data.Models;
 using Microsoft.AspNetCore.Identity;
@@ -27,9 +28,24 @@ public class ExtendedPhoneNumberTokenProvider<TUser> : PhoneNumberTokenProvider<
         if (userManager is null) {
             throw new ArgumentNullException(nameof(userManager));
         }
-        var token = await userManager.CreateSecurityTokenAsync(user);
-        var modifier = await GetUserModifierAsync(purpose, userManager, user);
-        return _rfc6238AuthenticationService.GenerateCode(token, modifier).ToString("D6", CultureInfo.InvariantCulture);
+
+        var securityToken = await GetSecurityToken(purpose, userManager, user).ConfigureAwait(false);
+        var modifier = await GetUserModifierAsync(purpose, userManager, user).ConfigureAwait(false);
+        return _rfc6238AuthenticationService.GenerateCode(securityToken, modifier).ToString("D6", CultureInfo.InvariantCulture);
+    }
+
+
+    private static async Task<byte[]> GetSecurityToken(string purpose, UserManager<TUser> userManager, TUser user) {
+        var securityToken = await userManager.CreateSecurityTokenAsync(user);
+        if (purpose != "TwoFactor") {
+            return securityToken;
+        }
+        var timeStamp = Encoding.Unicode.GetBytes((user.LastSignInDate ?? DateTime.UtcNow).ToString("yyyyMMddHHmmsss"));
+        byte[] token = new byte[securityToken.Length + timeStamp.Length];
+
+        Buffer.BlockCopy(timeStamp, 0, token, 0, timeStamp.Length);
+        Buffer.BlockCopy(timeStamp, 0, token, timeStamp.Length, timeStamp.Length);
+        return token;
     }
 
     /// <inheritdoc />
@@ -40,8 +56,8 @@ public class ExtendedPhoneNumberTokenProvider<TUser> : PhoneNumberTokenProvider<
         if (!int.TryParse(token, out var code)) {
             return false;
         }
-        var securityToken = await userManager.CreateSecurityTokenAsync(user);
-        var modifier = await GetUserModifierAsync(purpose, userManager, user);
+        var securityToken = await GetSecurityToken(purpose, userManager, user).ConfigureAwait(false);
+        var modifier = await GetUserModifierAsync(purpose, userManager, user).ConfigureAwait(false);
         return securityToken is not null && _rfc6238AuthenticationService.ValidateCode(securityToken, code, modifier);
     }
 }

--- a/src/Indice.Features.Identity.Core/TokenProviders/ExtendedPhoneNumberTokenProvider.cs
+++ b/src/Indice.Features.Identity.Core/TokenProviders/ExtendedPhoneNumberTokenProvider.cs
@@ -37,7 +37,7 @@ public class ExtendedPhoneNumberTokenProvider<TUser> : PhoneNumberTokenProvider<
 
     private static async Task<byte[]> GetSecurityToken(string purpose, UserManager<TUser> userManager, TUser user) {
         var securityToken = await userManager.CreateSecurityTokenAsync(user);
-        if (purpose != "TwoFactor") {
+        if (!string.Equals(purpose, "TwoFactor", StringComparison.Ordinal)) {
             return securityToken;
         }
         if (user.LastSignInDate == null) {

--- a/src/Indice.Features.Identity.Core/TokenProviders/ExtendedPhoneNumberTokenProvider.cs
+++ b/src/Indice.Features.Identity.Core/TokenProviders/ExtendedPhoneNumberTokenProvider.cs
@@ -40,10 +40,10 @@ public class ExtendedPhoneNumberTokenProvider<TUser> : PhoneNumberTokenProvider<
         if (purpose != "TwoFactor") {
             return securityToken;
         }
-        if(user.LastSignInDate == null) {
+        if (user.LastSignInDate == null) {
             return securityToken;
         }
-        var timeStamp = Encoding.Unicode.GetBytes(user.LastSignInDate.Value.ToString("yyyyMMddHHmmsss"));
+        var timeStamp = Encoding.UTF8.GetBytes(user.LastSignInDate.Value.ToUnixTimeMilliseconds().ToString(CultureInfo.InvariantCulture));
         byte[] token = new byte[securityToken.Length + timeStamp.Length];
 
         Buffer.BlockCopy(securityToken, 0, token, 0, securityToken.Length);

--- a/src/Indice.Features.Identity.Core/TokenProviders/ExtendedPhoneNumberTokenProvider.cs
+++ b/src/Indice.Features.Identity.Core/TokenProviders/ExtendedPhoneNumberTokenProvider.cs
@@ -36,7 +36,7 @@ public class ExtendedPhoneNumberTokenProvider<TUser> : PhoneNumberTokenProvider<
 
 
     private static async Task<byte[]> GetSecurityToken(string purpose, UserManager<TUser> userManager, TUser user) {
-        var securityToken = await userManager.CreateSecurityTokenAsync(user);
+        var securityToken = await userManager.CreateSecurityTokenAsync(user).ConfigureAwait(false);
         if (!string.Equals(purpose, "TwoFactor", StringComparison.Ordinal)) {
             return securityToken;
         }

--- a/test/Indice.Features.Identity.Tests/TotpServiceTests.cs
+++ b/test/Indice.Features.Identity.Tests/TotpServiceTests.cs
@@ -360,8 +360,8 @@ public class TotpServiceTests
     }
 
     [Theory]
-    [InlineData(TokenOptions.DefaultPhoneProvider)]
-    [InlineData(TokenOptions.DefaultEmailProvider)]
+    [InlineData("Phone")]
+    [InlineData("Email")]
     public async Task TwoFactorToken_Can_Be_Verified_After_User_Reload(string tokenProvider) {
         var userManager = TestServer.Services.GetRequiredService<ExtendedUserManager<User>>();
         var lastSignInDate = DateTimeOffset.UtcNow.AddMinutes(-5);
@@ -376,8 +376,8 @@ public class TotpServiceTests
     }
 
     [Theory]
-    [InlineData(TokenOptions.DefaultPhoneProvider)]
-    [InlineData(TokenOptions.DefaultEmailProvider)]
+    [InlineData("Phone")]
+    [InlineData("Email")]
     public async Task TwoFactorToken_Is_Invalid_When_LastSignInDate_Changes(string tokenProvider) {
         var userManager = TestServer.Services.GetRequiredService<ExtendedUserManager<User>>();
         var lastSignInDate = DateTimeOffset.UtcNow.AddMinutes(-5);

--- a/test/Indice.Features.Identity.Tests/TotpServiceTests.cs
+++ b/test/Indice.Features.Identity.Tests/TotpServiceTests.cs
@@ -43,6 +43,7 @@ public class TotpServiceTests
                     .AddEntityFrameworkStores<ExtendedIdentityDbContext<User, Role>>()
                     .AddUserStore<ExtendedUserStore<ExtendedIdentityDbContext<User, Role>, User, Role>>()
                     .AddExtendedPhoneNumberTokenProvider(configuration)
+                    .AddExtendedEmailTokenProvider(configuration)
                     .AddIdentityMessageDescriber<IdentityMessageDescriber>();
         });
         builder.Configure(app => { });
@@ -356,5 +357,68 @@ public class TotpServiceTests
         // Assert
         Assert.NotNull(result);
         Assert.False(result.Success);
+    }
+
+    [Theory]
+    [InlineData("Phone")]
+    [InlineData("Email")]
+    public async Task TwoFactorToken_Validates_When_LastSignInDate_Is_Unchanged(string tokenProvider) {
+        var userManager = TestServer.Services.GetRequiredService<ExtendedUserManager<User>>();
+        var lastSignInDate = DateTimeOffset.UtcNow.AddMinutes(-5);
+        var user = await CreateTwoFactorUserAsync(userManager, tokenProvider, lastSignInDate);
+
+        var token = await userManager.GenerateTwoFactorTokenAsync(user, tokenProvider);
+        var reloadedUser = await userManager.FindByIdAsync(user.Id);
+
+        var isValid = await userManager.VerifyTwoFactorTokenAsync(reloadedUser!, tokenProvider, token);
+
+        Assert.True(isValid);
+    }
+
+    [Theory]
+    [InlineData("Phone")]
+    [InlineData("Email")]
+    public async Task TwoFactorToken_Is_Invalidated_When_LastSignInDate_Changes(string tokenProvider) {
+        var userManager = TestServer.Services.GetRequiredService<ExtendedUserManager<User>>();
+        var lastSignInDate = DateTimeOffset.UtcNow.AddMinutes(-5);
+        var user = await CreateTwoFactorUserAsync(userManager, tokenProvider, lastSignInDate);
+
+        var token = await userManager.GenerateTwoFactorTokenAsync(user, tokenProvider);
+        user.LastSignInDate = lastSignInDate.AddMinutes(1);
+        var updateResult = await userManager.UpdateAsync(user);
+        Assert.True(updateResult.Succeeded);
+        var reloadedUser = await userManager.FindByIdAsync(user.Id);
+
+        var isValid = await userManager.VerifyTwoFactorTokenAsync(reloadedUser!, tokenProvider, token);
+
+        Assert.False(isValid);
+    }
+
+    private static async Task<User> CreateTwoFactorUserAsync(ExtendedUserManager<User> userManager, string tokenProvider, DateTimeOffset lastSignInDate) {
+        var random = new Random(Guid.NewGuid().GetHashCode()).Next();
+        var email = $"user_{random}@example.com";
+        var user = new User {
+            CreateDate = DateTimeOffset.UtcNow,
+            Email = email,
+            EmailConfirmed = true,
+            Id = Guid.NewGuid().ToString(),
+            LastSignInDate = lastSignInDate,
+            PhoneNumber = "+306991234567",
+            PhoneNumberConfirmed = true,
+            SecurityStamp = Guid.NewGuid().ToString(),
+            TwoFactorEnabled = true,
+            UserName = email
+        };
+
+        if (tokenProvider == TokenOptions.DefaultEmailProvider) {
+            user.PhoneNumber = null;
+            user.PhoneNumberConfirmed = false;
+        } else {
+            user.EmailConfirmed = false;
+        }
+
+        var createResult = await userManager.CreateAsync(user);
+        Assert.True(createResult.Succeeded);
+        return user;
     }
 }

--- a/test/Indice.Features.Identity.Tests/TotpServiceTests.cs
+++ b/test/Indice.Features.Identity.Tests/TotpServiceTests.cs
@@ -378,6 +378,7 @@ public class TotpServiceTests
     [Theory]
     [InlineData(TokenOptions.DefaultPhoneProvider)]
     [InlineData(TokenOptions.DefaultEmailProvider)]
+    public async Task TwoFactorToken_Is_Invalid_When_LastSignInDate_Changes(string tokenProvider) {
         var userManager = TestServer.Services.GetRequiredService<ExtendedUserManager<User>>();
         var lastSignInDate = DateTimeOffset.UtcNow.AddMinutes(-5);
         var user = await CreateTwoFactorUserAsync(userManager, tokenProvider, lastSignInDate);

--- a/test/Indice.Features.Identity.Tests/TotpServiceTests.cs
+++ b/test/Indice.Features.Identity.Tests/TotpServiceTests.cs
@@ -360,9 +360,8 @@ public class TotpServiceTests
     }
 
     [Theory]
-    [InlineData("Phone")]
-    [InlineData("Email")]
-    public async Task TwoFactorToken_Validates_When_LastSignInDate_Is_Unchanged(string tokenProvider) {
+    [InlineData(TokenOptions.DefaultPhoneProvider)]
+    [InlineData(TokenOptions.DefaultEmailProvider)]
         var userManager = TestServer.Services.GetRequiredService<ExtendedUserManager<User>>();
         var lastSignInDate = DateTimeOffset.UtcNow.AddMinutes(-5);
         var user = await CreateTwoFactorUserAsync(userManager, tokenProvider, lastSignInDate);
@@ -376,9 +375,8 @@ public class TotpServiceTests
     }
 
     [Theory]
-    [InlineData("Phone")]
-    [InlineData("Email")]
-    public async Task TwoFactorToken_Is_Invalidated_When_LastSignInDate_Changes(string tokenProvider) {
+    [InlineData(TokenOptions.DefaultPhoneProvider)]
+    [InlineData(TokenOptions.DefaultEmailProvider)]
         var userManager = TestServer.Services.GetRequiredService<ExtendedUserManager<User>>();
         var lastSignInDate = DateTimeOffset.UtcNow.AddMinutes(-5);
         var user = await CreateTwoFactorUserAsync(userManager, tokenProvider, lastSignInDate);

--- a/test/Indice.Features.Identity.Tests/TotpServiceTests.cs
+++ b/test/Indice.Features.Identity.Tests/TotpServiceTests.cs
@@ -362,6 +362,7 @@ public class TotpServiceTests
     [Theory]
     [InlineData(TokenOptions.DefaultPhoneProvider)]
     [InlineData(TokenOptions.DefaultEmailProvider)]
+    public async Task TwoFactorToken_Can_Be_Verified_After_User_Reload(string tokenProvider) {
         var userManager = TestServer.Services.GetRequiredService<ExtendedUserManager<User>>();
         var lastSignInDate = DateTimeOffset.UtcNow.AddMinutes(-5);
         var user = await CreateTwoFactorUserAsync(userManager, tokenProvider, lastSignInDate);


### PR DESCRIPTION
Added RemoveAuthenticatorKeyAsync to user store interfaces and ExtendedUserManager, updating security stamp on removal. Replaced ResetAuthenticatorKeyAsync with RemoveAuthenticatorKeyAsync in 2FA reset flow. Enhanced ExtendedEmailTokenProvider and ExtendedPhoneNumberTokenProvider to generate more unique "TwoFactor" tokens by combining the security token with a LastSignInDate-based timestamp. Updated token generation/validation to use this logic. Minor formatting and using directive updates.