### PR TITLE
[agents] fix failing tests

### DIFF
--- a/src/Indice.Common/Indice.Common.csproj
+++ b/src/Indice.Common/Indice.Common.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.18" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.18" />
     <PackageReference Include="System.Text.Json" Version="9.0.18" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.29" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.18" />

--- a/test/Indice.Features.Agents.Core.Tests/Streaming/ChatsServiceStreamingTests.cs
+++ b/test/Indice.Features.Agents.Core.Tests/Streaming/ChatsServiceStreamingTests.cs
@@ -169,13 +169,14 @@ internal sealed class FakeDexChatClient(List<ChatResponseUpdate> updates) : IDex
     public void Dispose() { }
 }
 
-internal sealed class FakeConversationStore(Guid conversationId, string persistedMessageId) : IConversationStore
+internal sealed class FakeConversationStore(Guid persistedConversationId, string persistedMessageId) : IConversationStore
 {
     public bool TurnPersisted { get; private set; }
     public bool FailedTurnPersisted { get; private set; }
 
-    public Task<Conversation?> LoadOrCreateAsync(string userId, Guid? id, CancellationToken cancellationToken)
-        => Task.FromResult<Conversation?>(new Conversation { Id = conversationId });
+    public Task<Conversation?> LoadOrCreateAsync(string userId, string? authorName,
+        Guid? conversationId, CancellationToken cancellationToken)
+        => Task.FromResult<Conversation?>(new Conversation { Id = persistedConversationId });
 
     public Task<ChatMessage> AppendTurnAsync(Guid id, ChatMessage userMessage, ChatResponse response, CancellationToken cancellationToken) {
         TurnPersisted = true;


### PR DESCRIPTION
- Downgraded System.Security.Cryptography.Xml NuGet package from 8.0.29 to 8.0.4 in Indice.Common.csproj.
- Renamed FakeConversationStore constructor parameter to persistedConversationId.
- Updated LoadOrCreateAsync to accept authorName and use persistedConversationId for Conversation.Id.